### PR TITLE
refactor(issue-131): replace println with proper logging

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation(libs.bpmnmodel)
     implementation(libs.bundles.codegen)
     implementation(libs.ant)
+    api(libs.slf4jApi)
+    api(libs.kotlinLogging)
     testImplementation(libs.bundles.testing)
     testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapter.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapter.kt
@@ -5,6 +5,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.extractor.EngineSpecificEx
 import io.github.emaarco.bpmn.adapter.outbound.engine.extractor.OperatonModelExtractor
 import io.github.emaarco.bpmn.adapter.outbound.engine.extractor.ZeebeModelExtractor
 import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.BpmnResource
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
@@ -19,7 +20,7 @@ class ExtractBpmnAdapter(
         val content = bpmnFile.content
         val (engine, extractor) = getExtractor(bpmnFile)
         return try {
-            println("Extracting model '${bpmnFile.fileName}' with extractor for '$engine'")
+            logger.info { "Extracting model '${bpmnFile.fileName}' with extractor for '$engine'" }
             extractor.extract(content)
         } catch (ex: Exception) {
             throw RuntimeException(
@@ -39,6 +40,7 @@ class ExtractBpmnAdapter(
     }
 
     companion object {
+        private val logger = KotlinLogging.logger {}
         val extractors = mapOf(
             ProcessEngine.ZEEBE to ZeebeModelExtractor(),
             ProcessEngine.CAMUNDA_7 to Camunda7ModelExtractor(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
@@ -1,10 +1,13 @@
 package io.github.emaarco.bpmn.adapter.outbound.filesystem
 
 import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.tools.ant.DirectoryScanner
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.absolute
+
+private val logger = KotlinLogging.logger {}
 
 class BpmnFileLoader : LoadBpmnFilesPort {
 
@@ -24,7 +27,7 @@ class BpmnFileLoader : LoadBpmnFilesPort {
         scanner.scan()
         
         val files = scanner.includedFiles.map { File(searchDir.toFile(), it) }
-        println("Found ${files.size} files matching pattern $pattern in directory $searchDir")
+        logger.info { "Found ${files.size} files matching pattern $pattern in directory $searchDir" }
 
         return files
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessApiFileSaver.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessApiFileSaver.kt
@@ -2,7 +2,10 @@ package io.github.emaarco.bpmn.adapter.outbound.filesystem
 
 import io.github.emaarco.bpmn.application.port.outbound.SaveProcessApiPort
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
+
+private val logger = KotlinLogging.logger {}
 
 class ProcessApiFileSaver : SaveProcessApiPort {
 
@@ -12,21 +15,21 @@ class ProcessApiFileSaver : SaveProcessApiPort {
     ) {
         val outputFolder = File(outputFolderPath)
         if (!outputFolder.exists()) {
-            println("Creating output folder: $outputFolderPath")
+            logger.debug { "Creating output folder: $outputFolderPath" }
             outputFolder.mkdirs()
         }
 
         generatedFiles.forEach { generatedFile ->
             val packageDir = File(outputFolder, generatedFile.packagePath.replace('.', File.separatorChar))
             if (!packageDir.exists()) {
-                println("Creating package folder: ${packageDir.absolutePath}")
+                logger.debug { "Creating package folder: ${packageDir.absolutePath}" }
                 packageDir.mkdirs()
             }
 
             val file = File(packageDir, generatedFile.fileName)
             file.writeText(generatedFile.content)
 
-            println("Generated ${generatedFile.fileName} in file-system")
+            logger.info { "Generated ${generatedFile.fileName} in file-system" }
         }
     }
 }

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
@@ -46,6 +46,6 @@ abstract class GenerateBpmnModelsTask : DefaultTask() {
             processEngine,
             useVersioning,
         )
-        println("BPMN models generated successfully")
+        logger.lifecycle("BPMN models generated successfully")
     }
 }

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
@@ -83,6 +83,7 @@ public class BpmnModelMojo extends AbstractMojo {
 		OutputLanguage language = OutputLanguage.valueOf(outputLanguage);
 		ProcessEngine engine = ProcessEngine.valueOf(processEngine);
 		plugin.execute(baseDir, filePattern, outputFolderPath, packagePath, language, engine, useVersioning);
+		getLog().info("BPMN models generated successfully");
 	}
 	
 }

--- a/bpmn-to-code-web/build.gradle.kts
+++ b/bpmn-to-code-web/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.bundles.ktor)
     implementation(libs.kotlinxSerializationJson)
     implementation(libs.logbackClassic)
+    implementation(libs.kotlinLogging)
 
     // Testing
     testImplementation(libs.bundles.testing)

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/Application.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/Application.kt
@@ -1,6 +1,7 @@
 package io.github.emaarco.bpmn.web
 
 import io.github.emaarco.bpmn.web.config.AppConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.emaarco.bpmn.web.routes.generateRoutes
 import io.github.emaarco.bpmn.web.service.WebGenerationService
 import io.ktor.http.*
@@ -17,6 +18,8 @@ import io.ktor.server.plugins.swagger.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.json.Json
+
+private val logger = KotlinLogging.logger {}
 
 fun main() {
 
@@ -67,6 +70,7 @@ fun Application.configureApp(
     // Status pages for error handling
     install(StatusPages) {
         exception<Throwable> { call, cause ->
+            logger.error(cause) { "Unhandled exception" }
             val message = mapOf("error" to (cause.message ?: "Unknown error"))
             call.respond(HttpStatusCode.InternalServerError, message)
         }

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationService.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationService.kt
@@ -1,25 +1,32 @@
 package io.github.emaarco.bpmn.web.service
 
 import io.github.emaarco.bpmn.adapter.inbound.CreateProcessApiInMemoryPlugin
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.validation.VariableNameCollisionException
 import io.github.emaarco.bpmn.web.model.GenerateRequest
 import io.github.emaarco.bpmn.web.model.GenerateResponse
 import java.util.*
 
+private val logger = KotlinLogging.logger {}
+
 class WebGenerationService {
 
     private val plugin = CreateProcessApiInMemoryPlugin()
 
     fun generate(request: GenerateRequest): GenerateResponse {
+        val config = request.config
+        logger.info { "Generating API for ${request.files.size} file(s) [${config.outputLanguage}, ${config.processEngine}]" }
         try {
             val bpmnInputs = request.files.map { this.buildCommand(it) }
             val generatedApiFiles = this.executePlugin(request.config, bpmnInputs)
             val generatedFiles = generatedApiFiles.map { mapToResponse(it) }
             return GenerateResponse(success = true, files = generatedFiles)
         } catch (e: VariableNameCollisionException) {
+            logger.error(e) { "Variable name collision during generation" }
             return GenerateResponse.fromCollisionException(e)
         } catch (e: Exception) {
+            logger.error(e) { "Unexpected error during generation" }
             return GenerateResponse.unknownError()
         }
     }

--- a/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
+++ b/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
@@ -46,9 +46,6 @@ class WebGenerationServiceTest {
         assertThat(generatedFile.fileName).describedAs("Should generate Kotlin file").endsWith(".kt")
         assertThat(generatedFile.content).describedAs("Should contain Kotlin object declaration").contains("object")
         assertThat(generatedFile.content).describedAs("Should contain process ID").contains("newsletterSubscription")
-
-        println("Generated file: ${generatedFile.fileName}")
-        println("Content preview: ${generatedFile.content.take(200)}...")
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ ant = "1.10.15"
 ktor = "3.4.1"
 kotlinxSerialization = "1.10.0"
 logback = "1.5.32"
+slf4j = "2.0.16"
+kotlinLogging = "7.0.3"
 
 [libraries]
 # Plugin dependencies
@@ -36,6 +38,8 @@ ktorServerSwagger = { module = "io.ktor:ktor-server-swagger", version.ref = "kto
 ktorServerTestHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 logbackClassic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+slf4jApi = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+kotlinLogging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlinLogging" }
 # Testing dependencies
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jUnit" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertJ" }


### PR DESCRIPTION
Introduce kotlin-logging (SLF4J) in core and web modules, use Gradle's built-in task logger and Maven's AbstractMojo.getLog() in their respective plugins. Remove debug printlns from tests.