### PR TITLE
ci(issue-162): automate Maven Central release

### DIFF
--- a/.agent/skills/release/SKILL.md
+++ b/.agent/skills/release/SKILL.md
@@ -108,7 +108,7 @@ gh release edit v<VERSION> --notes "<rewritten notes>"
 
 A maintainer will review and publish the draft.
 Publishing the release triggers the GitHub Action to publish all artifacts automatically:
-- **Maven Central** via `./gradlew publishToMavenCentral`
+- **Maven Central** via `./gradlew publishAndReleaseToMavenCentral`
 - **Gradle Plugin Portal** via `./gradlew publishPlugins`
 - **Docker Hub** via `./gradlew :bpmn-to-code-web:dockerBuild` and `dockerPush`
 

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -33,4 +33,4 @@ jobs:
         run: ./gradlew build
 
       - name: Publish to Maven Central
-        run: ./gradlew publishToMavenCentral --no-configuration-cache
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache


### PR DESCRIPTION
## Summary
- Use `publishAndReleaseToMavenCentral` instead of `publishToMavenCentral` to skip manual staging approval on central.sonatype.com

Closes #162

## Test plan
- [ ] Verify workflow file has updated task name
- [ ] Next release triggers automatic publish without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)