### PR TITLE
chore: mark validation tasks as experimental

### DIFF
--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
@@ -12,7 +12,7 @@ class BpmnModelGeneratorPlugin : Plugin<Project> {
         }
         project.tasks.register("validateBpmnModels", ValidateBpmnModelsTask::class.java) {
             it.group = "BPMN"
-            it.description = "Validates BPMN models against built-in rules without generating code."
+            it.description = "[Experimental] Validates BPMN models against built-in rules without generating code."
         }
     }
 }

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
@@ -6,10 +6,12 @@ import io.github.emaarco.bpmn.domain.validation.ValidationConfig
 import io.github.emaarco.bpmn.domain.validation.ValidationViolation
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.Incubating
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
+@Incubating
 @DisableCachingByDefault(
     because = "Validation depends on BPMN files that can change at any time without the plugin knowing about it"
 )
@@ -32,6 +34,7 @@ abstract class ValidateBpmnModelsTask : DefaultTask() {
 
     @TaskAction
     fun execute() {
+        logger.warn("[EXPERIMENTAL] The 'validateBpmnModels' task is experimental and may change in future releases.")
         val plugin = ValidateBpmnFilesystemPlugin()
         val config = ValidationConfig(
             failOnWarning = failOnWarning,

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
@@ -15,7 +15,8 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * Maven Mojo for validating BPMN models against built-in rules without generating code
+ * [Experimental] Maven Mojo for validating BPMN models against built-in rules without generating code.
+ * This goal is experimental and may change in future releases.
  */
 @Mojo(
 		name = "validate-bpmn",
@@ -70,6 +71,7 @@ public class BpmnValidateMojo extends AbstractMojo {
 	 */
 	@Override
 	public void execute() throws MojoFailureException {
+		getLog().warn("[EXPERIMENTAL] The 'validate-bpmn' goal is experimental and may change in future releases.");
 		if (processEngine == null || processEngine.isBlank()) {
 			throw new MojoFailureException("processEngine is required (valid values: CAMUNDA_7, ZEEBE, OPERATON)");
 		}


### PR DESCRIPTION
## Summary

Marks the `validateBpmnModels` Gradle task and `validate-bpmn` Maven goal as experimental, consistent with how the MCP module is treated. The feature works but is less mature than the core API generation.

**Changes:**
- Added `@Incubating` annotation to `ValidateBpmnModelsTask` (Gradle's standard incubating mechanism)
- Added runtime `logger.warn(...)` in both Gradle task and Maven mojo so users see the experimental notice when they run either
- Updated task description to `[Experimental] ...`
- Updated Maven Mojo Javadoc to reflect experimental status

## Test plan
- [x] Gradle tests pass (`bpmn-to-code-gradle`)
- [x] Maven tests pass (`bpmn-to-code-maven`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)