### PR TITLE
feat: sort JSON flow nodes in process-flow order

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
@@ -9,7 +9,7 @@ class BpmnJsonMapper {
     fun toJson(model: BpmnModel): BpmnModelJson {
         return BpmnModelJson(
             processId = model.processId,
-            flowNodes = model.flowNodes.map { it.toJson() },
+            flowNodes = FlowNodeSorter.sort(model.flowNodes).map { it.toJson() },
             sequenceFlows = model.sequenceFlows.map { it.toJson() },
             messages = model.messages.mapNotNull { it.toJson() },
             signals = model.signals.mapNotNull { it.toJson() },

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/FlowNodeSorter.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/FlowNodeSorter.kt
@@ -1,0 +1,70 @@
+package io.github.emaarco.bpmn.adapter.outbound.json
+
+import io.github.emaarco.bpmn.domain.shared.BpmnElementType
+import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
+
+/**
+ * Sorts BPMN flow nodes in process-flow order using DFS:
+ *
+ * - Top-level start events are visited first (alphabetically)
+ * - Subprocess children are inlined immediately after their parent subprocess
+ * - Boundary events are inserted after the node they are attached to, followed by their successors
+ * - Cycles are handled by skipping already-visited nodes
+ * - Any remaining unvisited nodes (e.g. isolated) are appended at the end, sorted alphabetically
+ */
+object FlowNodeSorter {
+
+    fun sort(nodes: List<FlowNodeDefinition>): List<FlowNodeDefinition> {
+        val nodeById = nodes.associateBy { it.id }
+        val childrenByParent = nodes.filter { it.parentId != null }.groupBy { it.parentId }
+        val boundaryByAttached = nodes.filter { it.attachedToRef != null }.groupBy { it.attachedToRef }
+        val visited = mutableSetOf<String?>()
+        val result = mutableListOf<FlowNodeDefinition>()
+
+        fun visit(node: FlowNodeDefinition) {
+            if (node.id in visited) return
+            visited.add(node.id)
+            result.add(node)
+
+            if (node.elementType == BpmnElementType.SUB_PROCESS) {
+                val children = childrenByParent[node.id] ?: emptyList()
+                val childStarts = children
+                    .filter { it.elementType == BpmnElementType.START_EVENT && it.attachedToRef == null && it.incoming.isEmpty() }
+                    .sortedBy { it.id ?: "" }
+                childStarts.forEach { visit(it) }
+                children.filter { it.id !in visited && it.attachedToRef == null }
+                    .sortedBy { it.id ?: "" }
+                    .forEach { visit(it) }
+            }
+
+            val attached = boundaryByAttached[node.id]?.sortedBy { it.id ?: "" } ?: emptyList()
+            for (boundary in attached) {
+                if (boundary.id !in visited) {
+                    visited.add(boundary.id)
+                    result.add(boundary)
+                    boundary.outgoing
+                        .mapNotNull { nodeById[it] }
+                        .filter { it.id !in visited }
+                        .sortedBy { it.id ?: "" }
+                        .forEach { visit(it) }
+                }
+            }
+
+            node.outgoing
+                .mapNotNull { nodeById[it] }
+                .filter { it.id !in visited && it.attachedToRef == null }
+                .sortedBy { it.id ?: "" }
+                .forEach { visit(it) }
+        }
+
+        val topLevel = nodes.filter { it.parentId == null && it.attachedToRef == null }
+        topLevel.filter { it.elementType == BpmnElementType.START_EVENT && it.incoming.isEmpty() }
+            .sortedBy { it.id ?: "" }
+            .forEach { visit(it) }
+        topLevel.filter { it.id !in visited }
+            .sortedBy { it.id ?: "" }
+            .forEach { visit(it) }
+
+        return result
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/FlowNodeSorterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/FlowNodeSorterTest.kt
@@ -1,0 +1,116 @@
+package io.github.emaarco.bpmn.adapter.outbound.json
+
+import io.github.emaarco.bpmn.domain.shared.BpmnElementType
+import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FlowNodeSorterTest {
+
+    private fun node(
+        id: String,
+        type: BpmnElementType = BpmnElementType.SERVICE_TASK,
+        incoming: List<String> = emptyList(),
+        outgoing: List<String> = emptyList(),
+        parentId: String? = null,
+        attachedToRef: String? = null,
+    ) = FlowNodeDefinition(id = id, elementType = type, incoming = incoming, outgoing = outgoing, parentId = parentId, attachedToRef = attachedToRef)
+
+    @Test
+    fun `linear chain is sorted start to end`() {
+        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node("Task", incoming = listOf("Start"), outgoing = listOf("End"))
+        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
+
+        val result = FlowNodeSorter.sort(listOf(task, end, start))
+
+        assertThat(result.map { it.id }).containsExactly("Start", "Task", "End")
+    }
+
+    @Test
+    fun `start events are visited before other top-level nodes`() {
+        val startA = node("Start_A", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val startB = node("Start_B", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node("Task", incoming = listOf("Start_A", "Start_B"), outgoing = listOf("End"))
+        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
+
+        val result = FlowNodeSorter.sort(listOf(task, end, startB, startA))
+        val ids = result.map { it.id }
+
+        // Start_A (alphabetically first) is the first element
+        assertThat(ids.first()).isEqualTo("Start_A")
+        // All nodes appear exactly once
+        assertThat(ids).containsExactlyInAnyOrder("Start_A", "Start_B", "Task", "End")
+    }
+
+    @Test
+    fun `boundary event appears after its parent`() {
+        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node("Task", incoming = listOf("Start"), outgoing = listOf("End"))
+        val boundary = node("Boundary", BpmnElementType.BOUNDARY_EVENT, attachedToRef = "Task", outgoing = listOf("ErrorEnd"))
+        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
+        val errorEnd = node("ErrorEnd", BpmnElementType.END_EVENT, incoming = listOf("Boundary"))
+
+        val result = FlowNodeSorter.sort(listOf(end, errorEnd, boundary, task, start))
+        val ids = result.map { it.id }
+
+        assertThat(ids.indexOf("Boundary")).isGreaterThan(ids.indexOf("Task"))
+        assertThat(ids.indexOf("ErrorEnd")).isGreaterThan(ids.indexOf("Boundary"))
+    }
+
+    @Test
+    fun `subprocess children are inlined after subprocess`() {
+        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Sub"))
+        val sub = node("Sub", BpmnElementType.SUB_PROCESS, incoming = listOf("Start"), outgoing = listOf("End"))
+        val subStart = node("SubStart", BpmnElementType.START_EVENT, parentId = "Sub", outgoing = listOf("SubTask"))
+        val subTask = node("SubTask", parentId = "Sub", incoming = listOf("SubStart"), outgoing = listOf("SubEnd"))
+        val subEnd = node("SubEnd", BpmnElementType.END_EVENT, parentId = "Sub", incoming = listOf("SubTask"))
+        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Sub"))
+
+        val result = FlowNodeSorter.sort(listOf(end, subEnd, subTask, subStart, sub, start))
+        val ids = result.map { it.id }
+
+        assertThat(ids).containsExactly("Start", "Sub", "SubStart", "SubTask", "SubEnd", "End")
+    }
+
+    @Test
+    fun `cycles do not cause infinite loops`() {
+        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("A"))
+        val a = node("A", incoming = listOf("Start", "B"), outgoing = listOf("B"))
+        val b = node("B", incoming = listOf("A"), outgoing = listOf("A", "End"))
+        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("B"))
+
+        val result = FlowNodeSorter.sort(listOf(b, a, end, start))
+
+        // Should not throw or loop; each node appears exactly once
+        assertThat(result.map { it.id }).containsExactlyInAnyOrder("Start", "A", "B", "End")
+        assertThat(result).hasSize(4)
+    }
+
+    @Test
+    fun `already sorted input is idempotent`() {
+        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node("Task", incoming = listOf("Start"), outgoing = listOf("End"))
+        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
+
+        val result = FlowNodeSorter.sort(listOf(start, task, end))
+
+        assertThat(result.map { it.id }).containsExactly("Start", "Task", "End")
+    }
+
+    @Test
+    fun `exclusive gateway branches appear after gateway`() {
+        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("GW"))
+        val gw = node("GW", BpmnElementType.EXCLUSIVE_GATEWAY, incoming = listOf("Start"), outgoing = listOf("Branch_A", "Branch_B"))
+        val branchA = node("Branch_A", incoming = listOf("GW"), outgoing = listOf("End"))
+        val branchB = node("Branch_B", incoming = listOf("GW"), outgoing = listOf("End"))
+        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Branch_A", "Branch_B"))
+
+        val result = FlowNodeSorter.sort(listOf(end, branchB, gw, branchA, start))
+        val ids = result.map { it.id }
+
+        assertThat(ids.indexOf("GW")).isGreaterThan(ids.indexOf("Start"))
+        assertThat(ids.indexOf("Branch_A")).isGreaterThan(ids.indexOf("GW"))
+        assertThat(ids.indexOf("Branch_B")).isGreaterThan(ids.indexOf("GW"))
+    }
+}

--- a/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
@@ -2,31 +2,34 @@
     "processId": "newsletterSubscription",
     "flowNodes": [
         {
-            "id": "CallActivity_AbortRegistration",
-            "elementType": "CALL_ACTIVITY",
-            "incoming": [
-                "Timer_After3Days"
-            ],
+            "id": "StartEvent_SubmitRegistrationForm",
+            "elementType": "START_EVENT",
             "outgoing": [
-                "EndEvent_RegistrationAborted"
+                "SubProcess_Confirmation"
             ],
             "variables": [
                 "subscriptionId"
-            ],
-            "properties": {
-                "type": "CallActivity",
-                "calledElement": "abort-registration"
-            }
+            ]
         },
         {
-            "id": "Activity_ConfirmRegistration",
-            "elementType": "RECEIVE_TASK",
-            "parentId": "SubProcess_Confirmation",
+            "id": "SubProcess_Confirmation",
+            "elementType": "SUB_PROCESS",
             "incoming": [
-                "Activity_SendConfirmationMail"
+                "StartEvent_SubmitRegistrationForm"
             ],
             "outgoing": [
-                "EndEvent_SubscriptionConfirmed"
+                "Activity_SendWelcomeMail"
+            ]
+        },
+        {
+            "id": "StartEvent_RequestReceived",
+            "elementType": "START_EVENT",
+            "parentId": "SubProcess_Confirmation",
+            "outgoing": [
+                "Activity_SendConfirmationMail"
+            ],
+            "variables": [
+                "subscriptionId"
             ]
         },
         {
@@ -49,49 +52,29 @@
             }
         },
         {
-            "id": "Activity_SendWelcomeMail",
-            "elementType": "SERVICE_TASK",
+            "id": "Activity_ConfirmRegistration",
+            "elementType": "RECEIVE_TASK",
+            "parentId": "SubProcess_Confirmation",
             "incoming": [
-                "SubProcess_Confirmation"
+                "Activity_SendConfirmationMail"
             ],
             "outgoing": [
-                "EndEvent_RegistrationCompleted"
-            ],
-            "variables": [
-                "subscriptionId"
-            ],
-            "properties": {
-                "type": "ServiceTask",
-                "implementationValue": "newsletter.sendWelcomeMail"
-            }
-        },
-        {
-            "id": "EndEvent_RegistrationAborted",
-            "elementType": "END_EVENT",
-            "incoming": [
-                "CallActivity_AbortRegistration"
+                "EndEvent_SubscriptionConfirmed"
             ]
         },
         {
-            "id": "EndEvent_RegistrationCompleted",
-            "elementType": "END_EVENT",
-            "incoming": [
-                "Activity_SendWelcomeMail"
-            ],
-            "variables": [
-                "subscriptionId"
+            "id": "Timer_EveryDay",
+            "elementType": "BOUNDARY_EVENT",
+            "parentId": "SubProcess_Confirmation",
+            "attachedToRef": "Activity_ConfirmRegistration",
+            "outgoing": [
+                "Activity_SendConfirmationMail"
             ],
             "properties": {
-                "type": "ServiceTask",
-                "implementationValue": "newsletter.registrationCompleted"
+                "type": "Timer",
+                "timerType": "Duration",
+                "timerValue": "PT1M"
             }
-        },
-        {
-            "id": "EndEvent_RegistrationNotPossible",
-            "elementType": "END_EVENT",
-            "incoming": [
-                "ErrorEvent_InvalidMail"
-            ]
         },
         {
             "id": "EndEvent_SubscriptionConfirmed",
@@ -110,34 +93,10 @@
             ]
         },
         {
-            "id": "StartEvent_RequestReceived",
-            "elementType": "START_EVENT",
-            "parentId": "SubProcess_Confirmation",
-            "outgoing": [
-                "Activity_SendConfirmationMail"
-            ],
-            "variables": [
-                "subscriptionId"
-            ]
-        },
-        {
-            "id": "StartEvent_SubmitRegistrationForm",
-            "elementType": "START_EVENT",
-            "outgoing": [
-                "SubProcess_Confirmation"
-            ],
-            "variables": [
-                "subscriptionId"
-            ]
-        },
-        {
-            "id": "SubProcess_Confirmation",
-            "elementType": "SUB_PROCESS",
+            "id": "EndEvent_RegistrationNotPossible",
+            "elementType": "END_EVENT",
             "incoming": [
-                "StartEvent_SubmitRegistrationForm"
-            ],
-            "outgoing": [
-                "Activity_SendWelcomeMail"
+                "ErrorEvent_InvalidMail"
             ]
         },
         {
@@ -154,17 +113,58 @@
             }
         },
         {
-            "id": "Timer_EveryDay",
-            "elementType": "BOUNDARY_EVENT",
-            "parentId": "SubProcess_Confirmation",
-            "attachedToRef": "Activity_ConfirmRegistration",
+            "id": "CallActivity_AbortRegistration",
+            "elementType": "CALL_ACTIVITY",
+            "incoming": [
+                "Timer_After3Days"
+            ],
             "outgoing": [
-                "Activity_SendConfirmationMail"
+                "EndEvent_RegistrationAborted"
+            ],
+            "variables": [
+                "subscriptionId"
             ],
             "properties": {
-                "type": "Timer",
-                "timerType": "Duration",
-                "timerValue": "PT1M"
+                "type": "CallActivity",
+                "calledElement": "abort-registration"
+            }
+        },
+        {
+            "id": "EndEvent_RegistrationAborted",
+            "elementType": "END_EVENT",
+            "incoming": [
+                "CallActivity_AbortRegistration"
+            ]
+        },
+        {
+            "id": "Activity_SendWelcomeMail",
+            "elementType": "SERVICE_TASK",
+            "incoming": [
+                "SubProcess_Confirmation"
+            ],
+            "outgoing": [
+                "EndEvent_RegistrationCompleted"
+            ],
+            "variables": [
+                "subscriptionId"
+            ],
+            "properties": {
+                "type": "ServiceTask",
+                "implementationValue": "newsletter.sendWelcomeMail"
+            }
+        },
+        {
+            "id": "EndEvent_RegistrationCompleted",
+            "elementType": "END_EVENT",
+            "incoming": [
+                "Activity_SendWelcomeMail"
+            ],
+            "variables": [
+                "subscriptionId"
+            ],
+            "properties": {
+                "type": "ServiceTask",
+                "implementationValue": "newsletter.registrationCompleted"
             }
         }
     ],


### PR DESCRIPTION
## Summary

- Adds `FlowNodeSorter` that sorts flow nodes using DFS starting from start events
- Subprocess children are inlined immediately after their parent subprocess
- Boundary events appear right after the node they attach to, followed by their successors
- Cycles are handled safely (visited check prevents infinite loops)
- Integrates into `BpmnJsonMapper` so all JSON output is now in process-flow order

## Test plan

- [ ] `FlowNodeSorterTest` covers: linear chain, start event ordering, boundary events, subprocesses, cycles, gateways, idempotency
- [ ] `BpmnJsonGeneratorTest` snapshot updated to reflect new topological order
- [ ] `./gradlew :bpmn-to-code-core:test` passes (102 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)