### PR TITLE
refactor: Extract Zeebe model constants to dedicated class

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -100,7 +100,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
 
     private fun extractVariables(modelInstance: ModelInstance): List<VariableDefinition> {
         val flowNodes = modelInstance.getModelElementsByType(FlowNode::class.java)
-        val extensions = flowNodes.flatMap { it.findExtensionElementsWithType(type = "inputOutput") }
+        val extensions = flowNodes.flatMap { it.findExtensionElementsWithType(type = BpmnModelConstants.CAMUNDA_ELEMENT_INPUT_OUTPUT) }
         val ioVariableNames = extractInputAndOutputVariables(extensions)
         val multiInstanceVariableNames = extractMultiInstanceVariables(flowNodes)
         val allVariableNames = ioVariableNames + multiInstanceVariableNames
@@ -110,10 +110,10 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
     private fun extractInputAndOutputVariables(
         extensions: List<ModelElementInstance>
     ): List<String> {
-        val allowedDefinitions = listOf("inputParameter", "outputParameter")
+        val allowedDefinitions = listOf(BpmnModelConstants.CAMUNDA_ELEMENT_INPUT_PARAMETER, BpmnModelConstants.CAMUNDA_ELEMENT_OUTPUT_PARAMETER)
         val allElementsInContainer = extensions.flatMap { it.domElement.childElements }
         val eitherInputOrOutput = allElementsInContainer.filter { allowedDefinitions.contains(it.localName) }
-        val variableNames = eitherInputOrOutput.map { it.getAttribute("name") }
+        val variableNames = eitherInputOrOutput.map { it.getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_NAME) }
         return variableNames.filterNot { it.isNullOrBlank() }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -83,9 +83,9 @@ class OperatonModelExtractor : EngineSpecificExtractor {
     private fun ServiceTask.detectWorkerType(): String {
         val taskExtractor = { attrName: String -> this.getAttributeValueNs(NAMESPACE, attrName) }
         return when {
-            taskExtractor("topic") != null -> taskExtractor("topic")
-            taskExtractor("delegateExpression") != null -> taskExtractor("delegateExpression")
-            taskExtractor("class") != null -> taskExtractor("class")
+            taskExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TOPIC) != null -> taskExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TOPIC)
+            taskExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_DELEGATE_EXPRESSION) != null -> taskExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_DELEGATE_EXPRESSION)
+            taskExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_CLASS) != null -> taskExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_CLASS)
             else -> throw IllegalStateException("Service task '${this.id}' has no valid worker type")
         }
     }
@@ -102,16 +102,16 @@ class OperatonModelExtractor : EngineSpecificExtractor {
     private fun MessageEventDefinition.detectSendEvents(): Pair<String, MessageEventDefinition>? {
         val eventExtractor = { attrName: String -> this.getAttributeValueNs(NAMESPACE, attrName) }
         return when {
-            eventExtractor("topic") != null -> eventExtractor("topic") to this
-            eventExtractor("delegateExpression") != null -> eventExtractor("delegateExpression") to this
-            eventExtractor("class") != null -> eventExtractor("class") to this
+            eventExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TOPIC) != null -> eventExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TOPIC) to this
+            eventExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_DELEGATE_EXPRESSION) != null -> eventExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_DELEGATE_EXPRESSION) to this
+            eventExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_CLASS) != null -> eventExtractor(BpmnModelConstants.CAMUNDA_ATTRIBUTE_CLASS) to this
             else -> null
         }
     }
 
     private fun extractVariables(modelInstance: ModelInstance): List<VariableDefinition> {
         val flowNodes = modelInstance.getModelElementsByType(FlowNode::class.java)
-        val extensions = flowNodes.flatMap { it.findExtensionElementsWithType(type = "inputOutput") }
+        val extensions = flowNodes.flatMap { it.findExtensionElementsWithType(type = BpmnModelConstants.CAMUNDA_ELEMENT_INPUT_OUTPUT) }
         val ioVariableNames = extractInputAndOutputVariables(extensions)
         val multiInstanceVariableNames = extractMultiInstanceVariables(flowNodes)
         val allVariableNames = ioVariableNames + multiInstanceVariableNames
@@ -121,10 +121,10 @@ class OperatonModelExtractor : EngineSpecificExtractor {
     private fun extractInputAndOutputVariables(
         extensions: List<ModelElementInstance>
     ): List<String> {
-        val allowedDefinitions = listOf("inputParameter", "outputParameter")
+        val allowedDefinitions = listOf(BpmnModelConstants.CAMUNDA_ELEMENT_INPUT_PARAMETER, BpmnModelConstants.CAMUNDA_ELEMENT_OUTPUT_PARAMETER)
         val allElementsInContainer = extensions.flatMap { it.domElement.childElements }
         val eitherInputOrOutput = allElementsInContainer.filter { allowedDefinitions.contains(it.localName) }
-        val variableNames = eitherInputOrOutput.map { it.getAttribute("name") }
+        val variableNames = eitherInputOrOutput.map { it.getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_NAME) }
         return variableNames.filterNot { it.isNullOrBlank() }
     }
 
@@ -132,8 +132,8 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         nodes: Collection<FlowNode>
     ): List<String> {
         val loops = nodes.flatMap { it.getChildElementsByType(MultiInstanceLoopCharacteristics::class.java) }
-        val elementVariables = loops.mapNotNull { it.getAttributeValueNs(NAMESPACE, "elementVariable") }
-        val collectionVariables = loops.mapNotNull { it.getAttributeValueNs(NAMESPACE, "collection") }
+        val elementVariables = loops.mapNotNull { it.getAttributeValueNs(NAMESPACE, BpmnModelConstants.CAMUNDA_ATTRIBUTE_ELEMENT_VARIABLE) }
+        val collectionVariables = loops.mapNotNull { it.getAttributeValueNs(NAMESPACE, BpmnModelConstants.CAMUNDA_ATTRIBUTE_COLLECTION) }
         val allVariables = elementVariables + collectionVariables
         return allVariables.map { it.removeExpressionSyntax() }
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -3,6 +3,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.FlowNodeUtils.findExtensionElement
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.FlowNodeUtils.findExtensionElements
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.FlowNodeUtils.findExtensionElementsWithType
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ZeebeModelConstants
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findMessages
@@ -53,7 +54,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         return callActivities.map { activity ->
             val elementId = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val extension = activity.findExtensionElement(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
-            val processId = extension.getAttributeValue("processId")
+            val processId = extension.getAttributeValue(ZeebeModelConstants.ATTRIBUTE_PROCESS_ID)
             requireNotNull(processId) { "processId cannot be null for call activity with id: $elementId" }
             CallActivityDefinition(elementId, processId)
         }
@@ -72,14 +73,14 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
     private fun findAllServiceTaskDefinitions(flowNodes: Collection<FlowNode>): List<Pair<FlowNode, ModelElementInstance>> {
         return flowNodes.mapNotNull { node ->
             val extensionElements = node.findExtensionElements()
-            val taskDefinition = extensionElements.firstOrNull { it.elementType.typeName == "taskDefinition" }
+            val taskDefinition = extensionElements.firstOrNull { it.elementType.typeName == ZeebeModelConstants.ELEMENT_TASK_DEFINITION }
             if (taskDefinition != null) Pair(node, taskDefinition) else null
         }
     }
 
     private fun extractVariables(modelInstance: ModelInstance): List<VariableDefinition> {
         val flowNodes = modelInstance.getModelElementsByType(FlowNode::class.java)
-        val extensions = flowNodes.flatMap { it.findExtensionElementsWithType(type = "ioMapping") }
+        val extensions = flowNodes.flatMap { it.findExtensionElementsWithType(type = ZeebeModelConstants.ELEMENT_IO_MAPPING) }
         val inputOutputVariables = extractInputAndOutputVariables(extensions)
         val multiInstanceVariables = extractMultiInstanceVariables(flowNodes)
         val allVariables = inputOutputVariables + multiInstanceVariables
@@ -89,10 +90,10 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
     private fun extractInputAndOutputVariables(
         extensions: List<ModelElementInstance>
     ): List<String> {
-        val allowedDefinitions = listOf("input", "output")
+        val allowedDefinitions = listOf(ZeebeModelConstants.ELEMENT_INPUT, ZeebeModelConstants.ELEMENT_OUTPUT)
         val allElementsInContainer = extensions.flatMap { it.domElement.childElements }
         val eitherInputOrOutput = allElementsInContainer.filter { allowedDefinitions.contains(it.localName) }
-        val variableNames = eitherInputOrOutput.map { it.getAttribute("target") }
+        val variableNames = eitherInputOrOutput.map { it.getAttribute(ZeebeModelConstants.ATTRIBUTE_TARGET) }
         return variableNames.filterNot { it.isNullOrBlank() }
     }
 
@@ -101,11 +102,11 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
     ): List<String> {
         val loops = nodes.flatMap { it.getChildElementsByType(MultiInstanceLoopCharacteristics::class.java) }
         val allExtensions = loops.flatMap { it.extensionElements.elementsQuery.list() }
-        val loopCharacteristics = allExtensions.filter { it.elementType.typeName == "loopCharacteristics" }
-        val inputElements = loopCharacteristics.map { it.domElement.getAttribute("inputElement") }
-        val inputCollections = loopCharacteristics.map { it.domElement.getAttribute("inputCollection") }
-        val outputElements = loopCharacteristics.mapNotNull { it.domElement.getAttribute("outputElement") }
-        val outputCollections = loopCharacteristics.mapNotNull { it.domElement.getAttribute("outputCollection") }
+        val loopCharacteristics = allExtensions.filter { it.elementType.typeName == ZeebeModelConstants.ELEMENT_LOOP_CHARACTERISTICS }
+        val inputElements = loopCharacteristics.map { it.domElement.getAttribute(ZeebeModelConstants.ATTRIBUTE_INPUT_ELEMENT) }
+        val inputCollections = loopCharacteristics.map { it.domElement.getAttribute(ZeebeModelConstants.ATTRIBUTE_INPUT_COLLECTION) }
+        val outputElements = loopCharacteristics.mapNotNull { it.domElement.getAttribute(ZeebeModelConstants.ATTRIBUTE_OUTPUT_ELEMENT) }
+        val outputCollections = loopCharacteristics.mapNotNull { it.domElement.getAttribute(ZeebeModelConstants.ATTRIBUTE_OUTPUT_COLLECTION) }
         val allLoopVariables = inputElements + inputCollections + outputElements + outputCollections
         return allLoopVariables.map { it.removePrefix("=") }
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ZeebeModelConstants.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ZeebeModelConstants.kt
@@ -1,0 +1,17 @@
+package io.github.emaarco.bpmn.adapter.outbound.engine.utils
+
+object ZeebeModelConstants {
+
+    const val ELEMENT_TASK_DEFINITION = "taskDefinition"
+    const val ELEMENT_IO_MAPPING = "ioMapping"
+    const val ELEMENT_INPUT = "input"
+    const val ELEMENT_OUTPUT = "output"
+    const val ELEMENT_LOOP_CHARACTERISTICS = "loopCharacteristics"
+
+    const val ATTRIBUTE_PROCESS_ID = "processId"
+    const val ATTRIBUTE_TARGET = "target"
+    const val ATTRIBUTE_INPUT_ELEMENT = "inputElement"
+    const val ATTRIBUTE_INPUT_COLLECTION = "inputCollection"
+    const val ATTRIBUTE_OUTPUT_ELEMENT = "outputElement"
+    const val ATTRIBUTE_OUTPUT_COLLECTION = "outputCollection"
+}


### PR DESCRIPTION
Replace hardcoded string literals in ZeebeModelExtractor with constants from new ZeebeModelConstants object. Also apply same constant pattern to Camunda7ModelExtractor and OperatonModelExtractor for consistency, using existing BpmnModelConstants where available.