### PR TITLE
feat(skill): rewrite release skill with interactive version detection

### DIFF
--- a/.agent/skills/bpmn-to-code-release/SKILL.md
+++ b/.agent/skills/bpmn-to-code-release/SKILL.md
@@ -1,82 +1,139 @@
 ---
 name: bpmn-to-code-release
-disable-model-invocation: true
-argument-hint: <version>
 description: Create a new release for bpmn-to-code and publish to Maven Central, Gradle Plugin Portal, and Docker Hub via GitHub Actions. Use when releasing a new version.
+allowed-tools: Bash(git *), Bash(gh *), Bash(./gradlew *), AskUserQuestion
 ---
 
 # Release – bpmn-to-code
 
-Create a new release for `bpmn-to-code` $ARGUMENTS.
+## Step 0 – Enforce main branch
 
-## Permission Required
-
-**Before taking any action**, summarize the release steps you are about to execute and ask the user for explicit confirmation to proceed. Do not run any commands until the user approves.
-
-## Pre-flight Checks
-
-After receiving approval, verify:
-- Working directory is clean: `git status`
-- You are on the `main` branch
-- All changes are tested and committed
-
-## Standard Release Workflow (Automated via GitHub Actions)
-
-When a GitHub release is published (draft=false), the GitHub Action automatically publishes artifacts to Maven Central, Gradle Plugin Portal, and Docker Hub.
-
-### 1. Bump Version
-
-Check the current version in `gradle.properties` (`projectVersion=...`) and compare it against the most recent releases:
+Run:
 
 ```bash
-gh release list --limit 5
+git branch --show-current
 ```
 
-If the version was already bumped (i.e., `gradle.properties` holds a version newer than the latest release), skip this step. Otherwise, update the `projectVersion` in `gradle.properties` and commit:
+If the result is **not** `main`, stop immediately with:
+
+> "This skill can only be run on the `main` branch. Please switch to `main` and try again."
+
+Do not proceed with any further steps.
+
+## Step 1 – Pre-flight checks
+
+Verify the working directory is clean:
+
+```bash
+git status
+```
+
+If dirty, stop and ask the user to commit or stash their changes first.
+
+Ensure local `main` is up to date with the remote:
+
+```bash
+git fetch origin main
+git status -sb
+```
+
+If the branch is **behind** `origin/main`, run:
+
+```bash
+git pull --ff-only origin main
+```
+
+If the pull fails (e.g. due to diverged history), stop and ask the user to resolve it manually.
+
+## Step 2 – Check whether a version bump is needed
+
+Read the current version from `gradle.properties` (`projectVersion=...`).
+
+Get the latest published release:
+
+```bash
+gh release list --limit 1
+```
+
+Compare:
+
+- If `gradle.properties` already holds a version **greater than** the latest release tag → the bump was already done. Inform the user ("Version already bumped to `<CURRENT_VERSION>`, skipping bump step.") and set `<NEXT_VERSION>` to that value, then jump to **Step 4**.
+- Otherwise → a bump is needed. Continue to **Step 3**.
+
+## Step 3 – Determine bump type
+
+Inspect commits since the last release tag:
+
+```bash
+git log <LAST_TAG>..HEAD --oneline
+```
+
+Use the following rules to derive a suggestion:
+
+| Commits contain              | Suggested bump |
+| ---------------------------- | -------------- |
+| `feat!` or `BREAKING CHANGE` | **major**      |
+| `feat:`                      | **minor**      |
+| Only fixes / chores / deps   | **patch**      |
+
+Compute all three candidate versions from `<LAST_RELEASE_VERSION>` (e.g. if last release was `1.2.3`: patch → `1.2.4`, minor → `1.3.0`, major → `2.0.0`).
+
+Call `AskUserQuestion`:
+
+> Based on the changes since `<LAST_TAG>`, here is what I found:
+>
+> `<one-line summary of notable commits>`
+>
+> **Suggestion: <suggested-type>**
+>
+> Which bump type should we use?
+> - `patch` → v`<patch-version>`
+> - `minor` → v`<minor-version>`
+> - `major` → v`<major-version>`
+
+Set `<NEXT_VERSION>` to the version the user selects.
+
+## Step 4 – Bump version in gradle.properties, commit, and push
+
+Update `projectVersion=<NEXT_VERSION>` in `gradle.properties`.
 
 ```bash
 git add gradle.properties
-git commit -m "release: bump version to <VERSION>"
+git commit -m "chore(release): <NEXT_VERSION>"
+git push origin main
 ```
 
-### 2. Build and Test
+## Step 5 – Build and test
 
-Run the full build to make sure everything passes:
+Run the full build:
 
 ```bash
 ./gradlew build
 ```
 
-If the build fails, stop and fix the issue before proceeding.
+If the build fails, **stop**. Do not tag or release until the build is green.
 
-### 3. Tag and Push
-
-Create an annotated tag and push it:
+## Step 6 – Tag and push
 
 ```bash
-git tag -a v<VERSION> -m "Release version <VERSION>"
-git push origin v<VERSION>
+git tag -a v<NEXT_VERSION> -m "Release version <NEXT_VERSION>"
+git push origin v<NEXT_VERSION>
 ```
 
-Only push `main` if there are unpushed commits (e.g., a version bump commit). Otherwise, just push the tag.
-
-### 4. Create a Draft Release
-
-First, get the auto-generated notes as a starting point:
+## Step 7 – Create a draft release
 
 ```bash
-gh release create v<VERSION> --title "v<VERSION>" --generate-notes --draft
+gh release create v<NEXT_VERSION> --title "v<NEXT_VERSION>" --generate-notes --draft
 ```
 
-Then rewrite the release notes to match the project's established format. Use `git log <PREV_TAG>..v<VERSION> --oneline` to understand all changes, and structure the notes using this template:
+Use `git log <PREV_TAG>..v<NEXT_VERSION> --oneline` to understand all changes, then rewrite the release notes using this template:
 
 ```markdown
-## 🧑🏽‍💻 Release – bpmn-to-code v<VERSION>
+## 🧑🏽‍💻 Release – bpmn-to-code v<NEXT_VERSION>
 
 ### What's Changed
 
 - **New Features**
-  - <short summary> (<PR refs>)
   - <short summary> (<PR refs>)
 
 - **Bug Fixes**
@@ -84,41 +141,38 @@ Then rewrite the release notes to match the project's established format. Use `g
 
 - **Refactoring**
   - <short summary> (<PR refs>)
-  - <short summary> (<PR refs>)
 
 - **Dependency Updates**
   - <short summary> (<PR refs>)
 
 ### Migration Notes
 
-<Breaking changes or "No breaking changes. Upgrade to v<VERSION> and regenerate your Process APIs to benefit from ...">
+<Breaking changes or "No breaking changes. Upgrade to v<NEXT_VERSION> and regenerate your Process APIs to benefit from ...">
 
-**Full Changelog**: https://github.com/emaarco/bpmn-to-code/compare/<PREV_TAG>...v<VERSION>
+**Full Changelog**: https://github.com/emaarco/bpmn-to-code/compare/<PREV_TAG>...v<NEXT_VERSION>
 ```
 
-Group related PRs into logical categories. Use **New Features**, **Bug Fixes**, **Refactoring**, **Dependency Updates**, or other fitting labels. Omit categories that have no entries.
-
-Update the draft with the rewritten notes:
+Omit categories that have no entries. Update the draft:
 
 ```bash
-gh release edit v<VERSION> --notes "<rewritten notes>"
+gh release edit v<NEXT_VERSION> --notes "<rewritten notes>"
 ```
 
-### 5. Done
+## Step 8 – Done
 
 A maintainer will review and publish the draft.
 Publishing the release triggers the GitHub Action to publish all artifacts automatically:
+
 - **Maven Central** via `./gradlew publishAndReleaseToMavenCentral`
 - **Gradle Plugin Portal** via `./gradlew publishPlugins`
 - **Docker Hub** via `./gradlew :bpmn-to-code-web:dockerBuild` and `dockerPush`
 
+---
+
 ## Manual Publishing (Fallback)
 
-Use this if automation fails or for an out-of-band publish.
-Do never invoke this yourself. Only if you are asked to do so.
-Even then ask for explicit confirmation first.
-
-Trigger the publish workflow manually:
+Use this only if automation fails or for an out-of-band publish.
+Do **not** invoke this yourself — only if explicitly asked, and ask for confirmation first.
 
 ```bash
 gh workflow run publish-all.yml
@@ -132,9 +186,7 @@ gh workflow run publish-to-gradle.yml
 gh workflow run publish-to-docker.yml
 ```
 
-### Verify Publication
-
-After the workflow completes, verify:
+Verify after the workflow completes:
 
 ```bash
 gh run list --workflow=publish-all.yml --limit 1


### PR DESCRIPTION
## Summary

- Enforces main-branch-only execution (hard stop otherwise)
- Fetches and fast-forwards `main` before proceeding
- Auto-detects whether a version bump is needed by comparing `gradle.properties` against the latest GitHub release
- Analyses commit history to suggest major/minor/patch bump type
- Uses `AskUserQuestion` to confirm bump type, showing all three candidate versions
- Commits version bump with conventional format: `chore(release): <version>`

## Test plan

- [ ] Run skill on a non-main branch → should refuse immediately
- [ ] Run skill on main with dirty working dir → should stop and prompt
- [ ] Run skill on main with version already bumped → should skip bump step
- [ ] Run skill on main with no bump → should suggest correct bump type and ask user

🤖 Generated with [Claude Code](https://claude.com/claude-code)