### PR TITLE
docs(issue-142): update README documentation for MCP module

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ bpmn-to-code consists of multiple modules to support different use cases:
 - [bpmn-to-code-maven](bpmn-to-code-maven/README.md): Maven plugin for integrating code generation
   into Maven builds.
 - [bpmn-to-code-web](bpmn-to-code-web/README.md): Web application for browser-based code generation (preview available).
+- [bpmn-to-code-mcp](bpmn-to-code-mcp/README.md): MCP server for AI-assisted code generation (experimental).
 
 ### Core & Examples
 - [bpmn-to-code-core](bpmn-to-code-core): Core logic for parsing BPMN files and generating API code.
@@ -174,6 +175,9 @@ bpmn-to-code consists of multiple modules to support different use cases:
 **Build Plugins:**
 - 📦 [Maven Central Repository](https://central.sonatype.com/artifact/io.github.emaarco/bpmn-to-code-maven) - Maven Plugin
 - 📦 [Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.github.emaarco.bpmn-to-code-gradle) - Gradle Plugin
+
+**MCP Server (Experimental):**
+- 🤖 [Setup Instructions](bpmn-to-code-mcp/README.md) - Use bpmn-to-code directly from AI assistants via MCP
 
 ## 🤝 Contributing
 

--- a/bpmn-to-code-mcp/README.md
+++ b/bpmn-to-code-mcp/README.md
@@ -3,6 +3,8 @@
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that exposes bpmn-to-code's code generation as a tool for AI assistants.
 Feed it BPMN XML and get type-safe process API code back — directly inside your AI-powered editor or chat.
 
+> **Experimental:** This module is an experiment to explore MCP in practice. It is not officially supported for production use alongside the Gradle, Maven, and Web modules. If you're interested in using it, please [leave feedback](https://github.com/emaarco/bpmn-to-code/issues) so it can be promoted to officially supported.
+
 ## Why MCP?
 
 - **No project setup needed** — generate process API code without adding a Gradle or Maven plugin
@@ -21,7 +23,7 @@ Generates type-safe process API code from BPMN XML.
 | `processEngine`  | no       | `ZEEBE`               | `ZEEBE`, `CAMUNDA_7`, or `OPERATON`             |
 | `packagePath`    | no       | `com.example.process` | Target package for generated code               |
 
-## Option 1: Local (stdio)
+## Getting Started
 
 Run the MCP server locally as a JAR. The MCP client launches and communicates with it via stdin/stdout.
 
@@ -39,7 +41,7 @@ The JAR is created at `bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-<version>-al
 java -jar bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-0.0.19-all.jar
 ```
 
-### Configuring Your MCP Client (stdio)
+### Configuring Your MCP Client
 
 #### Claude Code
 
@@ -79,54 +81,3 @@ Most MCP clients follow a similar pattern — point them at the JAR using stdio 
 - **Args:** `["-jar", "/absolute/path/to/bpmn-to-code-mcp-0.0.19-all.jar"]`
 
 Refer to your client's documentation for the exact configuration location.
-
-## Option 2: Remote (HTTP)
-
-Run the MCP server as a remote HTTP service. Useful for shared environments, CI pipelines, or hosting on a server.
-
-**Start with HTTP transport:**
-```bash
-java -jar bpmn-to-code-mcp-0.0.19-all.jar --http
-```
-
-**Custom port (default: 8080):**
-```bash
-java -jar bpmn-to-code-mcp-0.0.19-all.jar --http --port=9090
-```
-
-You can also use environment variables:
-```bash
-MCP_TRANSPORT=http MCP_PORT=9090 java -jar bpmn-to-code-mcp-0.0.19-all.jar
-```
-
-### Docker
-
-**Build the image:**
-```bash
-./gradlew :bpmn-to-code-mcp:dockerBuild
-```
-
-**Run it:**
-```bash
-docker run -p 8080:8080 --rm emaarco/bpmn-to-code-mcp:latest
-```
-
-### Configuring Your MCP Client (HTTP)
-
-Point your MCP client at the server's URL:
-
-```json
-{
-  "mcpServers": {
-    "bpmn-to-code": {
-      "url": "http://localhost:8080/mcp"
-    }
-  }
-}
-```
-
-Replace `localhost:8080` with the actual host and port if deployed remotely.
-
-## Remote Usage
-
-If you don't want to build locally, you can download the JAR from [GitHub Releases](https://github.com/emaarco/bpmn-to-code/releases) (once published) and point your MCP client config at the downloaded file.


### PR DESCRIPTION
Closes #142

## Summary

- Add `bpmn-to-code-mcp` to the root README's user-facing modules list and distribution channels section
- Add experimental disclaimer to MCP README encouraging user feedback
- Remove non-existent HTTP/remote transport documentation (`--http`, `--port`, Docker HTTP, remote URL config)
- Remove GitHub Releases download reference that doesn't exist yet
- Rename "Option 1: Local (stdio)" to "Getting Started" since it's the only option

🤖 Generated with [Claude Code](https://claude.com/claude-code)