### PR TITLE
fix: load files outside of current root

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(libs.bpmnmodel)
     implementation(libs.bundles.codegen)
+    implementation(libs.ant)
     testImplementation(libs.bundles.testing)
     testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
@@ -1,14 +1,10 @@
 package io.github.emaarco.bpmn.adapter.outbound.filesystem
 
 import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
+import org.apache.tools.ant.DirectoryScanner
 import java.io.File
-import java.io.IOException
-import java.io.UncheckedIOException
-import java.nio.file.FileSystems
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
-import java.util.stream.Collectors.toList
+import kotlin.io.path.absolute
 
 class BpmnFileLoader : LoadBpmnFilesPort {
 
@@ -19,19 +15,51 @@ class BpmnFileLoader : LoadBpmnFilesPort {
      * @param filePattern The wildcard pattern to match the files.
      */
     override fun loadFrom(baseDirectory: String, filePattern: String): List<File> {
-        val basePath = Paths.get(baseDirectory).toAbsolutePath().normalize()
-        val pathMatcher = FileSystems.getDefault().getPathMatcher("glob:$filePattern")
-        val pathFilter: (Path) -> Boolean = { pathMatcher.matches(basePath.relativize(it)) }
-        return filterFilesFromBasePath(basePath, pathFilter)
+        val basePath = Path.of(baseDirectory).absolute().normalize()
+        val (searchDir, pattern) = resolvePattern(basePath, filePattern)
+
+        val scanner = DirectoryScanner().apply {
+            basedir = searchDir.toFile()
+            setIncludes(arrayOf(pattern))
+            scan()
+        }
+
+        return scanner.includedFiles.map { File(searchDir.toFile(), it) }
     }
 
-    private fun filterFilesFromBasePath(
-        basePath: Path,
-        pathMatcher: (Path) -> Boolean
-    ) = try {
-        val matchingPaths = Files.walk(basePath).filter(pathMatcher).collect(toList())
-        matchingPaths.map(Path::toFile)
-    } catch (e: IOException) {
-        throw UncheckedIOException("Error searching for files in $basePath", e)
+    private fun resolvePattern(basePath: Path, pattern: String): Pair<Path, String> {
+
+        if (!pattern.contains('/')) return basePath to pattern
+
+        val segments = pattern.split('/')
+        val wildcard = checkForWildcard(segments)
+
+        return if (wildcard.hasNone()) {
+            val dirPath = segments.dropLast(1).joinToString("/")
+            val fileName = segments.last()
+            basePath.resolve(dirPath).normalize() to fileName
+        } else if (wildcard.position == 0) {
+            basePath to pattern
+        } else {
+            val dirPath = segments.take(wildcard.position).joinToString("/")
+            val globPattern = segments.drop(wildcard.position).joinToString("/")
+            basePath.resolve(dirPath).normalize() to globPattern
+        }
+    }
+
+    private fun checkForWildcard(pathSegments: List<String>): WildcardCheckResult {
+        val position = pathSegments.indexOfFirst { it.contains('*') }
+        return if (position == -1) {
+            WildcardCheckResult(position = position, isPresent = false)
+        } else {
+            WildcardCheckResult(position = position, isPresent = true)
+        }
+    }
+
+    private data class WildcardCheckResult(
+        val position: Int,
+        val isPresent: Boolean
+    ) {
+        fun hasNone() = !isPresent
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
@@ -1,17 +1,11 @@
 package io.github.emaarco.bpmn.adapter.outbound.filesystem
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.UncheckedIOException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
-/**
- * TODO: Check if the wildcard pattern is working & all cases are covered
- */
 class BpmnFileLoaderTest {
 
     private val underTest = BpmnFileLoader()
@@ -55,9 +49,82 @@ class BpmnFileLoaderTest {
     }
 
     @Test
-    fun `loadFrom throws UncheckedIOException when base directory does not exist`() {
-        val nonExistentDir = Paths.get(System.getProperty("java.io.tmpdir"), "nonexistent-${System.nanoTime()}")
-        assertThatThrownBy { underTest.loadFrom(nonExistentDir.toString(), "*.bpmn") }
-            .isInstanceOf(UncheckedIOException::class.java)
+    fun `loadFrom returns matching files from outside current root using relative paths`(@TempDir tempDir: Path) {
+
+        // given: a directory structure with files outside the base directory
+        val baseDir = Files.createDirectory(tempDir.resolve("project"))
+        val externalDir = Files.createDirectory(tempDir.resolve("external"))
+        val externalFile = Files.createFile(externalDir.resolve("external-process.bpmn")).toFile()
+        Files.createFile(externalDir.resolve("other.txt"))
+
+        // when: we call loadFrom with a relative path pattern going outside the root
+        val result = underTest.loadFrom(baseDir.toString(), "../external/*.bpmn")
+
+        // then: expect the list to contain the external BPMN file
+        assertThat(result).containsExactly(externalFile)
+    }
+
+    @Test
+    fun `loadFrom returns matching files from external subdirectories using recursive wildcard`(@TempDir tempDir: Path) {
+
+        // given: a directory structure with nested external files
+        val baseDir = Files.createDirectory(tempDir.resolve("project"))
+        val externalDir = Files.createDirectory(tempDir.resolve("external"))
+        val subDir1 = Files.createDirectory(externalDir.resolve("subdir1"))
+        val subDir2 = Files.createDirectory(externalDir.resolve("subdir2"))
+        val deepDir = Files.createDirectory(subDir1.resolve("deep"))
+
+        val externalFile1 = Files.createFile(externalDir.resolve("root-process.bpmn")).toFile()
+        val externalFile2 = Files.createFile(subDir1.resolve("sub1-process.bpmn")).toFile()
+        val externalFile3 = Files.createFile(subDir2.resolve("sub2-process.bpmn")).toFile()
+        val externalFile4 = Files.createFile(deepDir.resolve("deep-process.bpmn")).toFile()
+        Files.createFile(externalDir.resolve("other.txt"))
+        Files.createFile(subDir1.resolve("readme.md"))
+
+        // when: we call loadFrom with a recursive wildcard pattern
+        val result = underTest.loadFrom(baseDir.toString(), "../external/**/*.bpmn")
+
+        // then: expect the list to contain all BPMN files from external directory tree
+        assertThat(result).containsExactlyInAnyOrder(externalFile1, externalFile2, externalFile3, externalFile4)
+    }
+
+    @Test
+    fun `loadFrom returns matching files from deeply nested external paths`(@TempDir tempDir: Path) {
+
+        // given: a directory structure with deeply nested external files
+        val projectDir = Files.createDirectory(tempDir.resolve("workspace"))
+        val baseDir = Files.createDirectory(projectDir.resolve("current"))
+        val deepDir = Files.createDirectory(tempDir.resolve("shared"))
+        val nestedDir = Files.createDirectory(deepDir.resolve("resources"))
+        val bpmnDir = Files.createDirectory(nestedDir.resolve("bpmn"))
+
+        val deepFile1 = Files.createFile(bpmnDir.resolve("shared-process.bpmn")).toFile()
+        val deepFile2 = Files.createFile(nestedDir.resolve("resource-process.bpmn")).toFile()
+        Files.createFile(bpmnDir.resolve("config.xml"))
+
+        // when: we call loadFrom with a deep relative path pattern
+        val result = underTest.loadFrom(baseDir.toString(), "../../shared/**/*.bpmn")
+
+        // then: expect the list to contain all BPMN files from the deep external path
+        assertThat(result).containsExactlyInAnyOrder(deepFile1, deepFile2)
+    }
+
+    @Test
+    fun `loadFrom returns specific external file when exact path is provided`(@TempDir tempDir: Path) {
+
+        // given: a directory structure with specific external files
+        val baseDir = Files.createDirectory(tempDir.resolve("project"))
+        val externalDir = Files.createDirectory(tempDir.resolve("external"))
+        val specificDir = Files.createDirectory(externalDir.resolve("specific"))
+
+        val targetFile = Files.createFile(specificDir.resolve("target.bpmn")).toFile()
+        Files.createFile(specificDir.resolve("other.bpmn"))
+        Files.createFile(externalDir.resolve("different.bpmn"))
+
+        // when: we call loadFrom with a specific file pattern
+        val result = underTest.loadFrom(baseDir.toString(), "../external/specific/target.bpmn")
+
+        // then: expect the list to contain only the specific target file
+        assertThat(result).containsExactly(targetFile)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-kotlin = "2.2.10"
+kotlin = "2.2.20"
 kotlinpoet = "2.2.0"
 javapoet = "0.7.0"
 camunda = "7.23.0"
@@ -31,6 +31,6 @@ testing = ["junit", "junitPlatformLauncher", "assertj", "mockk"]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-gradlePluginPublish = { id = "com.gradle.plugin-publish", version = "1.3.1" }
+gradlePluginPublish = { id = "com.gradle.plugin-publish", version = "2.0.0" }
 mavenPluginDevelopment = { id = "org.gradlex.maven-plugin-development", version = "1.0.3" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ jUnit = "5.13.4"
 assertJ = "4.0.0-M1"
 junitPlatformLauncher = "1.13.4"
 mockk = "1.14.5"
+ant = "1.10.15"
 
 [libraries]
 # Plugin dependencies
@@ -19,6 +20,7 @@ mavenPluginAnnotations = { module = "org.apache.maven.plugin-tools:maven-plugin-
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 javapoet = { module = "com.palantir.javapoet:javapoet", version.ref = "javapoet" }
 bpmnmodel = { module = "org.camunda.bpm.model:camunda-bpmn-model", version.ref = "camunda" }
+ant = { module = "org.apache.ant:ant", version.ref = "ant" }
 # Testing dependencies
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jUnit" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertJ" }


### PR DESCRIPTION
### Fix

plugin wasn't able to load bpmn-files outside the projectDir. 
Assuming we are in `Open-Source/bpmn-to-code/project-a` it couldn't load files from `Open-Source/config/*`