### PR TITLE
feat(issue-125): add migrate-to-bpmn-to-code-apis skill and rename skills

### DIFF
--- a/.agent/skills/migrate-to-bpmn-to-code-apis/SKILL.md
+++ b/.agent/skills/migrate-to-bpmn-to-code-apis/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: migrate-to-api
+name: migrate-to-bpmn-to-code-apis
 argument-hint: "[path/to/scan] | [ProcessApiClassName]"
 description: "Replace hardcoded BPMN strings with references to the generated Process API. Use when the user asks to 'migrate to the process API', 'replace hardcoded strings with API references', 'use the generated BPMN API', or 'refactor to type-safe BPMN constants'."
 allowed-tools: Read, Glob, Grep, Edit
 ---
 
-# Skill: migrate-to-api
+# Skill: migrate-to-bpmn-to-code-apis
 
 Replace hardcoded BPMN string literals in user code with references to the generated Process API.
 

--- a/.agent/skills/setup-bpmn-to-code-gradle/SKILL.md
+++ b/.agent/skills/setup-bpmn-to-code-gradle/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: setup-gradle
+name: setup-bpmn-to-code-gradle
 description: "Set up the bpmn-to-code Gradle plugin in an existing project. Adds the plugin dependency and configures the code generation task. Use when the user asks to 'add bpmn-to-code to my Gradle project', 'set up BPMN code generation', or 'configure the Gradle plugin'."
 allowed-tools: Read, Write, Edit, Glob, Bash(./gradlew *)
 ---
 
-# Skill: setup-gradle
+# Skill: setup-bpmn-to-code-gradle
 
 Set up the bpmn-to-code Gradle plugin in an existing Gradle project.
 

--- a/.agent/skills/setup-bpmn-to-code-maven/SKILL.md
+++ b/.agent/skills/setup-bpmn-to-code-maven/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: setup-maven
+name: setup-bpmn-to-code-maven
 description: "Set up the bpmn-to-code Maven plugin in an existing project. Adds the plugin configuration to pom.xml with code generation goals. Use when the user asks to 'add bpmn-to-code to my Maven project', 'set up BPMN code generation for Maven', or 'configure the Maven plugin'."
 allowed-tools: Read, Write, Edit, Glob
 ---
 
-# Skill: setup-maven
+# Skill: setup-bpmn-to-code-maven
 
 Set up the bpmn-to-code Maven plugin in an existing Maven project.
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ bpmn-to-code includes [AI coding assistant skills](docs/skills.md) that help you
 npx skills add https://github.com/emaarco/bpmn-to-code
 
 # Or pick only what you need
-npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-gradle
-npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-maven
-npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/migrate-to-api
+npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-bpmn-to-code-gradle
+npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-bpmn-to-code-maven
+npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/migrate-to-bpmn-to-code-apis
 ```
 
 Available skills include project setup (Gradle & Maven), API migration, issue management, ADR writing, and code review.

--- a/docs/development/ai-skills.md
+++ b/docs/development/ai-skills.md
@@ -11,9 +11,9 @@ Skills live in `.agent/skills/` and are agent-agnostic by design.
     ├── clean-code/SKILL.md
     ├── create-adr/SKILL.md
     ├── create-ticket/SKILL.md
-    ├── migrate-to-api/SKILL.md
-    ├── setup-gradle/SKILL.md
-    └── setup-maven/SKILL.md
+    ├── migrate-to-bpmn-to-code-apis/SKILL.md
+    ├── setup-bpmn-to-code-gradle/SKILL.md
+    └── setup-bpmn-to-code-maven/SKILL.md
 .claude -> .agent              # symlink for Claude Code compatibility
 ```
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -7,9 +7,9 @@ Skills are stored under [`.agent/skills/`](../.agent/skills/) and work with [Cla
 
 | Skill | Description |
 |-------|-------------|
-| [setup-gradle](../.agent/skills/setup-gradle/SKILL.md) | Set up the bpmn-to-code Gradle plugin in an existing project |
-| [setup-maven](../.agent/skills/setup-maven/SKILL.md) | Set up the bpmn-to-code Maven plugin in an existing project |
-| [migrate-to-api](../.agent/skills/migrate-to-api/SKILL.md) | Replace hardcoded BPMN strings with generated Process API references |
+| [setup-bpmn-to-code-gradle](../.agent/skills/setup-bpmn-to-code-gradle/SKILL.md) | Set up the bpmn-to-code Gradle plugin in an existing project |
+| [setup-bpmn-to-code-maven](../.agent/skills/setup-bpmn-to-code-maven/SKILL.md) | Set up the bpmn-to-code Maven plugin in an existing project |
+| [migrate-to-bpmn-to-code-apis](../.agent/skills/migrate-to-bpmn-to-code-apis/SKILL.md) | Replace hardcoded BPMN strings with generated Process API references |
 
 ## Project Management
 
@@ -33,7 +33,7 @@ Install skills in [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 
 npx skills add https://github.com/emaarco/bpmn-to-code
 
 # Or pick only what you need
-npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-gradle
-npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-maven
-npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/migrate-to-api
+npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-bpmn-to-code-gradle
+npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/setup-bpmn-to-code-maven
+npx skills add https://github.com/emaarco/bpmn-to-code/tree/main/.claude/skills/migrate-to-bpmn-to-code-apis
 ```


### PR DESCRIPTION
## Summary
- Add `migrate-to-bpmn-to-code-apis` skill to replace hardcoded BPMN strings with generated Process API references
- Rename skills for clarity: `setup-gradle` → `setup-bpmn-to-code-gradle`, `setup-maven` → `setup-bpmn-to-code-maven`, `migrate-to-api` → `migrate-to-bpmn-to-code-apis`
- Update all references in README, `docs/skills.md`, and `docs/development/ai-skills.md`

Follow-up to #146. Part of #125.

## Test plan
- [ ] Verify each SKILL.md has valid frontmatter with updated `name` fields matching directory names
- [ ] Verify `docs/skills.md` links resolve correctly with new paths
- [ ] Verify README `npx skills add` URLs use new skill names

🤖 Generated with [Claude Code](https://claude.com/claude-code)