### PR TITLE
refactor: replace Ant with JDK PathMatcher, simplify BpmnResource

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(libs.bpmnmodel)
     implementation(libs.bundles.codegen)
-    implementation(libs.ant)
+
     api(libs.slf4jApi)
     api(libs.kotlinLogging)
     testImplementation(libs.bundles.testing)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapter.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapter.kt
@@ -15,10 +15,11 @@ class ExtractBpmnAdapter(
 ) : ExtractBpmnPort {
 
     override fun extract(
-        bpmnFile: BpmnResource
+        bpmnFile: BpmnResource,
+        engine: ProcessEngine,
     ): BpmnModel {
         val content = bpmnFile.content
-        val (engine, extractor) = getExtractor(bpmnFile)
+        val extractor = getExtractor(engine)
         return try {
             logger.info { "Extracting model '${bpmnFile.fileName}' with extractor for '$engine'" }
             extractor.extract(content)
@@ -30,13 +31,9 @@ class ExtractBpmnAdapter(
         }
     }
 
-    private fun getExtractor(file: BpmnResource): Map.Entry<ProcessEngine, EngineSpecificExtractor> {
-        val entry = extractors.entries.find { it.key == file.engine }
-        if (entry == null) {
-            throw IllegalStateException("No extractor found for engine: ${file.engine}")
-        } else {
-            return entry
-        }
+    private fun getExtractor(engine: ProcessEngine): EngineSpecificExtractor {
+        return extractors[engine]
+            ?: throw IllegalStateException("No extractor found for engine: $engine")
     }
 
     companion object {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
@@ -1,35 +1,47 @@
 package io.github.emaarco.bpmn.adapter.outbound.filesystem
 
 import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
+import io.github.emaarco.bpmn.domain.BpmnResource
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.apache.tools.ant.DirectoryScanner
-import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.PathMatcher
 import kotlin.io.path.absolute
+import kotlin.io.path.name
+import kotlin.streams.toList
 
 class BpmnFileLoader : LoadBpmnFilesPort {
 
     private val logger = KotlinLogging.logger {}
 
-    /**
-     * Retrieves all files from the specified base-directory
-     * that match the given wildcard pattern.
-     * @param baseDirectory The root directory to start the search.
-     * @param filePattern The wildcard pattern to match the files.
-     */
-    override fun loadFrom(baseDirectory: String, filePattern: String): List<File> {
+    override fun loadFrom(baseDirectory: String, filePattern: String): List<BpmnResource> {
         val basePath = Path.of(baseDirectory).absolute().normalize()
         val (searchDir, pattern) = resolvePattern(basePath, filePattern)
 
-        val scanner = DirectoryScanner()
-        scanner.basedir = searchDir.toFile()
-        scanner.setIncludes(arrayOf(pattern))
-        scanner.scan()
-        
-        val files = scanner.includedFiles.map { File(searchDir.toFile(), it) }
+        val matcher = createMatcher(pattern)
+        val files = Files.walk(searchDir)
+            .filter { Files.isRegularFile(it) }
+            .filter { matcher.matches(searchDir.relativize(it)) }
+            .toList()
+
         logger.info { "Found ${files.size} files matching pattern $pattern in directory $searchDir" }
 
-        return files
+        return files.map { file ->
+            BpmnResource(
+                fileName = file.name,
+                content = file.toFile().inputStream(),
+            )
+        }
+    }
+
+    private fun createMatcher(pattern: String): PathMatcher {
+        val fs = FileSystems.getDefault()
+        val primary = fs.getPathMatcher("glob:$pattern")
+        if (!pattern.startsWith("**/")) return primary
+        val rootPattern = pattern.removePrefix("**/")
+        val rootMatcher = fs.getPathMatcher("glob:$rootPattern")
+        return PathMatcher { path -> primary.matches(path) || rootMatcher.matches(path) }
     }
 
     private fun resolvePattern(basePath: Path, pattern: String): Pair<Path, String> {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/ExtractBpmnPort.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/ExtractBpmnPort.kt
@@ -1,8 +1,9 @@
 package io.github.emaarco.bpmn.application.port.outbound
 
-import io.github.emaarco.bpmn.domain.BpmnResource
 import io.github.emaarco.bpmn.domain.BpmnModel
+import io.github.emaarco.bpmn.domain.BpmnResource
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 
 interface ExtractBpmnPort {
-    fun extract(bpmnFile: BpmnResource): BpmnModel
+    fun extract(bpmnFile: BpmnResource, engine: ProcessEngine): BpmnModel
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/LoadBpmnFilesPort.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/LoadBpmnFilesPort.kt
@@ -1,7 +1,7 @@
 package io.github.emaarco.bpmn.application.port.outbound
 
-import java.io.File
+import io.github.emaarco.bpmn.domain.BpmnResource
 
 interface LoadBpmnFilesPort {
-    fun loadFrom(baseDirectory: String, filePattern: String): List<File>
+    fun loadFrom(baseDirectory: String, filePattern: String): List<BpmnResource>
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryService.kt
@@ -25,7 +25,7 @@ class GenerateProcessApiInMemoryService(
     ): List<GeneratedApiFile> {
         val validationService = BpmnValidationService(command.validationConfig)
         val modelsAsFiles = toBpmnFiles(command)
-        val models = modelsAsFiles.map { bpmnService.extract(it) }
+        val models = modelsAsFiles.map { bpmnService.extract(it, command.engine) }
         validationService.validate(models, command.engine, ValidationPhase.PRE_MERGE)
         val mergedModels = modelMergerService.mergeModels(models)
         validationService.validate(mergedModels, command.engine, ValidationPhase.POST_MERGE)
@@ -51,7 +51,6 @@ class GenerateProcessApiInMemoryService(
         BpmnResource(
             fileName = it.processName,
             content = it.bpmnXml.byteInputStream(),
-            engine = command.engine,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiService.kt
@@ -11,11 +11,10 @@ import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
 import io.github.emaarco.bpmn.application.port.outbound.SaveProcessApiPort
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.BpmnModelApi
-import io.github.emaarco.bpmn.domain.BpmnResource
+import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.service.BpmnValidationService
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
 import io.github.emaarco.bpmn.domain.validation.ValidationPhase
-import java.io.File
 
 class GenerateProcessApiService(
     private val codeGenerator: GenerateApiCodePort = CodeGenerationAdapter(),
@@ -29,7 +28,7 @@ class GenerateProcessApiService(
     override fun generateProcessApi(command: GenerateProcessApiFromFilesystemUseCase.Command) {
         val validationService = BpmnValidationService(command.validationConfig)
         val inputFiles = bpmnFileLoader.loadFrom(command.baseDir, command.filePattern)
-        val models = inputFiles.map { bpmnService.extract(toBpmnFile(it, command)) }
+        val models = inputFiles.map { bpmnService.extract(it, command.engine) }
         validationService.validate(models, command.engine, ValidationPhase.PRE_MERGE)
         val mergedModels = modelMergerService.mergeModels(models)
         validationService.validate(mergedModels, command.engine, ValidationPhase.POST_MERGE)
@@ -44,15 +43,6 @@ class GenerateProcessApiService(
         model = model,
         outputLanguage = command.outputLanguage,
         packagePath = command.packagePath,
-        engine = command.engine,
-    )
-
-    private fun toBpmnFile(
-        bpmnFile: File,
-        command: GenerateProcessApiFromFilesystemUseCase.Command
-    ) = BpmnResource(
-        fileName = bpmnFile.name,
-        content = bpmnFile.inputStream(),
         engine = command.engine,
     )
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnService.kt
@@ -5,7 +5,6 @@ import io.github.emaarco.bpmn.adapter.outbound.filesystem.BpmnFileLoader
 import io.github.emaarco.bpmn.application.port.inbound.ValidateBpmnFromFilesystemUseCase
 import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
 import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
-import io.github.emaarco.bpmn.domain.BpmnResource
 import io.github.emaarco.bpmn.domain.service.BpmnValidationService
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
 import io.github.emaarco.bpmn.domain.validation.Severity
@@ -22,9 +21,7 @@ class ValidateBpmnService(
     override fun validateBpmn(command: ValidateBpmnFromFilesystemUseCase.Command): ValidationResult {
         val validationService = BpmnValidationService(command.validationConfig)
         val inputFiles = bpmnFileLoader.loadFrom(command.baseDir, command.filePattern)
-        val models = inputFiles.map { file ->
-            bpmnService.extract(BpmnResource(file.name, file.inputStream(), command.engine))
-        }
+        val models = inputFiles.map { bpmnService.extract(it, command.engine) }
         val preMergeViolations = validationService.collectViolations(models, command.engine, ValidationPhase.PRE_MERGE)
         if (preMergeViolations.any { it.severity == Severity.ERROR }) {
             return ValidationResult(preMergeViolations)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnResource.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnResource.kt
@@ -1,10 +1,8 @@
 package io.github.emaarco.bpmn.domain
 
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import java.io.InputStream
 
 data class BpmnResource(
     val fileName: String,
     val content: InputStream,
-    val engine: ProcessEngine,
 )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
@@ -26,11 +26,11 @@ class ExtractBpmnAdapterTest {
         val expectedModel = testBpmnModel(processId = "dummyProcess")
         val dummyFile = File.createTempFile("dummy", ".bpmn").apply { deleteOnExit() }
         val inputStream = dummyFile.inputStream()
-        val bpmnFile = BpmnResource(fileName = "dummy.bpmn", content = inputStream, engine = ProcessEngine.ZEEBE)
+        val bpmnFile = BpmnResource(fileName = "dummy.bpmn", content = inputStream)
         every { extractor.extract(any()) } returns expectedModel
 
         // when: extract is invoked
-        val result = underTest.extract(bpmnFile)
+        val result = underTest.extract(bpmnFile, ProcessEngine.ZEEBE)
 
         // then: the extractor is used and the expected model is returned
         verify { extractor.extract(any()) }
@@ -46,8 +46,8 @@ class ExtractBpmnAdapterTest {
                 BpmnResource(
                     fileName = "dummy.bpmn",
                     content = inputStream,
-                    engine = ProcessEngine.CAMUNDA_7
-                )
+                ),
+                ProcessEngine.CAMUNDA_7
             )
         }
     }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoaderTest.kt
@@ -20,15 +20,16 @@ class BpmnFileLoaderTest {
     fun `loadFrom returns matching files in base directory`(@TempDir tempDir: Path) {
 
         // given: a directory with files where some match the pattern
-        val file1 = Files.createFile(tempDir.resolve("process1.bpmn")).toFile()
-        val file2 = Files.createFile(tempDir.resolve("process2.bpmn")).toFile()
+        Files.createFile(tempDir.resolve("process1.bpmn"))
+        Files.createFile(tempDir.resolve("process2.bpmn"))
         Files.createFile(tempDir.resolve("other.txt"))
 
         // when: we call loadFrom with pattern "*.bpmn"
         val result = underTest.loadFrom(tempDir.toString(), "*.bpmn")
 
         // then: expect the list to contain only BPMN files
-        assertThat(result).containsExactlyInAnyOrder(file1, file2)
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.fileName }).containsExactlyInAnyOrder("process1.bpmn", "process2.bpmn")
     }
 
     @Test
@@ -37,15 +38,16 @@ class BpmnFileLoaderTest {
         // given: a base directory with a subdirectory containing a matching file
         val subDir = Files.createDirectory(tempDir.resolve("subDir"))
         val subSubDir = Files.createDirectory(subDir.resolve("subSubDir"))
-        val subFile = Files.createFile(subDir.resolve("diagram.bpmn")).toFile()
-        val otherSubFile = Files.createFile(subSubDir.resolve("process.bpmn")).toFile()
+        Files.createFile(subDir.resolve("diagram.bpmn"))
+        Files.createFile(subSubDir.resolve("process.bpmn"))
         Files.createFile(tempDir.resolve("process.txt"))
 
         // when: we call loadFrom with pattern "**/*.bpmn"
         val result = underTest.loadFrom(tempDir.toString(), "**/*.bpmn")
 
-        // then: expect the list to contain the matching subdirectory file
-        assertThat(result).containsExactlyInAnyOrder(subFile, otherSubFile)
+        // then: expect the list to contain the matching subdirectory files
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.fileName }).containsExactlyInAnyOrder("diagram.bpmn", "process.bpmn")
     }
 
     @Test
@@ -54,14 +56,15 @@ class BpmnFileLoaderTest {
         // given: a directory structure with files outside the base directory
         val baseDir = Files.createDirectory(tempDir.resolve("project"))
         val externalDir = Files.createDirectory(tempDir.resolve("external"))
-        val externalFile = Files.createFile(externalDir.resolve("external-process.bpmn")).toFile()
+        Files.createFile(externalDir.resolve("external-process.bpmn"))
         Files.createFile(externalDir.resolve("other.txt"))
 
         // when: we call loadFrom with a relative path pattern going outside the root
         val result = underTest.loadFrom(baseDir.toString(), "../external/*.bpmn")
 
         // then: expect the list to contain the external BPMN file
-        assertThat(result).containsExactly(externalFile)
+        assertThat(result).hasSize(1)
+        assertThat(result[0].fileName).isEqualTo("external-process.bpmn")
     }
 
     @Test
@@ -74,10 +77,10 @@ class BpmnFileLoaderTest {
         val subDir2 = Files.createDirectory(externalDir.resolve("subdir2"))
         val deepDir = Files.createDirectory(subDir1.resolve("deep"))
 
-        val externalFile1 = Files.createFile(externalDir.resolve("root-process.bpmn")).toFile()
-        val externalFile2 = Files.createFile(subDir1.resolve("sub1-process.bpmn")).toFile()
-        val externalFile3 = Files.createFile(subDir2.resolve("sub2-process.bpmn")).toFile()
-        val externalFile4 = Files.createFile(deepDir.resolve("deep-process.bpmn")).toFile()
+        Files.createFile(externalDir.resolve("root-process.bpmn"))
+        Files.createFile(subDir1.resolve("sub1-process.bpmn"))
+        Files.createFile(subDir2.resolve("sub2-process.bpmn"))
+        Files.createFile(deepDir.resolve("deep-process.bpmn"))
         Files.createFile(externalDir.resolve("other.txt"))
         Files.createFile(subDir1.resolve("readme.md"))
 
@@ -85,7 +88,10 @@ class BpmnFileLoaderTest {
         val result = underTest.loadFrom(baseDir.toString(), "../external/**/*.bpmn")
 
         // then: expect the list to contain all BPMN files from external directory tree
-        assertThat(result).containsExactlyInAnyOrder(externalFile1, externalFile2, externalFile3, externalFile4)
+        assertThat(result).hasSize(4)
+        assertThat(result.map { it.fileName }).containsExactlyInAnyOrder(
+            "root-process.bpmn", "sub1-process.bpmn", "sub2-process.bpmn", "deep-process.bpmn"
+        )
     }
 
     @Test
@@ -98,15 +104,16 @@ class BpmnFileLoaderTest {
         val nestedDir = Files.createDirectory(deepDir.resolve("resources"))
         val bpmnDir = Files.createDirectory(nestedDir.resolve("bpmn"))
 
-        val deepFile1 = Files.createFile(bpmnDir.resolve("shared-process.bpmn")).toFile()
-        val deepFile2 = Files.createFile(nestedDir.resolve("resource-process.bpmn")).toFile()
+        Files.createFile(bpmnDir.resolve("shared-process.bpmn"))
+        Files.createFile(nestedDir.resolve("resource-process.bpmn"))
         Files.createFile(bpmnDir.resolve("config.xml"))
 
         // when: we call loadFrom with a deep relative path pattern
         val result = underTest.loadFrom(baseDir.toString(), "../../shared/**/*.bpmn")
 
         // then: expect the list to contain all BPMN files from the deep external path
-        assertThat(result).containsExactlyInAnyOrder(deepFile1, deepFile2)
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.fileName }).containsExactlyInAnyOrder("shared-process.bpmn", "resource-process.bpmn")
     }
 
     @Test
@@ -117,7 +124,7 @@ class BpmnFileLoaderTest {
         val externalDir = Files.createDirectory(tempDir.resolve("external"))
         val specificDir = Files.createDirectory(externalDir.resolve("specific"))
 
-        val targetFile = Files.createFile(specificDir.resolve("target.bpmn")).toFile()
+        Files.createFile(specificDir.resolve("target.bpmn"))
         Files.createFile(specificDir.resolve("other.bpmn"))
         Files.createFile(externalDir.resolve("different.bpmn"))
 
@@ -125,6 +132,7 @@ class BpmnFileLoaderTest {
         val result = underTest.loadFrom(baseDir.toString(), "../external/specific/target.bpmn")
 
         // then: expect the list to contain only the specific target file
-        assertThat(result).containsExactly(targetFile)
+        assertThat(result).hasSize(1)
+        assertThat(result[0].fileName).isEqualTo("target.bpmn")
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryServiceTest.kt
@@ -38,7 +38,7 @@ class GenerateProcessApiInMemoryServiceTest {
             content = "// generated code",
             language = OutputLanguage.KOTLIN
         )
-        every { bpmnService.extract(any()) } returns dummyModel
+        every { bpmnService.extract(any(), any()) } returns dummyModel
         every { codeGenerator.generateCode(any()) } returns expectedGeneratedFile
         val command = GenerateProcessApiInMemoryUseCase.Command(
             bpmnContents = listOf(bpmnInput),
@@ -51,7 +51,7 @@ class GenerateProcessApiInMemoryServiceTest {
         val result = underTest.generateProcessApi(command)
 
         // then: BpmnFile is created, models are extracted, code is generated
-        verify { bpmnService.extract(match { it.fileName == "test.bpmn" && it.engine == ProcessEngine.ZEEBE }) }
+        verify { bpmnService.extract(match { it.fileName == "test.bpmn" }, eq(ProcessEngine.ZEEBE)) }
         verify { codeGenerator.generateCode(match { it.model == dummyModel }) }
         assertThat(result).hasSize(1)
         assertThat(result[0]).isEqualTo(expectedGeneratedFile)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
@@ -6,6 +6,7 @@ import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
 import io.github.emaarco.bpmn.application.port.outbound.GenerateApiCodePort
 import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
 import io.github.emaarco.bpmn.domain.BpmnModel
+import io.github.emaarco.bpmn.domain.BpmnResource
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
@@ -15,7 +16,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
-import java.io.File
 
 class GenerateProcessApiServiceTest {
 
@@ -34,19 +34,19 @@ class GenerateProcessApiServiceTest {
     @Test
     fun `generateProcessApi generates API file`() {
 
-        // given: a dummy BPMN model and a command
-        val dummyFile = File.createTempFile("dummy", ".bpmn").apply {
-            writeText("<bpmn></bpmn>")
-            deleteOnExit()
-        }
+        // given: a dummy BPMN resource and a command
+        val dummyResource = BpmnResource(
+            fileName = "dummy.bpmn",
+            content = "<bpmn></bpmn>".byteInputStream(),
+        )
         val expectedGeneratedFile = GeneratedApiFile(
             fileName = "NewsletterSubscriptionProcessApi.kt",
             packagePath = "de.emaarco.example",
             content = "// generated code",
             language = OutputLanguage.KOTLIN
         )
-        every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(dummyFile)
-        every { bpmnService.extract(any()) } returns dummyModel
+        every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(dummyResource)
+        every { bpmnService.extract(any(), any()) } returns dummyModel
         every { codeGenerator.generateCode(any()) } returns expectedGeneratedFile
         val command = GenerateProcessApiFromFilesystemUseCase.Command(
             baseDir = "baseDir",

--- a/bpmn-to-code-gradle/build.gradle.kts
+++ b/bpmn-to-code-gradle/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     api(kotlin("stdlib"))
     api(libs.bpmnmodel)
     api(libs.bundles.codegen)
-    api(libs.ant)
     api(libs.slf4jApi)
     api(libs.kotlinLogging)
     compileOnly(project(":bpmn-to-code-core"))

--- a/bpmn-to-code-maven/build.gradle.kts
+++ b/bpmn-to-code-maven/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     api(kotlin("stdlib"))
     api(libs.bpmnmodel)
     api(libs.bundles.codegen)
-    api(libs.ant)
     api(libs.slf4jApi)
     api(libs.kotlinLogging)
     compileOnly(project(":bpmn-to-code-core"))

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoader.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoader.kt
@@ -1,7 +1,6 @@
 package io.github.emaarco.bpmn.testing
 
 import io.github.emaarco.bpmn.domain.BpmnResource
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import java.net.URL
 import java.nio.file.FileSystems
 import java.nio.file.FileSystemNotFoundException
@@ -20,39 +19,39 @@ import kotlin.io.path.name
  */
 internal object BpmnResourceLoader {
 
-    fun fromClasspath(classpathPath: String, engine: ProcessEngine): List<BpmnResource> {
+    fun fromClasspath(classpathPath: String): List<BpmnResource> {
         val classLoader = Thread.currentThread().contextClassLoader
         val normalizedPath = classpathPath.trimEnd('/')
         val resources = classLoader.getResources(normalizedPath).toList()
         require(resources.isNotEmpty()) {
             "No classpath resources found at '$normalizedPath'"
         }
-        return resources.flatMap { url -> loadFromUrl(url, engine) }
+        return resources.flatMap { url -> loadFromUrl(url) }
     }
 
-    fun fromDirectory(directory: Path, engine: ProcessEngine): List<BpmnResource> {
+    fun fromDirectory(directory: Path): List<BpmnResource> {
         require(Files.isDirectory(directory)) {
             "Path is not a directory: $directory"
         }
-        return walkForBpmnFiles(directory, engine)
+        return walkForBpmnFiles(directory)
     }
 
-    private fun loadFromUrl(url: URL, engine: ProcessEngine): List<BpmnResource> {
+    private fun loadFromUrl(url: URL): List<BpmnResource> {
         return when (url.protocol) {
-            "file" -> loadFromPath(Path.of(url.toURI()), engine)
-            "jar"  -> loadFromJar(url, engine)
+            "file" -> loadFromPath(Path.of(url.toURI()))
+            "jar"  -> loadFromJar(url)
             else   -> error("Unsupported classpath protocol: ${url.protocol}")
         }
     }
 
-    private fun loadFromPath(path: Path, engine: ProcessEngine): List<BpmnResource> {
+    private fun loadFromPath(path: Path): List<BpmnResource> {
         if (Files.isRegularFile(path) && path.extension == "bpmn") {
-            return listOf(BpmnResource(fileName = path.name, content = Files.newInputStream(path), engine = engine))
+            return listOf(BpmnResource(fileName = path.name, content = Files.newInputStream(path)))
         }
         require(Files.isDirectory(path)) {
             "Classpath resource is not a directory or .bpmn file: $path"
         }
-        return walkForBpmnFiles(path, engine)
+        return walkForBpmnFiles(path)
     }
 
     /**
@@ -62,20 +61,20 @@ internal object BpmnResourceLoader {
      * expanded onto the filesystem — for example, when `bpmn-to-code-testing` is used as a
      * library dependency and the user's BPMN test files are bundled in their own test jar.
      */
-    private fun loadFromJar(url: URL, engine: ProcessEngine): List<BpmnResource> {
+    private fun loadFromJar(url: URL): List<BpmnResource> {
         val jarUri = url.toURI()
         val fs = try {
             FileSystems.getFileSystem(jarUri)
         } catch (_: FileSystemNotFoundException) {
             FileSystems.newFileSystem(jarUri, emptyMap<String, Any>())
         }
-        return loadFromPath(fs.getPath(url.path.substringAfter("!")), engine)
+        return loadFromPath(fs.getPath(url.path.substringAfter("!")))
     }
 
-    private fun walkForBpmnFiles(directory: Path, engine: ProcessEngine): List<BpmnResource> {
+    private fun walkForBpmnFiles(directory: Path): List<BpmnResource> {
         return Files.walk(directory)
             .filter { it.extension == "bpmn" }
-            .map { BpmnResource(fileName = it.name, content = Files.newInputStream(it), engine = engine) }
+            .map { BpmnResource(fileName = it.name, content = Files.newInputStream(it)) }
             .toList()
     }
 }

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
@@ -26,7 +26,7 @@ import java.nio.file.Path
  * ```
  */
 class BpmnValidator private constructor(
-    private val resourceLoader: (ProcessEngine) -> List<BpmnResource>,
+    private val resourceLoader: () -> List<BpmnResource>,
 ) {
 
     private var engine: ProcessEngine? = null
@@ -83,8 +83,8 @@ class BpmnValidator private constructor(
         }
 
         val extractor = ExtractBpmnAdapter()
-        val resources = resourceLoader(selectedEngine)
-        val models = resources.map { extractor.extract(it) }
+        val resources = resourceLoader()
+        val models = resources.map { extractor.extract(it, selectedEngine) }
         val activeRules = resolveRules()
         val result = runValidation(models, selectedEngine, activeRules)
         return BpmnValidationAssert.assertThat(result)
@@ -138,7 +138,7 @@ class BpmnValidator private constructor(
          */
         @JvmStatic
         fun fromClasspath(path: String): BpmnValidator {
-            return BpmnValidator { engine -> BpmnResourceLoader.fromClasspath(path, engine) }
+            return BpmnValidator { BpmnResourceLoader.fromClasspath(path) }
         }
 
         /**
@@ -146,7 +146,7 @@ class BpmnValidator private constructor(
          */
         @JvmStatic
         fun fromDirectory(directory: Path): BpmnValidator {
-            return BpmnValidator { engine -> BpmnResourceLoader.fromDirectory(directory, engine) }
+            return BpmnValidator { BpmnResourceLoader.fromDirectory(directory) }
         }
     }
 }

--- a/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoaderTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoaderTest.kt
@@ -1,6 +1,5 @@
 package io.github.emaarco.bpmn.testing
 
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -12,28 +11,22 @@ class BpmnResourceLoaderTest {
 
     @Test
     fun `fromClasspath loads bpmn files from classpath directory`() {
-        val resources = BpmnResourceLoader.fromClasspath("bpmn", ProcessEngine.CAMUNDA_7)
+        val resources = BpmnResourceLoader.fromClasspath("bpmn")
         assertThat(resources).isNotEmpty
         assertThat(resources).allMatch { it.fileName.endsWith(".bpmn") }
     }
 
     @Test
-    fun `fromClasspath sets the correct engine on loaded resources`() {
-        val resources = BpmnResourceLoader.fromClasspath("bpmn", ProcessEngine.ZEEBE)
-        assertThat(resources).allMatch { it.engine == ProcessEngine.ZEEBE }
-    }
-
-    @Test
     fun `fromClasspath throws on missing classpath path`() {
         assertThatThrownBy {
-            BpmnResourceLoader.fromClasspath("nonexistent/path", ProcessEngine.CAMUNDA_7)
+            BpmnResourceLoader.fromClasspath("nonexistent/path")
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("No classpath resources found")
     }
 
     @Test
     fun `fromClasspath handles trailing slash in path`() {
-        val resources = BpmnResourceLoader.fromClasspath("bpmn/", ProcessEngine.CAMUNDA_7)
+        val resources = BpmnResourceLoader.fromClasspath("bpmn/")
         assertThat(resources).isNotEmpty
     }
 
@@ -44,18 +37,9 @@ class BpmnResourceLoaderTest {
         Files.createFile(subDir.resolve("nested.bpmn"))
         Files.createFile(tempDir.resolve("other.xml"))
 
-        val resources = BpmnResourceLoader.fromDirectory(tempDir, ProcessEngine.ZEEBE)
+        val resources = BpmnResourceLoader.fromDirectory(tempDir)
 
         assertThat(resources.map { it.fileName }).containsExactlyInAnyOrder("root.bpmn", "nested.bpmn")
-    }
-
-    @Test
-    fun `fromDirectory sets the correct engine on loaded resources`(@TempDir tempDir: Path) {
-        Files.createFile(tempDir.resolve("process.bpmn"))
-
-        val resources = BpmnResourceLoader.fromDirectory(tempDir, ProcessEngine.CAMUNDA_7)
-
-        assertThat(resources).allMatch { it.engine == ProcessEngine.CAMUNDA_7 }
     }
 
     @Test
@@ -63,7 +47,7 @@ class BpmnResourceLoaderTest {
         val file = Files.createFile(tempDir.resolve("process.bpmn"))
 
         assertThatThrownBy {
-            BpmnResourceLoader.fromDirectory(file, ProcessEngine.ZEEBE)
+            BpmnResourceLoader.fromDirectory(file)
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Path is not a directory")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ jUnit = "6.0.3"
 assertJ = "4.0.0-M1"
 junitPlatformLauncher = "6.0.3"
 mockk = "1.14.9"
-ant = "1.10.16"
 ktor = "3.4.2"
 kotlinxSerialization = "1.10.0"
 logback = "1.5.32"
@@ -27,7 +26,7 @@ mavenPluginAnnotations = { module = "org.apache.maven.plugin-tools:maven-plugin-
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 javapoet = { module = "com.palantir.javapoet:javapoet", version.ref = "javapoet" }
 bpmnmodel = { module = "org.camunda.bpm.model:camunda-bpmn-model", version.ref = "camunda" }
-ant = { module = "org.apache.ant:ant", version.ref = "ant" }
+
 # Web module dependencies
 ktorServerCore = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktorServerNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- Remove `engine` field from `BpmnResource`, pass `ProcessEngine` as explicit parameter to `ExtractBpmnPort.extract()`
- Replace Apache Ant `DirectoryScanner` with JDK `Files.walk` + `PathMatcher` in `BpmnFileLoader`
- Change `LoadBpmnFilesPort` to return `List<BpmnResource>` directly instead of `List<File>`
- Remove Ant dependency from core, gradle, and maven modules

## Test plan
- [x] All existing `BpmnFileLoaderTest` cases pass (including `../../` relative paths and `**/*.bpmn` recursive patterns)
- [x] All `ExtractBpmnAdapterTest` cases pass
- [x] All `GenerateProcessApiServiceTest` and `GenerateProcessApiInMemoryServiceTest` cases pass
- [x] Full `./gradlew test` passes across all modules

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)