### PR TITLE
refactor: remove element type groups from Elements in generated API

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
@@ -10,7 +10,6 @@ import io.github.emaarco.bpmn.adapter.outbound.codegen.writer.ObjectWriter
 import io.github.emaarco.bpmn.domain.BpmnModelApi
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.shared.ApiObjectType
-import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.VariableMapping
 import io.github.emaarco.bpmn.domain.utils.StringUtils.toCamelCase
 import javax.lang.model.element.Modifier.*
@@ -81,16 +80,6 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val elementsBuilder = TypeSpec.classBuilder("Elements").addModifiers(PUBLIC, STATIC, FINAL)
             modelApi.model.flowNodes.forEach { flowNode -> elementsBuilder.addField(createAttribute(flowNode)) }
-            elementGroups.forEach { (groupName, types) ->
-                val groupNodes = modelApi.model.flowNodes
-                    .filter { it.elementType in types }
-                    .sortedBy { it.getName() }
-                if (groupNodes.isNotEmpty()) {
-                    val groupBuilder = TypeSpec.classBuilder(groupName).addModifiers(PUBLIC, STATIC, FINAL)
-                    groupNodes.forEach { groupBuilder.addField(createAttribute(it)) }
-                    elementsBuilder.addType(groupBuilder.build())
-                }
-            }
             builder.addType(elementsBuilder.build())
         }
     }
@@ -229,41 +218,6 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
             )
             return builder.build()
         }
-    }
-
-    companion object {
-        private val elementGroups = linkedMapOf(
-            "Tasks" to setOf(
-                BpmnElementType.SERVICE_TASK,
-                BpmnElementType.USER_TASK,
-                BpmnElementType.RECEIVE_TASK,
-                BpmnElementType.SEND_TASK,
-                BpmnElementType.SCRIPT_TASK,
-                BpmnElementType.MANUAL_TASK,
-                BpmnElementType.BUSINESS_RULE_TASK,
-            ),
-            "Events" to setOf(
-                BpmnElementType.START_EVENT,
-                BpmnElementType.END_EVENT,
-                BpmnElementType.INTERMEDIATE_CATCH_EVENT,
-                BpmnElementType.INTERMEDIATE_THROW_EVENT,
-                BpmnElementType.BOUNDARY_EVENT,
-            ),
-            "Gateways" to setOf(
-                BpmnElementType.EXCLUSIVE_GATEWAY,
-                BpmnElementType.PARALLEL_GATEWAY,
-                BpmnElementType.INCLUSIVE_GATEWAY,
-                BpmnElementType.EVENT_BASED_GATEWAY,
-                BpmnElementType.COMPLEX_GATEWAY,
-            ),
-            "Containers" to setOf(
-                BpmnElementType.SUB_PROCESS,
-                BpmnElementType.TRANSACTION,
-            ),
-            "CallActivities" to setOf(
-                BpmnElementType.CALL_ACTIVITY,
-            ),
-        )
     }
 
     private fun createAttribute(variable: VariableMapping<*>): FieldSpec {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
@@ -157,8 +157,8 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
                 .forEach { node ->
                     val className = node.getRawName().toCamelCase()
                     val nodeVarsBuilder = TypeSpec.classBuilder(className).addModifiers(PUBLIC, STATIC, FINAL)
-                    val sortedVariables = node.variables.sortedBy { it.getRawName() }
-                    sortedVariables.forEach { nodeVarsBuilder.addField(createAttribute(it)) }
+                    node.variables.sortedBy { it.getRawName() }
+                        .forEach { nodeVarsBuilder.addField(createAttribute(it)) }
                     variablesBuilder.addType(nodeVarsBuilder.build())
                 }
             builder.addType(variablesBuilder.build())
@@ -234,34 +234,22 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
     companion object {
         private val elementGroups = linkedMapOf(
             "Tasks" to setOf(
-                BpmnElementType.SERVICE_TASK,
-                BpmnElementType.USER_TASK,
-                BpmnElementType.RECEIVE_TASK,
-                BpmnElementType.SEND_TASK,
-                BpmnElementType.SCRIPT_TASK,
-                BpmnElementType.MANUAL_TASK,
+                BpmnElementType.SERVICE_TASK, BpmnElementType.USER_TASK, BpmnElementType.RECEIVE_TASK,
+                BpmnElementType.SEND_TASK, BpmnElementType.SCRIPT_TASK, BpmnElementType.MANUAL_TASK,
                 BpmnElementType.BUSINESS_RULE_TASK,
             ),
             "Events" to setOf(
-                BpmnElementType.START_EVENT,
-                BpmnElementType.END_EVENT,
-                BpmnElementType.INTERMEDIATE_CATCH_EVENT,
-                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnElementType.START_EVENT, BpmnElementType.END_EVENT,
+                BpmnElementType.INTERMEDIATE_CATCH_EVENT, BpmnElementType.INTERMEDIATE_THROW_EVENT,
                 BpmnElementType.BOUNDARY_EVENT,
             ),
             "Gateways" to setOf(
-                BpmnElementType.EXCLUSIVE_GATEWAY,
-                BpmnElementType.PARALLEL_GATEWAY,
-                BpmnElementType.INCLUSIVE_GATEWAY,
-                BpmnElementType.EVENT_BASED_GATEWAY,
+                BpmnElementType.EXCLUSIVE_GATEWAY, BpmnElementType.PARALLEL_GATEWAY,
+                BpmnElementType.INCLUSIVE_GATEWAY, BpmnElementType.EVENT_BASED_GATEWAY,
                 BpmnElementType.COMPLEX_GATEWAY,
             ),
             "Containers" to setOf(
-                BpmnElementType.SUB_PROCESS,
-                BpmnElementType.TRANSACTION,
-            ),
-            "CallActivities" to setOf(
-                BpmnElementType.CALL_ACTIVITY,
+                BpmnElementType.SUB_PROCESS, BpmnElementType.CALL_ACTIVITY, BpmnElementType.TRANSACTION,
             ),
         )
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
@@ -157,8 +157,8 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
                 .forEach { node ->
                     val className = node.getRawName().toCamelCase()
                     val nodeVarsBuilder = TypeSpec.classBuilder(className).addModifiers(PUBLIC, STATIC, FINAL)
-                    node.variables.sortedBy { it.getRawName() }
-                        .forEach { nodeVarsBuilder.addField(createAttribute(it)) }
+                    val sortedVariables = node.variables.sortedBy { it.getRawName() }
+                    sortedVariables.forEach { nodeVarsBuilder.addField(createAttribute(it)) }
                     variablesBuilder.addType(nodeVarsBuilder.build())
                 }
             builder.addType(variablesBuilder.build())
@@ -234,22 +234,34 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
     companion object {
         private val elementGroups = linkedMapOf(
             "Tasks" to setOf(
-                BpmnElementType.SERVICE_TASK, BpmnElementType.USER_TASK, BpmnElementType.RECEIVE_TASK,
-                BpmnElementType.SEND_TASK, BpmnElementType.SCRIPT_TASK, BpmnElementType.MANUAL_TASK,
+                BpmnElementType.SERVICE_TASK,
+                BpmnElementType.USER_TASK,
+                BpmnElementType.RECEIVE_TASK,
+                BpmnElementType.SEND_TASK,
+                BpmnElementType.SCRIPT_TASK,
+                BpmnElementType.MANUAL_TASK,
                 BpmnElementType.BUSINESS_RULE_TASK,
             ),
             "Events" to setOf(
-                BpmnElementType.START_EVENT, BpmnElementType.END_EVENT,
-                BpmnElementType.INTERMEDIATE_CATCH_EVENT, BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnElementType.START_EVENT,
+                BpmnElementType.END_EVENT,
+                BpmnElementType.INTERMEDIATE_CATCH_EVENT,
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
                 BpmnElementType.BOUNDARY_EVENT,
             ),
             "Gateways" to setOf(
-                BpmnElementType.EXCLUSIVE_GATEWAY, BpmnElementType.PARALLEL_GATEWAY,
-                BpmnElementType.INCLUSIVE_GATEWAY, BpmnElementType.EVENT_BASED_GATEWAY,
+                BpmnElementType.EXCLUSIVE_GATEWAY,
+                BpmnElementType.PARALLEL_GATEWAY,
+                BpmnElementType.INCLUSIVE_GATEWAY,
+                BpmnElementType.EVENT_BASED_GATEWAY,
                 BpmnElementType.COMPLEX_GATEWAY,
             ),
             "Containers" to setOf(
-                BpmnElementType.SUB_PROCESS, BpmnElementType.CALL_ACTIVITY, BpmnElementType.TRANSACTION,
+                BpmnElementType.SUB_PROCESS,
+                BpmnElementType.TRANSACTION,
+            ),
+            "CallActivities" to setOf(
+                BpmnElementType.CALL_ACTIVITY,
             ),
         )
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
@@ -163,8 +163,8 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
                 .forEach { node ->
                     val objectName = (node.getRawName()).toCamelCase()
                     val nodeVarsBuilder = TypeSpec.objectBuilder(objectName)
-                    val sortedVariables = node.variables.sortedBy { it.getRawName() }
-                    sortedVariables.forEach { nodeVarsBuilder.addProperty(createAttribute(it)) }
+                    node.variables.sortedBy { it.getRawName() }
+                        .forEach { nodeVarsBuilder.addProperty(createAttribute(it)) }
                     variablesBuilder.addType(nodeVarsBuilder.build())
                 }
             builder.addType(variablesBuilder.build())
@@ -235,34 +235,22 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
     companion object {
         private val elementGroups = linkedMapOf(
             "Tasks" to setOf(
-                BpmnElementType.SERVICE_TASK,
-                BpmnElementType.USER_TASK,
-                BpmnElementType.RECEIVE_TASK,
-                BpmnElementType.SEND_TASK,
-                BpmnElementType.SCRIPT_TASK,
-                BpmnElementType.MANUAL_TASK,
+                BpmnElementType.SERVICE_TASK, BpmnElementType.USER_TASK, BpmnElementType.RECEIVE_TASK,
+                BpmnElementType.SEND_TASK, BpmnElementType.SCRIPT_TASK, BpmnElementType.MANUAL_TASK,
                 BpmnElementType.BUSINESS_RULE_TASK,
             ),
             "Events" to setOf(
-                BpmnElementType.START_EVENT,
-                BpmnElementType.END_EVENT,
-                BpmnElementType.INTERMEDIATE_CATCH_EVENT,
-                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnElementType.START_EVENT, BpmnElementType.END_EVENT,
+                BpmnElementType.INTERMEDIATE_CATCH_EVENT, BpmnElementType.INTERMEDIATE_THROW_EVENT,
                 BpmnElementType.BOUNDARY_EVENT,
             ),
             "Gateways" to setOf(
-                BpmnElementType.EXCLUSIVE_GATEWAY,
-                BpmnElementType.PARALLEL_GATEWAY,
-                BpmnElementType.INCLUSIVE_GATEWAY,
-                BpmnElementType.EVENT_BASED_GATEWAY,
+                BpmnElementType.EXCLUSIVE_GATEWAY, BpmnElementType.PARALLEL_GATEWAY,
+                BpmnElementType.INCLUSIVE_GATEWAY, BpmnElementType.EVENT_BASED_GATEWAY,
                 BpmnElementType.COMPLEX_GATEWAY,
             ),
             "Containers" to setOf(
-                BpmnElementType.SUB_PROCESS,
-                BpmnElementType.TRANSACTION,
-            ),
-            "CallActivities" to setOf(
-                BpmnElementType.CALL_ACTIVITY,
+                BpmnElementType.SUB_PROCESS, BpmnElementType.CALL_ACTIVITY, BpmnElementType.TRANSACTION,
             ),
         )
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
@@ -13,7 +13,6 @@ import io.github.emaarco.bpmn.adapter.outbound.codegen.writer.ObjectWriter
 import io.github.emaarco.bpmn.domain.BpmnModelApi
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.shared.ApiObjectType
-import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.VariableMapping
 import io.github.emaarco.bpmn.domain.utils.StringUtils.toCamelCase
 
@@ -87,16 +86,6 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val elementsBuilder = TypeSpec.objectBuilder("Elements")
             modelApi.model.flowNodes.forEach { flowNode -> elementsBuilder.addProperty(createAttribute(flowNode)) }
-            elementGroups.forEach { (groupName, types) ->
-                val groupNodes = modelApi.model.flowNodes
-                    .filter { it.elementType in types }
-                    .sortedBy { it.getName() }
-                if (groupNodes.isNotEmpty()) {
-                    val groupBuilder = TypeSpec.objectBuilder(groupName)
-                    groupNodes.forEach { groupBuilder.addProperty(createAttribute(it)) }
-                    elementsBuilder.addType(groupBuilder.build())
-                }
-            }
             builder.addType(elementsBuilder.build())
         }
     }
@@ -230,41 +219,6 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         }
 
         private fun FunSpec.Builder.addStringParameter(name: String) = addParameter(name, String::class)
-    }
-
-    companion object {
-        private val elementGroups = linkedMapOf(
-            "Tasks" to setOf(
-                BpmnElementType.SERVICE_TASK,
-                BpmnElementType.USER_TASK,
-                BpmnElementType.RECEIVE_TASK,
-                BpmnElementType.SEND_TASK,
-                BpmnElementType.SCRIPT_TASK,
-                BpmnElementType.MANUAL_TASK,
-                BpmnElementType.BUSINESS_RULE_TASK,
-            ),
-            "Events" to setOf(
-                BpmnElementType.START_EVENT,
-                BpmnElementType.END_EVENT,
-                BpmnElementType.INTERMEDIATE_CATCH_EVENT,
-                BpmnElementType.INTERMEDIATE_THROW_EVENT,
-                BpmnElementType.BOUNDARY_EVENT,
-            ),
-            "Gateways" to setOf(
-                BpmnElementType.EXCLUSIVE_GATEWAY,
-                BpmnElementType.PARALLEL_GATEWAY,
-                BpmnElementType.INCLUSIVE_GATEWAY,
-                BpmnElementType.EVENT_BASED_GATEWAY,
-                BpmnElementType.COMPLEX_GATEWAY,
-            ),
-            "Containers" to setOf(
-                BpmnElementType.SUB_PROCESS,
-                BpmnElementType.TRANSACTION,
-            ),
-            "CallActivities" to setOf(
-                BpmnElementType.CALL_ACTIVITY,
-            ),
-        )
     }
 
     private fun createAttribute(variable: VariableMapping<String>): PropertySpec {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
@@ -163,8 +163,8 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
                 .forEach { node ->
                     val objectName = (node.getRawName()).toCamelCase()
                     val nodeVarsBuilder = TypeSpec.objectBuilder(objectName)
-                    node.variables.sortedBy { it.getRawName() }
-                        .forEach { nodeVarsBuilder.addProperty(createAttribute(it)) }
+                    val sortedVariables = node.variables.sortedBy { it.getRawName() }
+                    sortedVariables.forEach { nodeVarsBuilder.addProperty(createAttribute(it)) }
                     variablesBuilder.addType(nodeVarsBuilder.build())
                 }
             builder.addType(variablesBuilder.build())
@@ -235,22 +235,34 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
     companion object {
         private val elementGroups = linkedMapOf(
             "Tasks" to setOf(
-                BpmnElementType.SERVICE_TASK, BpmnElementType.USER_TASK, BpmnElementType.RECEIVE_TASK,
-                BpmnElementType.SEND_TASK, BpmnElementType.SCRIPT_TASK, BpmnElementType.MANUAL_TASK,
+                BpmnElementType.SERVICE_TASK,
+                BpmnElementType.USER_TASK,
+                BpmnElementType.RECEIVE_TASK,
+                BpmnElementType.SEND_TASK,
+                BpmnElementType.SCRIPT_TASK,
+                BpmnElementType.MANUAL_TASK,
                 BpmnElementType.BUSINESS_RULE_TASK,
             ),
             "Events" to setOf(
-                BpmnElementType.START_EVENT, BpmnElementType.END_EVENT,
-                BpmnElementType.INTERMEDIATE_CATCH_EVENT, BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnElementType.START_EVENT,
+                BpmnElementType.END_EVENT,
+                BpmnElementType.INTERMEDIATE_CATCH_EVENT,
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
                 BpmnElementType.BOUNDARY_EVENT,
             ),
             "Gateways" to setOf(
-                BpmnElementType.EXCLUSIVE_GATEWAY, BpmnElementType.PARALLEL_GATEWAY,
-                BpmnElementType.INCLUSIVE_GATEWAY, BpmnElementType.EVENT_BASED_GATEWAY,
+                BpmnElementType.EXCLUSIVE_GATEWAY,
+                BpmnElementType.PARALLEL_GATEWAY,
+                BpmnElementType.INCLUSIVE_GATEWAY,
+                BpmnElementType.EVENT_BASED_GATEWAY,
                 BpmnElementType.COMPLEX_GATEWAY,
             ),
             "Containers" to setOf(
-                BpmnElementType.SUB_PROCESS, BpmnElementType.CALL_ACTIVITY, BpmnElementType.TRANSACTION,
+                BpmnElementType.SUB_PROCESS,
+                BpmnElementType.TRANSACTION,
+            ),
+            "CallActivities" to setOf(
+                BpmnElementType.CALL_ACTIVITY,
             ),
         )
     }

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -66,9 +66,11 @@ public final class NewsletterSubscriptionProcessApi {
     }
 
     public static final class Containers {
-      public static final String CALL_ACTIVITY_ABORT_REGISTRATION = "CallActivity_AbortRegistration";
-
       public static final String SUB_PROCESS_CONFIRMATION = "SubProcess_Confirmation";
+    }
+
+    public static final class CallActivities {
+      public static final String CALL_ACTIVITY_ABORT_REGISTRATION = "CallActivity_AbortRegistration";
     }
   }
 

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -66,11 +66,9 @@ public final class NewsletterSubscriptionProcessApi {
     }
 
     public static final class Containers {
-      public static final String SUB_PROCESS_CONFIRMATION = "SubProcess_Confirmation";
-    }
-
-    public static final class CallActivities {
       public static final String CALL_ACTIVITY_ABORT_REGISTRATION = "CallActivity_AbortRegistration";
+
+      public static final String SUB_PROCESS_CONFIRMATION = "SubProcess_Confirmation";
     }
   }
 

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -36,42 +36,6 @@ public final class NewsletterSubscriptionProcessApi {
     public static final String TIMER_AFTER_3_DAYS = "Timer_After3Days";
 
     public static final String TIMER_EVERY_DAY = "Timer_EveryDay";
-
-    public static final class Tasks {
-      public static final String ACTIVITY_CONFIRM_REGISTRATION = "Activity_ConfirmRegistration";
-
-      public static final String ACTIVITY_SEND_CONFIRMATION_MAIL = "Activity_SendConfirmationMail";
-
-      public static final String ACTIVITY_SEND_WELCOME_MAIL = "Activity_SendWelcomeMail";
-    }
-
-    public static final class Events {
-      public static final String END_EVENT_REGISTRATION_ABORTED = "EndEvent_RegistrationAborted";
-
-      public static final String END_EVENT_REGISTRATION_COMPLETED = "EndEvent_RegistrationCompleted";
-
-      public static final String END_EVENT_REGISTRATION_NOT_POSSIBLE = "EndEvent_RegistrationNotPossible";
-
-      public static final String END_EVENT_SUBSCRIPTION_CONFIRMED = "EndEvent_SubscriptionConfirmed";
-
-      public static final String ERROR_EVENT_INVALID_MAIL = "ErrorEvent_InvalidMail";
-
-      public static final String START_EVENT_REQUEST_RECEIVED = "StartEvent_RequestReceived";
-
-      public static final String START_EVENT_SUBMIT_REGISTRATION_FORM = "StartEvent_SubmitRegistrationForm";
-
-      public static final String TIMER_AFTER_3_DAYS = "Timer_After3Days";
-
-      public static final String TIMER_EVERY_DAY = "Timer_EveryDay";
-    }
-
-    public static final class Containers {
-      public static final String SUB_PROCESS_CONFIRMATION = "SubProcess_Confirmation";
-    }
-
-    public static final class CallActivities {
-      public static final String CALL_ACTIVITY_ABORT_REGISTRATION = "CallActivity_AbortRegistration";
-    }
   }
 
   public static final class CallActivities {

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -73,9 +73,11 @@ object NewsletterSubscriptionProcessApi {
     }
 
     object Containers {
-      const val CALL_ACTIVITY_ABORT_REGISTRATION: String = "CallActivity_AbortRegistration"
-
       const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
+    }
+
+    object CallActivities {
+      const val CALL_ACTIVITY_ABORT_REGISTRATION: String = "CallActivity_AbortRegistration"
     }
   }
 

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -41,44 +41,6 @@ object NewsletterSubscriptionProcessApi {
     const val TIMER_AFTER_3_DAYS: String = "Timer_After3Days"
 
     const val TIMER_EVERY_DAY: String = "Timer_EveryDay"
-
-    object Tasks {
-      const val ACTIVITY_CONFIRM_REGISTRATION: String = "Activity_ConfirmRegistration"
-
-      const val ACTIVITY_SEND_CONFIRMATION_MAIL: String = "Activity_SendConfirmationMail"
-
-      const val ACTIVITY_SEND_WELCOME_MAIL: String = "Activity_SendWelcomeMail"
-    }
-
-    object Events {
-      const val END_EVENT_REGISTRATION_ABORTED: String = "EndEvent_RegistrationAborted"
-
-      const val END_EVENT_REGISTRATION_COMPLETED: String = "EndEvent_RegistrationCompleted"
-
-      const val END_EVENT_REGISTRATION_NOT_POSSIBLE: String =
-          "EndEvent_RegistrationNotPossible"
-
-      const val END_EVENT_SUBSCRIPTION_CONFIRMED: String = "EndEvent_SubscriptionConfirmed"
-
-      const val ERROR_EVENT_INVALID_MAIL: String = "ErrorEvent_InvalidMail"
-
-      const val START_EVENT_REQUEST_RECEIVED: String = "StartEvent_RequestReceived"
-
-      const val START_EVENT_SUBMIT_REGISTRATION_FORM: String =
-          "StartEvent_SubmitRegistrationForm"
-
-      const val TIMER_AFTER_3_DAYS: String = "Timer_After3Days"
-
-      const val TIMER_EVERY_DAY: String = "Timer_EveryDay"
-    }
-
-    object Containers {
-      const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
-    }
-
-    object CallActivities {
-      const val CALL_ACTIVITY_ABORT_REGISTRATION: String = "CallActivity_AbortRegistration"
-    }
   }
 
   object CallActivities {

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -73,11 +73,9 @@ object NewsletterSubscriptionProcessApi {
     }
 
     object Containers {
-      const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
-    }
-
-    object CallActivities {
       const val CALL_ACTIVITY_ABORT_REGISTRATION: String = "CallActivity_AbortRegistration"
+
+      const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
     }
   }
 


### PR DESCRIPTION
## Summary

- Reverts the typed element subgroups (`Tasks`, `Events`, `Gateways`, `Containers`, `CallActivities`) that were added inside `Elements` in commit 98fd223
- Per-element variable subgroups inside `Variables` are kept as-is
- Removes the unused `BpmnElementType` import and `companion object` from both `KotlinApiBuilder` and `JavaApiBuilder`

## Test plan

- [ ] `./gradlew :bpmn-to-code-core:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)