### PR TITLE
feat: generate JSON representation of BpmnModel

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 group = "io.github.emaarco"
@@ -12,6 +13,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(libs.bpmnmodel)
     implementation(libs.bundles.codegen)
+    implementation(libs.kotlinxSerializationJson)
 
     api(libs.slf4jApi)
     api(libs.kotlinLogging)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPlugin.kt
@@ -1,0 +1,47 @@
+package io.github.emaarco.bpmn.adapter.inbound
+
+import io.github.emaarco.bpmn.adapter.outbound.engine.ExtractBpmnAdapter
+import io.github.emaarco.bpmn.adapter.outbound.filesystem.BpmnFileLoader
+import io.github.emaarco.bpmn.adapter.outbound.json.BpmnJsonGenerator
+import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.service.BpmnValidationService
+import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+
+class CreateProcessJsonFilesystemPlugin(
+    private val bpmnFileLoader: LoadBpmnFilesPort = BpmnFileLoader(),
+    private val bpmnExtractor: ExtractBpmnPort = ExtractBpmnAdapter(),
+    private val jsonGenerator: BpmnJsonGenerator = BpmnJsonGenerator(),
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    fun execute(
+        baseDir: String,
+        filePattern: String,
+        outputFolderPath: String,
+        engine: ProcessEngine,
+        validationConfig: ValidationConfig = ValidationConfig(),
+    ) {
+        val validationService = BpmnValidationService(validationConfig)
+        val inputFiles = bpmnFileLoader.loadFrom(baseDir, filePattern)
+        val models = inputFiles.map { bpmnExtractor.extract(it, engine) }
+        validationService.validate(models, engine, ValidationPhase.PRE_MERGE)
+
+        val outputFolder = File(outputFolderPath)
+        if (!outputFolder.exists()) outputFolder.mkdirs()
+
+        models.forEach { model ->
+            val json = jsonGenerator.generate(model)
+            val fileName = "${model.processId}.json"
+            val file = File(outputFolder, fileName)
+            file.writeText(json)
+            logger.info { "Generated $fileName in file-system" }
+        }
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPlugin.kt
@@ -1,25 +1,13 @@
 package io.github.emaarco.bpmn.adapter.inbound
 
-import io.github.emaarco.bpmn.adapter.outbound.engine.ExtractBpmnAdapter
-import io.github.emaarco.bpmn.adapter.outbound.filesystem.BpmnFileLoader
-import io.github.emaarco.bpmn.adapter.outbound.json.BpmnJsonGenerator
-import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
-import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
-import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonFromFilesystemUseCase
+import io.github.emaarco.bpmn.application.service.GenerateProcessJsonService
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.ValidationConfig
-import io.github.emaarco.bpmn.domain.service.BpmnValidationService
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
-import io.github.oshai.kotlinlogging.KotlinLogging
-import java.io.File
 
 class CreateProcessJsonFilesystemPlugin(
-    private val bpmnFileLoader: LoadBpmnFilesPort = BpmnFileLoader(),
-    private val bpmnExtractor: ExtractBpmnPort = ExtractBpmnAdapter(),
-    private val jsonGenerator: BpmnJsonGenerator = BpmnJsonGenerator(),
+    private val useCase: GenerateProcessJsonFromFilesystemUseCase = GenerateProcessJsonService(),
 ) {
-
-    private val logger = KotlinLogging.logger {}
 
     fun execute(
         baseDir: String,
@@ -27,21 +15,13 @@ class CreateProcessJsonFilesystemPlugin(
         outputFolderPath: String,
         engine: ProcessEngine,
         validationConfig: ValidationConfig = ValidationConfig(),
-    ) {
-        val validationService = BpmnValidationService(validationConfig)
-        val inputFiles = bpmnFileLoader.loadFrom(baseDir, filePattern)
-        val models = inputFiles.map { bpmnExtractor.extract(it, engine) }
-        validationService.validate(models, engine, ValidationPhase.PRE_MERGE)
-
-        val outputFolder = File(outputFolderPath)
-        if (!outputFolder.exists()) outputFolder.mkdirs()
-
-        models.forEach { model ->
-            val json = jsonGenerator.generate(model)
-            val fileName = "${model.processId}.json"
-            val file = File(outputFolder, fileName)
-            file.writeText(json)
-            logger.info { "Generated $fileName in file-system" }
-        }
-    }
+    ) = useCase.generateProcessJson(
+        GenerateProcessJsonFromFilesystemUseCase.Command(
+            baseDir = baseDir,
+            filePattern = filePattern,
+            outputFolderPath = outputFolderPath,
+            engine = engine,
+            validationConfig = validationConfig,
+        )
+    )
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPlugin.kt
@@ -1,18 +1,13 @@
 package io.github.emaarco.bpmn.adapter.inbound
 
-import io.github.emaarco.bpmn.adapter.outbound.engine.ExtractBpmnAdapter
-import io.github.emaarco.bpmn.adapter.outbound.json.BpmnJsonGenerator
-import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
-import io.github.emaarco.bpmn.domain.BpmnResource
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonInMemoryUseCase
+import io.github.emaarco.bpmn.application.service.GenerateProcessJsonInMemoryService
 import io.github.emaarco.bpmn.domain.GeneratedJsonFile
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.ValidationConfig
-import io.github.emaarco.bpmn.domain.service.BpmnValidationService
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
 
 class CreateProcessJsonInMemoryPlugin(
-    private val bpmnExtractor: ExtractBpmnPort = ExtractBpmnAdapter(),
-    private val jsonGenerator: BpmnJsonGenerator = BpmnJsonGenerator(),
+    private val useCase: GenerateProcessJsonInMemoryUseCase = GenerateProcessJsonInMemoryService(),
 ) {
 
     fun execute(
@@ -20,18 +15,18 @@ class CreateProcessJsonInMemoryPlugin(
         engine: ProcessEngine,
         validationConfig: ValidationConfig = ValidationConfig(),
     ): List<GeneratedJsonFile> {
-        val validationService = BpmnValidationService(validationConfig)
-        val bpmnResources = bpmnContents.map { BpmnResource(fileName = it.processName, content = it.bpmnXml.byteInputStream()) }
-        val models = bpmnResources.map { bpmnExtractor.extract(it, engine) }
-        validationService.validate(models, engine, ValidationPhase.PRE_MERGE)
-
-        return models.map { model ->
-            val json = jsonGenerator.generate(model)
-            GeneratedJsonFile(
-                fileName = "${model.processId}.json",
-                content = json,
+        return useCase.generateProcessJson(
+            GenerateProcessJsonInMemoryUseCase.Command(
+                engine = engine,
+                validationConfig = validationConfig,
+                bpmnContents = bpmnContents.map {
+                    GenerateProcessJsonInMemoryUseCase.BpmnInput(
+                        bpmnXml = it.bpmnXml,
+                        processName = it.processName,
+                    )
+                },
             )
-        }
+        )
     }
 
     data class BpmnInput(

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPlugin.kt
@@ -1,0 +1,41 @@
+package io.github.emaarco.bpmn.adapter.inbound
+
+import io.github.emaarco.bpmn.adapter.outbound.engine.ExtractBpmnAdapter
+import io.github.emaarco.bpmn.adapter.outbound.json.BpmnJsonGenerator
+import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.emaarco.bpmn.domain.BpmnResource
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.service.BpmnValidationService
+import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+
+class CreateProcessJsonInMemoryPlugin(
+    private val bpmnExtractor: ExtractBpmnPort = ExtractBpmnAdapter(),
+    private val jsonGenerator: BpmnJsonGenerator = BpmnJsonGenerator(),
+) {
+
+    fun execute(
+        bpmnContents: List<BpmnInput>,
+        engine: ProcessEngine,
+        validationConfig: ValidationConfig = ValidationConfig(),
+    ): List<GeneratedJsonFile> {
+        val validationService = BpmnValidationService(validationConfig)
+        val bpmnResources = bpmnContents.map { BpmnResource(fileName = it.processName, content = it.bpmnXml.byteInputStream()) }
+        val models = bpmnResources.map { bpmnExtractor.extract(it, engine) }
+        validationService.validate(models, engine, ValidationPhase.PRE_MERGE)
+
+        return models.map { model ->
+            val json = jsonGenerator.generate(model)
+            GeneratedJsonFile(
+                fileName = "${model.processId}.json",
+                content = json,
+            )
+        }
+    }
+
+    data class BpmnInput(
+        val bpmnXml: String,
+        val processName: String,
+    )
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessJsonFileSaver.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessJsonFileSaver.kt
@@ -1,0 +1,28 @@
+package io.github.emaarco.bpmn.adapter.outbound.filesystem
+
+import io.github.emaarco.bpmn.application.port.outbound.SaveProcessJsonPort
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+
+class ProcessJsonFileSaver : SaveProcessJsonPort {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun writeFiles(
+        generatedFiles: List<GeneratedJsonFile>,
+        outputFolderPath: String,
+    ) {
+        val outputFolder = File(outputFolderPath)
+        if (!outputFolder.exists()) {
+            logger.debug { "Creating output folder: $outputFolderPath" }
+            outputFolder.mkdirs()
+        }
+
+        generatedFiles.forEach { generatedFile ->
+            val file = File(outputFolder, generatedFile.fileName)
+            file.writeText(generatedFile.content)
+            logger.info { "Generated ${generatedFile.fileName} in file-system" }
+        }
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGenerationAdapter.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGenerationAdapter.kt
@@ -1,0 +1,18 @@
+package io.github.emaarco.bpmn.adapter.outbound.json
+
+import io.github.emaarco.bpmn.application.port.outbound.GenerateJsonPort
+import io.github.emaarco.bpmn.domain.BpmnModel
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+
+class BpmnJsonGenerationAdapter(
+    private val jsonGenerator: BpmnJsonGenerator = BpmnJsonGenerator(),
+) : GenerateJsonPort {
+
+    override fun generateJson(model: BpmnModel): GeneratedJsonFile {
+        val json = jsonGenerator.generate(model)
+        return GeneratedJsonFile(
+            fileName = "${model.processId}.json",
+            content = json,
+        )
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGenerator.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGenerator.kt
@@ -1,0 +1,17 @@
+package io.github.emaarco.bpmn.adapter.outbound.json
+
+import io.github.emaarco.bpmn.adapter.outbound.json.model.BpmnModelJson
+import io.github.emaarco.bpmn.domain.BpmnModel
+import kotlinx.serialization.json.Json
+
+class BpmnJsonGenerator(
+    private val mapper: BpmnJsonMapper = BpmnJsonMapper(),
+) {
+
+    private val json = Json { prettyPrint = true }
+
+    fun generate(model: BpmnModel): String {
+        val dto = mapper.toJson(model)
+        return json.encodeToString(BpmnModelJson.serializer(), dto)
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
@@ -1,0 +1,79 @@
+package io.github.emaarco.bpmn.adapter.outbound.json
+
+import io.github.emaarco.bpmn.adapter.outbound.json.model.*
+import io.github.emaarco.bpmn.domain.BpmnModel
+import io.github.emaarco.bpmn.domain.shared.*
+
+class BpmnJsonMapper {
+
+    fun toJson(model: BpmnModel): BpmnModelJson {
+        return BpmnModelJson(
+            processId = model.processId,
+            flowNodes = model.flowNodes.map { it.toJson() },
+            sequenceFlows = model.sequenceFlows.map { it.toJson() },
+            messages = model.messages.mapNotNull { it.toJson() },
+            signals = model.signals.mapNotNull { it.toJson() },
+            errors = model.errors.mapNotNull { it.toJson() },
+        )
+    }
+
+    private fun FlowNodeDefinition.toJson(): FlowNodeJson {
+        return FlowNodeJson(
+            id = id ?: "",
+            elementType = elementType.name,
+            parentId = parentId,
+            attachedToRef = attachedToRef,
+            incoming = incoming,
+            outgoing = outgoing,
+            variables = variables.map { it.getRawName() },
+            properties = properties.toJson(),
+        )
+    }
+
+    private fun FlowNodeProperties.toJson(): FlowNodePropertiesJson? = when (this) {
+        is FlowNodeProperties.None -> null
+        is FlowNodeProperties.ServiceTask -> FlowNodePropertiesJson(
+            type = "ServiceTask",
+            implementationValue = definition.customProperties[ServiceTaskDefinition.IMPL_VALUE_KEY] as? String,
+            implementationKind = definition.customProperties[ServiceTaskDefinition.IMPL_KIND_KEY] as? String,
+        )
+        is FlowNodeProperties.CallActivity -> FlowNodePropertiesJson(
+            type = "CallActivity",
+            calledElement = definition.getValue(),
+        )
+        is FlowNodeProperties.Timer -> {
+            val (type, value) = definition.getValue()
+            FlowNodePropertiesJson(
+                type = "Timer",
+                timerType = type.takeIf { it.isNotEmpty() },
+                timerValue = value.takeIf { it.isNotEmpty() },
+            )
+        }
+    }
+
+    private fun SequenceFlowDefinition.toJson(): SequenceFlowJson {
+        return SequenceFlowJson(
+            id = id ?: "",
+            sourceRef = sourceRef,
+            targetRef = targetRef,
+            name = flowName,
+            conditionExpression = conditionExpression,
+        )
+    }
+
+    private fun MessageDefinition.toJson(): MessageJson? {
+        val name = getValue().takeIf { it.isNotEmpty() } ?: return null
+        return MessageJson(id = id ?: "", name = name)
+    }
+
+    private fun SignalDefinition.toJson(): SignalJson? {
+        val name = getValue().takeIf { it.isNotEmpty() } ?: return null
+        return SignalJson(id = id ?: "", name = name)
+    }
+
+    private fun ErrorDefinition.toJson(): ErrorJson? {
+        val (name, code) = getValue()
+        if (name.isEmpty()) return null
+        return ErrorJson(id = id ?: "", name = name, code = code)
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
@@ -1,0 +1,63 @@
+package io.github.emaarco.bpmn.adapter.outbound.json.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BpmnModelJson(
+    val processId: String,
+    val flowNodes: List<FlowNodeJson>,
+    val sequenceFlows: List<SequenceFlowJson>,
+    val messages: List<MessageJson>,
+    val signals: List<SignalJson>,
+    val errors: List<ErrorJson>,
+)
+
+@Serializable
+data class FlowNodeJson(
+    val id: String,
+    val elementType: String,
+    val parentId: String? = null,
+    val attachedToRef: String? = null,
+    val incoming: List<String> = emptyList(),
+    val outgoing: List<String> = emptyList(),
+    val variables: List<String> = emptyList(),
+    val properties: FlowNodePropertiesJson? = null,
+)
+
+@Serializable
+data class FlowNodePropertiesJson(
+    val type: String,
+    val implementationValue: String? = null,
+    val implementationKind: String? = null,
+    val calledElement: String? = null,
+    val timerType: String? = null,
+    val timerValue: String? = null,
+)
+
+@Serializable
+data class SequenceFlowJson(
+    val id: String,
+    val sourceRef: String,
+    val targetRef: String,
+    val name: String? = null,
+    val conditionExpression: String? = null,
+)
+
+@Serializable
+data class MessageJson(
+    val id: String,
+    val name: String,
+)
+
+@Serializable
+data class SignalJson(
+    val id: String,
+    val name: String,
+)
+
+@Serializable
+data class ErrorJson(
+    val id: String,
+    val name: String,
+    val code: String,
+)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonFromFilesystemUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonFromFilesystemUseCase.kt
@@ -1,0 +1,17 @@
+package io.github.emaarco.bpmn.application.port.inbound
+
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+
+interface GenerateProcessJsonFromFilesystemUseCase {
+
+    fun generateProcessJson(command: Command)
+
+    data class Command(
+        val baseDir: String,
+        val filePattern: String,
+        val outputFolderPath: String,
+        val engine: ProcessEngine,
+        val validationConfig: ValidationConfig = ValidationConfig(),
+    )
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonInMemoryUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonInMemoryUseCase.kt
@@ -1,0 +1,21 @@
+package io.github.emaarco.bpmn.application.port.inbound
+
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+
+interface GenerateProcessJsonInMemoryUseCase {
+
+    fun generateProcessJson(command: Command): List<GeneratedJsonFile>
+
+    data class Command(
+        val bpmnContents: List<BpmnInput>,
+        val engine: ProcessEngine,
+        val validationConfig: ValidationConfig = ValidationConfig(),
+    )
+
+    data class BpmnInput(
+        val bpmnXml: String,
+        val processName: String,
+    )
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/GenerateJsonPort.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/GenerateJsonPort.kt
@@ -1,0 +1,8 @@
+package io.github.emaarco.bpmn.application.port.outbound
+
+import io.github.emaarco.bpmn.domain.BpmnModel
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+
+interface GenerateJsonPort {
+    fun generateJson(model: BpmnModel): GeneratedJsonFile
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/SaveProcessJsonPort.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/outbound/SaveProcessJsonPort.kt
@@ -1,0 +1,7 @@
+package io.github.emaarco.bpmn.application.port.outbound
+
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+
+interface SaveProcessJsonPort {
+    fun writeFiles(generatedFiles: List<GeneratedJsonFile>, outputFolderPath: String)
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryService.kt
@@ -1,0 +1,29 @@
+package io.github.emaarco.bpmn.application.service
+
+import io.github.emaarco.bpmn.adapter.outbound.engine.ExtractBpmnAdapter
+import io.github.emaarco.bpmn.adapter.outbound.json.BpmnJsonGenerationAdapter
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonInMemoryUseCase
+import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.emaarco.bpmn.application.port.outbound.GenerateJsonPort
+import io.github.emaarco.bpmn.domain.BpmnResource
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.service.BpmnValidationService
+import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+
+class GenerateProcessJsonInMemoryService(
+    private val jsonGenerator: GenerateJsonPort = BpmnJsonGenerationAdapter(),
+    private val bpmnExtractor: ExtractBpmnPort = ExtractBpmnAdapter(),
+) : GenerateProcessJsonInMemoryUseCase {
+
+    override fun generateProcessJson(
+        command: GenerateProcessJsonInMemoryUseCase.Command,
+    ): List<GeneratedJsonFile> {
+        val validationService = BpmnValidationService(command.validationConfig)
+        val bpmnResources = command.bpmnContents.map {
+            BpmnResource(fileName = it.processName, content = it.bpmnXml.byteInputStream())
+        }
+        val models = bpmnResources.map { bpmnExtractor.extract(it, command.engine) }
+        validationService.validate(models, command.engine, ValidationPhase.PRE_MERGE)
+        return models.map { jsonGenerator.generateJson(it) }
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonService.kt
@@ -1,0 +1,30 @@
+package io.github.emaarco.bpmn.application.service
+
+import io.github.emaarco.bpmn.adapter.outbound.engine.ExtractBpmnAdapter
+import io.github.emaarco.bpmn.adapter.outbound.filesystem.BpmnFileLoader
+import io.github.emaarco.bpmn.adapter.outbound.filesystem.ProcessJsonFileSaver
+import io.github.emaarco.bpmn.adapter.outbound.json.BpmnJsonGenerationAdapter
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonFromFilesystemUseCase
+import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.emaarco.bpmn.application.port.outbound.GenerateJsonPort
+import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
+import io.github.emaarco.bpmn.application.port.outbound.SaveProcessJsonPort
+import io.github.emaarco.bpmn.domain.service.BpmnValidationService
+import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+
+class GenerateProcessJsonService(
+    private val jsonGenerator: GenerateJsonPort = BpmnJsonGenerationAdapter(),
+    private val bpmnFileLoader: LoadBpmnFilesPort = BpmnFileLoader(),
+    private val bpmnExtractor: ExtractBpmnPort = ExtractBpmnAdapter(),
+    private val fileSaver: SaveProcessJsonPort = ProcessJsonFileSaver(),
+) : GenerateProcessJsonFromFilesystemUseCase {
+
+    override fun generateProcessJson(command: GenerateProcessJsonFromFilesystemUseCase.Command) {
+        val validationService = BpmnValidationService(command.validationConfig)
+        val inputFiles = bpmnFileLoader.loadFrom(command.baseDir, command.filePattern)
+        val models = inputFiles.map { bpmnExtractor.extract(it, command.engine) }
+        validationService.validate(models, command.engine, ValidationPhase.PRE_MERGE)
+        val generatedFiles = models.map { jsonGenerator.generateJson(it) }
+        fileSaver.writeFiles(generatedFiles, command.outputFolderPath)
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/GeneratedJsonFile.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/GeneratedJsonFile.kt
@@ -1,0 +1,6 @@
+package io.github.emaarco.bpmn.domain
+
+data class GeneratedJsonFile(
+    val fileName: String,
+    val content: String,
+)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
@@ -1,0 +1,26 @@
+package io.github.emaarco.bpmn.adapter.outbound.json
+
+import io.github.emaarco.bpmn.domain.testNewsletterBpmnModel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class BpmnJsonGeneratorTest {
+
+    private val underTest = BpmnJsonGenerator()
+
+    @Test
+    fun `generates correct JSON for newsletter model`() {
+
+        // given: the newsletter BPMN model
+        val model = testNewsletterBpmnModel()
+
+        // when: generating JSON
+        val result = underTest.generate(model)
+
+        // then: expect the generated JSON to match the expected snapshot
+        val expectedFile = File(javaClass.getResource("/json/NewsletterSubscriptionProcess.json")!!.toURI())
+        val expectedContent = expectedFile.readText()
+        assertThat(result).isEqualToIgnoringWhitespace(expectedContent)
+    }
+}

--- a/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
@@ -1,0 +1,246 @@
+{
+    "processId": "newsletterSubscription",
+    "flowNodes": [
+        {
+            "id": "CallActivity_AbortRegistration",
+            "elementType": "CALL_ACTIVITY",
+            "incoming": [
+                "Timer_After3Days"
+            ],
+            "outgoing": [
+                "EndEvent_RegistrationAborted"
+            ],
+            "variables": [
+                "subscriptionId"
+            ],
+            "properties": {
+                "type": "CallActivity",
+                "calledElement": "abort-registration"
+            }
+        },
+        {
+            "id": "Activity_ConfirmRegistration",
+            "elementType": "RECEIVE_TASK",
+            "parentId": "SubProcess_Confirmation",
+            "incoming": [
+                "Activity_SendConfirmationMail"
+            ],
+            "outgoing": [
+                "EndEvent_SubscriptionConfirmed"
+            ]
+        },
+        {
+            "id": "Activity_SendConfirmationMail",
+            "elementType": "SERVICE_TASK",
+            "parentId": "SubProcess_Confirmation",
+            "incoming": [
+                "StartEvent_RequestReceived",
+                "Timer_EveryDay"
+            ],
+            "outgoing": [
+                "Activity_ConfirmRegistration"
+            ],
+            "variables": [
+                "subscriptionId"
+            ],
+            "properties": {
+                "type": "ServiceTask",
+                "implementationValue": "newsletter.sendConfirmationMail"
+            }
+        },
+        {
+            "id": "Activity_SendWelcomeMail",
+            "elementType": "SERVICE_TASK",
+            "incoming": [
+                "SubProcess_Confirmation"
+            ],
+            "outgoing": [
+                "EndEvent_RegistrationCompleted"
+            ],
+            "variables": [
+                "subscriptionId"
+            ],
+            "properties": {
+                "type": "ServiceTask",
+                "implementationValue": "newsletter.sendWelcomeMail"
+            }
+        },
+        {
+            "id": "EndEvent_RegistrationAborted",
+            "elementType": "END_EVENT",
+            "incoming": [
+                "CallActivity_AbortRegistration"
+            ]
+        },
+        {
+            "id": "EndEvent_RegistrationCompleted",
+            "elementType": "END_EVENT",
+            "incoming": [
+                "Activity_SendWelcomeMail"
+            ],
+            "variables": [
+                "subscriptionId"
+            ],
+            "properties": {
+                "type": "ServiceTask",
+                "implementationValue": "newsletter.registrationCompleted"
+            }
+        },
+        {
+            "id": "EndEvent_RegistrationNotPossible",
+            "elementType": "END_EVENT",
+            "incoming": [
+                "ErrorEvent_InvalidMail"
+            ]
+        },
+        {
+            "id": "EndEvent_SubscriptionConfirmed",
+            "elementType": "END_EVENT",
+            "parentId": "SubProcess_Confirmation",
+            "incoming": [
+                "Activity_ConfirmRegistration"
+            ]
+        },
+        {
+            "id": "ErrorEvent_InvalidMail",
+            "elementType": "BOUNDARY_EVENT",
+            "attachedToRef": "SubProcess_Confirmation",
+            "outgoing": [
+                "EndEvent_RegistrationNotPossible"
+            ]
+        },
+        {
+            "id": "StartEvent_RequestReceived",
+            "elementType": "START_EVENT",
+            "parentId": "SubProcess_Confirmation",
+            "outgoing": [
+                "Activity_SendConfirmationMail"
+            ],
+            "variables": [
+                "subscriptionId"
+            ]
+        },
+        {
+            "id": "StartEvent_SubmitRegistrationForm",
+            "elementType": "START_EVENT",
+            "outgoing": [
+                "SubProcess_Confirmation"
+            ],
+            "variables": [
+                "subscriptionId"
+            ]
+        },
+        {
+            "id": "SubProcess_Confirmation",
+            "elementType": "SUB_PROCESS",
+            "incoming": [
+                "StartEvent_SubmitRegistrationForm"
+            ],
+            "outgoing": [
+                "Activity_SendWelcomeMail"
+            ]
+        },
+        {
+            "id": "Timer_After3Days",
+            "elementType": "BOUNDARY_EVENT",
+            "attachedToRef": "SubProcess_Confirmation",
+            "outgoing": [
+                "CallActivity_AbortRegistration"
+            ],
+            "properties": {
+                "type": "Timer",
+                "timerType": "Duration",
+                "timerValue": "${testVariable}"
+            }
+        },
+        {
+            "id": "Timer_EveryDay",
+            "elementType": "BOUNDARY_EVENT",
+            "parentId": "SubProcess_Confirmation",
+            "attachedToRef": "Activity_ConfirmRegistration",
+            "outgoing": [
+                "Activity_SendConfirmationMail"
+            ],
+            "properties": {
+                "type": "Timer",
+                "timerType": "Duration",
+                "timerValue": "PT1M"
+            }
+        }
+    ],
+    "sequenceFlows": [
+        {
+            "id": "Flow_05i3x1y",
+            "sourceRef": "StartEvent_RequestReceived",
+            "targetRef": "Activity_SendConfirmationMail"
+        },
+        {
+            "id": "Flow_09cuvzp",
+            "sourceRef": "SubProcess_Confirmation",
+            "targetRef": "Activity_SendWelcomeMail"
+        },
+        {
+            "id": "Flow_0i2ctuv",
+            "sourceRef": "ErrorEvent_InvalidMail",
+            "targetRef": "EndEvent_RegistrationNotPossible"
+        },
+        {
+            "id": "Flow_0x4ewvb",
+            "sourceRef": "Timer_EveryDay",
+            "targetRef": "Activity_SendConfirmationMail"
+        },
+        {
+            "id": "Flow_1bckm43",
+            "sourceRef": "Activity_SendConfirmationMail",
+            "targetRef": "Activity_ConfirmRegistration"
+        },
+        {
+            "id": "Flow_1bsb8no",
+            "sourceRef": "CallActivity_AbortRegistration",
+            "targetRef": "EndEvent_RegistrationAborted"
+        },
+        {
+            "id": "Flow_1cpwe57",
+            "sourceRef": "Activity_ConfirmRegistration",
+            "targetRef": "EndEvent_SubscriptionConfirmed"
+        },
+        {
+            "id": "Flow_1csfyyz",
+            "sourceRef": "StartEvent_SubmitRegistrationForm",
+            "targetRef": "SubProcess_Confirmation"
+        },
+        {
+            "id": "Flow_1i7hjid",
+            "sourceRef": "Activity_SendWelcomeMail",
+            "targetRef": "EndEvent_RegistrationCompleted"
+        },
+        {
+            "id": "Flow_1l1lj4m",
+            "sourceRef": "Timer_After3Days",
+            "targetRef": "CallActivity_AbortRegistration"
+        }
+    ],
+    "messages": [
+        {
+            "id": "StartEvent_SubmitRegistrationForm",
+            "name": "Message_FormSubmitted"
+        },
+        {
+            "id": "Activity_ConfirmRegistration",
+            "name": "Message_SubscriptionConfirmed"
+        }
+    ],
+    "signals": [
+        {
+            "id": "EndEvent_RegistrationNotPossible",
+            "name": "Signal_RegistrationNotPossible"
+        }
+    ],
+    "errors": [
+        {
+            "id": "ErrorEvent_InvalidMail",
+            "name": "Error_InvalidMail",
+            "code": "500"
+        }
+    ]
+}

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
@@ -10,6 +10,10 @@ class BpmnModelGeneratorPlugin : Plugin<Project> {
             it.group = "BPMN"
             it.description = "Generates API-files from BPMN files to interact with a process-engine."
         }
+        project.tasks.register("generateBpmnModelJson", GenerateBpmnJsonTask::class.java) {
+            it.group = "BPMN"
+            it.description = "Generates JSON representations of BPMN process models for AI and human consumption."
+        }
         project.tasks.register("validateBpmnModels", ValidateBpmnModelsTask::class.java) {
             it.group = "BPMN"
             it.description = "[Experimental] Validates BPMN models against built-in rules without generating code."

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnJsonTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnJsonTask.kt
@@ -1,0 +1,38 @@
+package io.github.emaarco.bpmn.adapter
+
+import io.github.emaarco.bpmn.adapter.inbound.CreateProcessJsonFilesystemPlugin
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(
+    because = "Task produces output based on files that can change at any time without the plugin knowing about it"
+)
+abstract class GenerateBpmnJsonTask : DefaultTask() {
+
+    @Input
+    lateinit var baseDir: String
+
+    @Input
+    lateinit var filePattern: String
+
+    @Input
+    lateinit var outputFolderPath: String
+
+    @Input
+    lateinit var processEngine: ProcessEngine
+
+    @TaskAction
+    fun execute() {
+        val plugin = CreateProcessJsonFilesystemPlugin()
+        plugin.execute(
+            baseDir = baseDir,
+            filePattern = filePattern,
+            outputFolderPath = outputFolderPath,
+            engine = processEngine,
+        )
+        logger.lifecycle("BPMN JSON files generated successfully")
+    }
+}

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
@@ -1,0 +1,45 @@
+package io.github.emaarco.bpmn.adapter;
+
+import io.github.emaarco.bpmn.adapter.inbound.CreateProcessJsonFilesystemPlugin;
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine;
+import io.github.emaarco.bpmn.domain.validation.ValidationConfig;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Maven Mojo for generating JSON representations of BPMN process models
+ */
+@Mojo(
+		name = "generate-bpmn-json",
+		defaultPhase = LifecyclePhase.NONE,
+		requiresProject = false
+)
+public class BpmnJsonMojo extends AbstractMojo {
+
+	@Parameter(property = "baseDir", defaultValue = ".")
+	private String baseDir;
+
+	@Parameter(property = "filePattern", defaultValue = "src/main/resources/*.bpmn")
+	private String filePattern;
+
+	@Parameter(property = "outputFolderPath", defaultValue = "src/main/resources/bpmn-json")
+	private String outputFolderPath;
+
+	@Parameter(property = "processEngine")
+	private String processEngine;
+
+	@SuppressWarnings("unused")
+	public BpmnJsonMojo() {
+	}
+
+	@Override
+	public void execute() {
+		CreateProcessJsonFilesystemPlugin plugin = new CreateProcessJsonFilesystemPlugin();
+		ProcessEngine engine = ProcessEngine.valueOf(processEngine);
+		plugin.execute(baseDir, filePattern, outputFolderPath, engine, new ValidationConfig());
+		getLog().info("BPMN JSON files generated successfully");
+	}
+
+}

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/Application.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/Application.kt
@@ -5,8 +5,10 @@ package io.github.emaarco.bpmn.web
 import io.github.emaarco.bpmn.web.config.AppConfig
 import io.github.emaarco.bpmn.web.model.ConfigResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.emaarco.bpmn.web.routes.generateJsonRoutes
 import io.github.emaarco.bpmn.web.routes.generateRoutes
 import io.github.emaarco.bpmn.web.service.WebGenerationService
+import io.github.emaarco.bpmn.web.service.WebJsonGenerationService
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
@@ -128,5 +130,8 @@ fun Application.configureApp(
         // API routes
         val generationService = WebGenerationService()
         generateRoutes(generationService)
+
+        val jsonService = WebJsonGenerationService()
+        generateJsonRoutes(jsonService)
     }
 }

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/model/GenerateJsonRequest.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/model/GenerateJsonRequest.kt
@@ -1,0 +1,22 @@
+package io.github.emaarco.bpmn.web.model
+
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GenerateJsonRequest(
+    val files: List<BpmnFileData>,
+    val config: JsonGenerationConfig,
+) {
+
+    @Serializable
+    data class BpmnFileData(
+        val fileName: String,
+        val content: String,
+    )
+
+    @Serializable
+    data class JsonGenerationConfig(
+        val processEngine: ProcessEngine,
+    )
+}

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/model/GenerateJsonResponse.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/model/GenerateJsonResponse.kt
@@ -1,0 +1,52 @@
+package io.github.emaarco.bpmn.web.model
+
+import io.github.emaarco.bpmn.domain.validation.BpmnValidationException
+import io.ktor.http.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+data class GenerateJsonResponse(
+    val success: Boolean,
+    val files: List<GeneratedJsonFileResponse>,
+    val error: String? = null,
+    @Transient val statusCode: HttpStatusCode = HttpStatusCode.OK,
+) {
+
+    @Serializable
+    data class GeneratedJsonFileResponse(
+        val fileName: String,
+        val content: String,
+        val processId: String,
+    )
+
+    companion object {
+        fun noFilesProvided() = GenerateJsonResponse(
+            success = false,
+            files = emptyList(),
+            error = "No files provided",
+        )
+
+        fun tooManyFiles() = GenerateJsonResponse(
+            success = false,
+            files = emptyList(),
+            error = "Maximum 3 BPMN files allowed",
+        )
+
+        fun unknownError() = GenerateJsonResponse(
+            success = false,
+            files = emptyList(),
+            error = "Unknown error occurred",
+            statusCode = HttpStatusCode.InternalServerError,
+        )
+
+        fun fromValidationException(
+            exception: BpmnValidationException,
+        ) = GenerateJsonResponse(
+            success = false,
+            files = emptyList(),
+            error = exception.message,
+            statusCode = HttpStatusCode.BadRequest,
+        )
+    }
+}

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/routes/GenerateJsonRoutes.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/routes/GenerateJsonRoutes.kt
@@ -1,0 +1,42 @@
+@file:OptIn(ExperimentalKtorApi::class)
+
+package io.github.emaarco.bpmn.web.routes
+
+import io.github.emaarco.bpmn.web.model.GenerateJsonRequest
+import io.github.emaarco.bpmn.web.model.GenerateJsonResponse
+import io.github.emaarco.bpmn.web.service.WebJsonGenerationService
+import io.ktor.http.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.routing.openapi.*
+import io.ktor.utils.io.ExperimentalKtorApi
+
+fun Route.generateJsonRoutes(
+    jsonService: WebJsonGenerationService,
+) {
+
+    post("/api/generate-json") {
+
+        val request = call.receive<GenerateJsonRequest>()
+
+        if (request.files.isEmpty()) {
+            call.respond(status = HttpStatusCode.BadRequest, message = GenerateJsonResponse.noFilesProvided())
+            return@post
+        } else if (request.files.size > 3) {
+            call.respond(status = HttpStatusCode.BadRequest, message = GenerateJsonResponse.tooManyFiles())
+            return@post
+        }
+
+        val result = jsonService.generate(request)
+        call.respond(result.statusCode, result)
+    }.describe {
+        summary = "Generate process JSON"
+        description = "Upload BPMN files and generate JSON representations of the process models"
+        responses {
+            HttpStatusCode.OK { description = "JSON generated successfully" }
+            HttpStatusCode.BadRequest { description = "No files provided, or more than 3 files" }
+            HttpStatusCode.InternalServerError { description = "Unexpected error during generation" }
+        }
+    }
+}

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/service/WebJsonGenerationService.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/service/WebJsonGenerationService.kt
@@ -1,0 +1,53 @@
+package io.github.emaarco.bpmn.web.service
+
+import io.github.emaarco.bpmn.adapter.inbound.CreateProcessJsonInMemoryPlugin
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.validation.BpmnValidationException
+import io.github.emaarco.bpmn.web.model.GenerateJsonRequest
+import io.github.emaarco.bpmn.web.model.GenerateJsonResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.*
+
+class WebJsonGenerationService {
+
+    private val logger = KotlinLogging.logger {}
+
+    private val plugin = CreateProcessJsonInMemoryPlugin()
+
+    fun generate(request: GenerateJsonRequest): GenerateJsonResponse {
+        val config = request.config
+        logger.info { "Generating JSON for ${request.files.size} file(s) [${config.processEngine}]" }
+        try {
+            val bpmnInputs = request.files.map { buildInput(it) }
+            val jsonFiles = plugin.execute(
+                bpmnContents = bpmnInputs,
+                engine = config.processEngine,
+            )
+            val responseFiles = jsonFiles.map { mapToResponse(it) }
+            return GenerateJsonResponse(success = true, files = responseFiles)
+        } catch (e: BpmnValidationException) {
+            logger.error(e) { "BPMN validation failed during JSON generation" }
+            return GenerateJsonResponse.fromValidationException(e)
+        } catch (e: Exception) {
+            logger.error(e) { "Unexpected error during JSON generation" }
+            return GenerateJsonResponse.unknownError()
+        }
+    }
+
+    private fun buildInput(file: GenerateJsonRequest.BpmnFileData): CreateProcessJsonInMemoryPlugin.BpmnInput {
+        val bpmnXml = String(Base64.getDecoder().decode(file.content))
+        val processName = file.fileName.removeSuffix(".bpmn")
+        return CreateProcessJsonInMemoryPlugin.BpmnInput(
+            bpmnXml = bpmnXml,
+            processName = processName,
+        )
+    }
+
+    private fun mapToResponse(
+        jsonFile: GeneratedJsonFile,
+    ) = GenerateJsonResponse.GeneratedJsonFileResponse(
+        fileName = jsonFile.fileName,
+        content = jsonFile.content,
+        processId = jsonFile.fileName.removeSuffix(".json"),
+    )
+}

--- a/bpmn-to-code-web/src/main/resources/static/index.html
+++ b/bpmn-to-code-web/src/main/resources/static/index.html
@@ -18,6 +18,7 @@
             <a class="version-badge" id="version-badge" href="https://github.com/emaarco/bpmn-to-code/releases" target="_blank" style="display: none;"></a>
         </a>
         <div class="navbar-links">
+            <a href="/static/json.html">JSON Export</a>
             <a href="https://emaarco.github.io/bpmn-to-code/" target="_blank">Documentation</a>
             <a href="https://github.com/emaarco/bpmn-to-code" target="_blank" class="navbar-icon" aria-label="GitHub">
                 <svg fill="currentColor" height="20" viewBox="0 0 24 24" width="20">

--- a/bpmn-to-code-web/src/main/resources/static/js/json-app.js
+++ b/bpmn-to-code-web/src/main/resources/static/js/json-app.js
@@ -1,0 +1,344 @@
+// Application State
+const state = {
+    files: [],
+    generatedFiles: [],
+    bpmnViewer: null,
+    currentBpmnXml: null,
+    selectedFileIndex: 0
+};
+
+// DOM Elements
+const fileInput = document.getElementById('file-input');
+const uploadArea = document.getElementById('upload-area');
+const fileList = document.getElementById('file-list');
+const configSection = document.getElementById('config-section');
+const resultsSection = document.getElementById('results-section');
+const configForm = document.getElementById('config-form');
+const generateBtn = document.getElementById('generate-btn');
+const loading = document.getElementById('loading');
+const errorMessage = document.getElementById('error-message');
+const resultsContent = document.getElementById('results-content');
+const bpmnViewerContainer = document.getElementById('bpmn-viewer-container');
+const trySampleBtn = document.getElementById('try-sample-btn');
+
+// Initialize
+document.addEventListener('DOMContentLoaded', () => {
+    setupEventListeners();
+    loadConfiguration();
+});
+
+function setupEventListeners() {
+    fileInput.addEventListener('change', handleFileSelect);
+
+    uploadArea.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        uploadArea.classList.add('drag-over');
+    });
+
+    uploadArea.addEventListener('dragleave', () => {
+        uploadArea.classList.remove('drag-over');
+    });
+
+    uploadArea.addEventListener('drop', (e) => {
+        e.preventDefault();
+        uploadArea.classList.remove('drag-over');
+        const files = Array.from(e.dataTransfer.files).filter(f => f.name.endsWith('.bpmn'));
+        if (files.length > 0) {
+            addFiles(files);
+        }
+    });
+
+    configForm.addEventListener('submit', handleGenerate);
+    trySampleBtn.addEventListener('click', loadSample);
+}
+
+function handleFileSelect(e) {
+    const files = Array.from(e.target.files);
+    addFiles(files);
+    e.target.value = '';
+}
+
+function addFiles(newFiles) {
+    newFiles.forEach(file => {
+        if (!state.files.some(f => f.name === file.name)) {
+            state.files.push(file);
+        }
+    });
+
+    if (state.files.length > 0) {
+        configSection.style.display = 'block';
+        selectFile(state.selectedFileIndex);
+    }
+}
+
+function selectFile(index) {
+    if (index < 0 || index >= state.files.length) return;
+    state.selectedFileIndex = index;
+    renderFileList();
+
+    const file = state.files[index];
+    const reader = new FileReader();
+    reader.onload = () => {
+        state.currentBpmnXml = reader.result;
+        renderBpmnDiagram(reader.result);
+    };
+    reader.readAsText(file);
+}
+
+function removeFile(fileName) {
+    state.files = state.files.filter(f => f.name !== fileName);
+
+    if (state.files.length === 0) {
+        configSection.style.display = 'none';
+        resultsSection.style.display = 'none';
+        bpmnViewerContainer.style.display = 'none';
+        state.currentBpmnXml = null;
+        state.selectedFileIndex = 0;
+        renderFileList();
+    } else {
+        if (state.selectedFileIndex >= state.files.length) {
+            state.selectedFileIndex = state.files.length - 1;
+        }
+        selectFile(state.selectedFileIndex);
+    }
+}
+
+function renderFileList() {
+    if (state.files.length === 0) {
+        fileList.innerHTML = '';
+        return;
+    }
+
+    fileList.innerHTML = state.files.map((file, index) => `
+        <div class="file-item ${index === state.selectedFileIndex ? 'file-item-active' : ''}" onclick="selectFile(${index})">
+            <div class="file-item-info">
+                <span class="file-item-name">${escapeHtml(file.name)}</span>
+                <span class="file-item-size">${formatFileSize(file.size)}</span>
+            </div>
+            <button type="button" class="file-item-remove" onclick="event.stopPropagation(); removeFile('${escapeHtml(file.name)}')">&times;</button>
+        </div>
+    `).join('');
+}
+
+// BPMN Viewer
+async function renderBpmnDiagram(xml) {
+    if (state.bpmnViewer) {
+        state.bpmnViewer.destroy();
+        state.bpmnViewer = null;
+    }
+
+    bpmnViewerContainer.style.display = 'block';
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    state.bpmnViewer = new BpmnJS({ container: '#bpmn-canvas' });
+    try {
+        await state.bpmnViewer.importXML(xml);
+    } catch (err) {
+        console.error('Failed to import BPMN diagram:', err);
+        bpmnViewerContainer.style.display = 'none';
+        return;
+    }
+
+    const canvas = state.bpmnViewer.get('canvas');
+    for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+            canvas.zoom('fit-viewport');
+            const currentZoom = canvas.zoom();
+            canvas.zoom(currentZoom * 0.92);
+            return;
+        } catch (err) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+    }
+}
+
+// Sample loading
+async function loadSample() {
+    try {
+        trySampleBtn.disabled = true;
+        trySampleBtn.textContent = 'Loading...';
+
+        const response = await fetch('/samples/c8-newsletter.bpmn');
+        if (!response.ok) throw new Error('Failed to fetch sample');
+        const xml = await response.text();
+
+        const blob = new Blob([xml], { type: 'application/xml' });
+        const file = new File([blob], 'c8-newsletter.bpmn', { type: 'application/xml' });
+
+        state.files = [];
+        addFiles([file]);
+
+        document.getElementById('process-engine').value = 'ZEEBE';
+
+    } catch (err) {
+        showError('Failed to load sample: ' + err.message);
+    } finally {
+        trySampleBtn.disabled = false;
+        trySampleBtn.textContent = 'Try with Newsletter Sample';
+    }
+}
+
+async function handleGenerate(e) {
+    e.preventDefault();
+
+    resultsSection.style.display = 'none';
+    errorMessage.style.display = 'none';
+    loading.style.display = 'block';
+    generateBtn.disabled = true;
+
+    try {
+        const filesData = await Promise.all(
+            state.files.map(async (file) => ({
+                fileName: file.name,
+                content: await readFileAsBase64(file)
+            }))
+        );
+
+        const config = {
+            processEngine: document.getElementById('process-engine').value
+        };
+
+        const response = await fetch('/api/generate-json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ files: filesData, config: config })
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+            state.generatedFiles = result.files;
+            renderResults(result.files);
+            resultsSection.style.display = 'block';
+            resultsSection.scrollIntoView({ behavior: 'smooth' });
+        } else {
+            showError(result.error || 'Unknown error occurred');
+        }
+
+    } catch (error) {
+        console.error('Generation error:', error);
+        showError(`Failed to generate JSON: ${error.message}`);
+    } finally {
+        loading.style.display = 'none';
+        generateBtn.disabled = false;
+    }
+}
+
+function renderResults(files) {
+    resultsContent.innerHTML = files.map(file => `
+        <div class="code-file">
+            <div class="code-file-header">
+                <div>
+                    <div class="code-file-title">${escapeHtml(file.fileName)}</div>
+                    <div class="code-file-meta">Process: ${escapeHtml(file.processId)}</div>
+                </div>
+                <div class="code-file-actions">
+                    <button class="btn-copy" onclick="copyToClipboard(${files.indexOf(file)})">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                        </svg>
+                        Copy
+                    </button>
+                    <button class="btn-download" onclick="downloadFile('${escapeHtml(file.fileName)}', ${files.indexOf(file)})">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
+                        </svg>
+                        Download
+                    </button>
+                </div>
+            </div>
+            <div class="code-preview">
+                <pre><code class="language-json">${escapeHtml(file.content)}</code></pre>
+            </div>
+        </div>
+    `).join('');
+
+    document.querySelectorAll('pre code').forEach((block) => {
+        hljs.highlightElement(block);
+    });
+}
+
+function copyToClipboard(index) {
+    const file = state.generatedFiles[index];
+    navigator.clipboard.writeText(file.content).then(() => {
+        const buttons = document.querySelectorAll('.btn-copy');
+        const button = buttons[index];
+        const originalHTML = button.innerHTML;
+        button.innerHTML = `
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <polyline points="20 6 9 17 4 12"></polyline>
+            </svg>
+            Copied!
+        `;
+        button.style.background = '#10b981';
+        setTimeout(() => {
+            button.innerHTML = originalHTML;
+            button.style.background = '';
+        }, 2000);
+    }).catch(err => {
+        console.error('Failed to copy:', err);
+        showError('Failed to copy to clipboard');
+    });
+}
+
+function downloadFile(fileName, index) {
+    const file = state.generatedFiles[index];
+    const blob = new Blob([file.content], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+function showError(message) {
+    const escapedMessage = escapeHtml(message);
+    errorMessage.innerHTML = escapedMessage.replace(/\n/g, '<br>');
+    errorMessage.style.display = 'block';
+    errorMessage.scrollIntoView({ behavior: 'smooth' });
+}
+
+// Utility Functions
+function readFileAsBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const base64 = reader.result.split(',')[1];
+            resolve(base64);
+        };
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
+function formatFileSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+async function loadConfiguration() {
+    try {
+        const response = await fetch('/api/config');
+        const config = await response.json();
+        if (config.version) {
+            const badge = document.getElementById('version-badge');
+            badge.textContent = config.version;
+            badge.style.display = 'inline-flex';
+        }
+    } catch (error) {
+        console.error('Failed to load configuration:', error);
+    }
+}

--- a/bpmn-to-code-web/src/main/resources/static/json.html
+++ b/bpmn-to-code-web/src/main/resources/static/json.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>bpmn-to-code - JSON Generator</title>
+    <link href="/static/favicon/miragon.png" rel="icon" type="image/png">
+    <link href="/static/css/styles.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" rel="stylesheet">
+</head>
+<body>
+<!-- Navbar -->
+<nav class="navbar">
+    <div class="navbar-inner">
+        <a href="/" class="navbar-brand">
+            <img src="/static/favicon/miragon.png" alt="" width="24" height="24">
+            <span>bpmn-to-code</span>
+            <a class="version-badge" id="version-badge" href="https://github.com/emaarco/bpmn-to-code/releases" target="_blank" style="display: none;"></a>
+        </a>
+        <div class="navbar-links">
+            <a href="/static/index.html">Code Generator</a>
+            <a href="/static/json.html" style="font-weight: 600;">JSON Export</a>
+            <a href="https://emaarco.github.io/bpmn-to-code/" target="_blank">Documentation</a>
+            <a href="https://github.com/emaarco/bpmn-to-code" target="_blank" class="navbar-icon" aria-label="GitHub">
+                <svg fill="currentColor" height="20" viewBox="0 0 24 24" width="20">
+                    <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+                </svg>
+            </a>
+        </div>
+    </div>
+</nav>
+
+<div class="container">
+    <!-- Hero -->
+    <header class="hero">
+        <h1 class="hero-name">JSON Export</h1>
+        <p class="hero-text">Your BPMN process as structured JSON.</p>
+        <p class="hero-description">
+            Generate a machine-readable JSON representation of your BPMN process model.
+            Includes flow nodes, sequence flows, properties, variables, and subprocess structure.
+        </p>
+        <div class="hero-features">
+            <span class="feature-badge">AI-Readable</span>
+            <span class="feature-badge">Process Graph</span>
+            <span class="feature-badge">Per-File Export</span>
+        </div>
+    </header>
+
+    <main>
+        <!-- Step 1: Upload BPMN Files -->
+        <section class="card upload-section" id="upload-section">
+            <h2>1. Upload BPMN File</h2>
+            <div class="upload-area" id="upload-area">
+                <input accept=".bpmn" hidden id="file-input" multiple type="file">
+                <label class="upload-label" for="file-input">
+                    <svg fill="none" height="48" stroke="currentColor" viewBox="0 0 24 24" width="48">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                        <polyline points="17 8 12 3 7 8"></polyline>
+                        <line x1="12" x2="12" y1="3" y2="15"></line>
+                    </svg>
+                    <span>Click to select BPMN files or drag & drop</span>
+                    <span class="upload-hint">.bpmn files only</span>
+                </label>
+            </div>
+            <div class="sample-divider"><span>or</span></div>
+            <button class="btn btn-secondary" id="try-sample-btn" type="button">
+                Try with Newsletter Sample
+            </button>
+            <div class="file-list" id="file-list"></div>
+            <div class="bpmn-viewer-container" id="bpmn-viewer-container" style="display: none;">
+                <div id="bpmn-canvas"></div>
+            </div>
+        </section>
+
+        <!-- Step 2: Configure -->
+        <section class="card config-section" id="config-section" style="display: none;">
+            <h2>2. Select Process Engine</h2>
+            <form id="config-form">
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="process-engine">Process Engine</label>
+                        <select id="process-engine">
+                            <option selected value="ZEEBE">Zeebe (Camunda 8)</option>
+                            <option value="CAMUNDA_7">Camunda 7</option>
+                            <option value="OPERATON">Operaton</option>
+                        </select>
+                    </div>
+                </div>
+
+                <button class="btn btn-primary" id="generate-btn" type="submit">
+                    Generate JSON
+                </button>
+            </form>
+        </section>
+
+        <!-- Step 3: Results -->
+        <section class="card results-section" id="results-section" style="display: none;">
+            <h2>3. Generated JSON</h2>
+            <div id="results-content"></div>
+        </section>
+
+        <!-- Loading State -->
+        <div class="loading" id="loading" style="display: none;">
+            <div class="spinner"></div>
+            <p>Generating JSON...</p>
+        </div>
+
+        <!-- Error Display -->
+        <div class="error-message" id="error-message" style="display: none;"></div>
+    </main>
+</div>
+
+<script src="https://unpkg.com/bpmn-js@18.6.3/dist/bpmn-navigated-viewer.production.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/json.min.js"></script>
+<script src="/static/js/json-app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #220

## Summary
- **JSON DTOs** (`BpmnModelJson`, `FlowNodeJson`, etc.) with `@Serializable` — domain classes stay clean, no annotations on them
- **BpmnJsonMapper** converts domain model to DTOs
- **BpmnJsonGenerator** produces pretty-printed JSON
- **Snapshot test** comparing against golden `.json` file (same pattern as Kotlin/Java builder tests)
- **Separate pipeline** — no merging, each BPMN file gets its own JSON
- **Gradle task**: `generateBpmnModelJson`
- **Maven mojo**: `generate-bpmn-json`
- **Web endpoint**: `POST /api/generate-json`

## Key design decisions
- Domain classes have NO `@Serializable` annotations — separate DTO layer in `adapter/outbound/json/model/`
- No merging — each model produces its own JSON (merged models would show things that don't exist in individual files)
- Separate pipeline from code generation (own plugins, own tasks, own web route)

## Test plan
- [x] All core module tests pass (snapshot test verifies JSON output)
- [x] Testing module tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)