### PR TITLE
chore: prepare 1.0.0 release

### DIFF
--- a/bpmn-to-code-gradle/README.md
+++ b/bpmn-to-code-gradle/README.md
@@ -14,7 +14,7 @@ To get started, apply the plugin in your build.gradle.kts file:
 
 ```kotlin
 plugins {
-    id("io.github.emaarco.bpmn-to-code-gradle") version "0.0.19"
+    id("io.github.emaarco.bpmn-to-code-gradle") version "1.0.0"
 }
 ```
 

--- a/bpmn-to-code-maven/README.md
+++ b/bpmn-to-code-maven/README.md
@@ -22,7 +22,7 @@ where to output the generated API files, and how to format the output
         <plugin>
             <groupId>io.github.emaarco</groupId>
             <artifactId>bpmn-to-code-maven</artifactId>
-            <version>0.0.18</version>
+            <version>1.0.0</version>
             <executions>
                 <execution>
                     <goals>

--- a/bpmn-to-code-mcp/README.md
+++ b/bpmn-to-code-mcp/README.md
@@ -40,7 +40,7 @@ The JAR is created at `bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-<version>-al
 
 **Test it manually:**
 ```bash
-java -jar bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-0.0.19-all.jar
+java -jar bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-1.0.0-all.jar
 ```
 
 ### Configuring Your MCP Client
@@ -54,7 +54,7 @@ Add to your `.claude/settings.json` (project-level) or `~/.claude/settings.json`
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-0.0.19-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-1.0.0-all.jar"]
     }
   }
 }
@@ -69,7 +69,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-0.0.19-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-1.0.0-all.jar"]
     }
   }
 }
@@ -80,6 +80,6 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 Most MCP clients follow a similar pattern — point them at the JAR using stdio transport:
 
 - **Command:** `java`
-- **Args:** `["-jar", "/absolute/path/to/bpmn-to-code-mcp-0.0.19-all.jar"]`
+- **Args:** `["-jar", "/absolute/path/to/bpmn-to-code-mcp-1.0.0-all.jar"]`
 
 Refer to your client's documentation for the exact configuration location.

--- a/docs/development/docker-hub-deployment.md
+++ b/docs/development/docker-hub-deployment.md
@@ -32,7 +32,7 @@ cd /path/to/bpmn-to-code
 
 Edit `bpmn-to-code-web/build.gradle.kts`:
 ```kotlin
-version = "0.0.19"  // Increment version
+version = "1.0.0"  // Increment version
 ```
 
 Follow semantic versioning:
@@ -51,7 +51,7 @@ This task:
 1. Builds the fat JAR: `./gradlew :bpmn-to-code-web:buildFatJar`
 2. Runs `docker build` using `bpmn-to-code-web/Dockerfile`
 3. Tags image as:
-   - `emaarco/bpmn-to-code-web:VERSION` (e.g., `0.0.18`)
+   - `emaarco/bpmn-to-code-web:VERSION` (e.g., `1.0.0`)
    - `emaarco/bpmn-to-code-web:latest`
 
 **Platform Architecture:**
@@ -75,7 +75,7 @@ docker images | grep bpmn-to-code-web
 
 Expected output:
 ```
-emaarco/bpmn-to-code-web   0.0.18    abc123def456   ...
+emaarco/bpmn-to-code-web   1.0.0    abc123def456   ...
 emaarco/bpmn-to-code-web   latest    abc123def456   ...
 ```
 
@@ -103,14 +103,14 @@ docker run -p 8080:8080 --rm emaarco/bpmn-to-code-web:latest
 
 Create Git tag for the version:
 ```bash
-git tag -a v0.0.18 -m "Release version 0.0.18"
-git push origin v0.0.18
+git tag -a v1.0.0 -m "Release version 1.0.0"
+git push origin v1.0.0
 ```
 
 Create a GitHub release:
 1. Go to: https://github.com/emaarco/bpmn-to-code/releases
 2. Click "Draft a new release"
-3. Select tag `v0.0.18`
+3. Select tag `v1.0.0`
 4. Add release notes
 5. Publish release
 
@@ -127,7 +127,7 @@ This pushes both tags:
 
 **Manual push (alternative):**
 ```bash
-docker push emaarco/bpmn-to-code-web:0.0.18
+docker push emaarco/bpmn-to-code-web:1.0.0
 docker push emaarco/bpmn-to-code-web:latest
 ```
 
@@ -140,8 +140,8 @@ Check Docker Hub:
 
 Pull and test from Docker Hub:
 ```bash
-docker pull emaarco/bpmn-to-code-web:0.0.18
-docker run -p 8080:8080 emaarco/bpmn-to-code-web:0.0.18
+docker pull emaarco/bpmn-to-code-web:1.0.0
+docker run -p 8080:8080 emaarco/bpmn-to-code-web:1.0.0
 ```
 
 ## Gradle Tasks Reference

--- a/docs/website/src/getting-started/gradle.md
+++ b/docs/website/src/getting-started/gradle.md
@@ -8,13 +8,13 @@ The bpmn-to-code Gradle plugin generates type-safe Process API files from your B
 
 ```kotlin [build.gradle.kts]
 plugins {
-    id("io.github.emaarco.bpmn-to-code-gradle") version "0.0.19"
+    id("io.github.emaarco.bpmn-to-code-gradle") version "1.0.0"
 }
 ```
 
 ```groovy [build.gradle]
 plugins {
-    id 'io.github.emaarco.bpmn-to-code-gradle' version '0.0.19'
+    id 'io.github.emaarco.bpmn-to-code-gradle' version '1.0.0'
 }
 ```
 

--- a/docs/website/src/getting-started/maven-advanced.md
+++ b/docs/website/src/getting-started/maven-advanced.md
@@ -10,7 +10,7 @@ Add separate `<execution>` blocks with their own `<configuration>` to generate f
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>0.0.18</version>
+    <version>1.0.0</version>
     <executions>
         <!-- Camunda 7 processes -->
         <execution>
@@ -80,7 +80,7 @@ bpmn-to-code processes all files matching the `filePattern` glob — it has no b
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>0.0.18</version>
+    <version>1.0.0</version>
     <executions>
         <execution>
             <goals><goal>generate-bpmn-api</goal></goals>

--- a/docs/website/src/getting-started/maven.md
+++ b/docs/website/src/getting-started/maven.md
@@ -12,7 +12,7 @@ Add the following to the `<build>` section of your `pom.xml`:
         <plugin>
             <groupId>io.github.emaarco</groupId>
             <artifactId>bpmn-to-code-maven</artifactId>
-            <version>0.0.18</version>
+            <version>1.0.0</version>
             <executions>
                 <execution>
                     <goals>

--- a/docs/website/src/mcp/index.md
+++ b/docs/website/src/mcp/index.md
@@ -46,7 +46,7 @@ Add the server config to your client. Replace the JAR path with the absolute pat
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-0.0.19-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-1.0.0-all.jar"]
     }
   }
 }
@@ -58,7 +58,7 @@ Add the server config to your client. Replace the JAR path with the absolute pat
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-0.0.19-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-1.0.0-all.jar"]
     }
   }
 }
@@ -70,7 +70,7 @@ Add the server config to your client. Replace the JAR path with the absolute pat
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-0.0.19-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-1.0.0-all.jar"]
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@
 org.gradle.configuration-cache=false
 org.gradle.parallel=true
 org.gradle.caching=true
-projectVersion=0.0.20
+projectVersion=1.0.0


### PR DESCRIPTION
## Summary
- Bump `projectVersion` from `0.0.20` to `1.0.0` in `gradle.properties`
- Update all version references across READMEs, website docs (Gradle, Maven, MCP), and Docker deployment guide

## Test plan
- [x] `./gradlew build` passes
- [ ] Verify docs site renders correctly with new version numbers
- [ ] After merge: tag `v1.0.0`, create GitHub release, publish artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)