### PR TITLE
feat(issue-156): show latest version chip in docs navbar

### DIFF
--- a/docs/website/src/.vitepress/theme/VersionBadge.vue
+++ b/docs/website/src/.vitepress/theme/VersionBadge.vue
@@ -1,0 +1,23 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const version = ref('')
+
+onMounted(async () => {
+  try {
+    const res = await fetch('https://api.github.com/repos/emaarco/bpmn-to-code/releases/latest')
+    if (res.ok) {
+      const data = await res.json()
+      version.value = data.tag_name
+    }
+  } catch (e) {
+    console.warn('Failed to fetch latest version:', e)
+  }
+})
+</script>
+
+<template>
+  <a v-if="version" class="version-badge" href="https://github.com/emaarco/bpmn-to-code/releases" target="_blank">
+    {{ version }}
+  </a>
+</template>

--- a/docs/website/src/.vitepress/theme/index.ts
+++ b/docs/website/src/.vitepress/theme/index.ts
@@ -1,4 +1,13 @@
 import DefaultTheme from 'vitepress/theme'
+import VersionBadge from './VersionBadge.vue'
 import './style.css'
+import { h } from 'vue'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'nav-bar-content-after': () => h(VersionBadge),
+    })
+  },
+}

--- a/docs/website/src/.vitepress/theme/style.css
+++ b/docs/website/src/.vitepress/theme/style.css
@@ -240,3 +240,28 @@
   background: var(--vp-c-bg);
   border-bottom: 1px solid var(--vp-c-divider);
 }
+
+/**
+ * Version badge in navbar
+ */
+.version-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--vp-c-brand-1) !important;
+  background: var(--vp-c-brand-soft);
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 999px;
+  text-decoration: none !important;
+  white-space: nowrap;
+  transition: background 0.2s, color 0.2s;
+}
+
+.version-badge:hover {
+  background: var(--vp-c-brand-1);
+  color: #fff !important;
+}


### PR DESCRIPTION
## Summary

- Adds a `VersionBadge.vue` component that fetches the latest release from the GitHub Releases API
- Injects the badge into the VitePress navbar via the `nav-bar-content-after` layout slot
- Styled as a pill-shaped chip with brand colors, light/dark mode support, and hover state

Closes #156

## Test plan

- [ ] Run `cd docs/website && npm run dev` and verify the version chip appears in the navbar
- [ ] Verify light and dark mode styling
- [ ] Verify the chip links to GitHub releases
- [ ] Check mobile/responsive nav behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)