### PR TITLE
[Feature]: Add EVENT_SUB_PROCESS type and escalation extraction

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
@@ -30,6 +30,7 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
         ApiObjectType.SERVICE_TASKS to ServiceTasksWriter(),
         ApiObjectType.TIMERS to TimersWriter(),
         ApiObjectType.ERRORS to ErrorsWriter(),
+        ApiObjectType.ESCALATIONS to EscalationsWriter(),
         ApiObjectType.SIGNALS to SignalsWriter(),
         ApiObjectType.VARIABLES to VariablesWriter()
     )
@@ -304,6 +305,39 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
 
         private fun buildErrorClass(): TypeSpec {
             val builder = TypeSpec.classBuilder("BpmnError").addModifiers(PUBLIC, STATIC)
+            builder.addField(FieldSpec.builder(String::class.java, "name").addModifiers(PUBLIC, FINAL).build())
+            builder.addField(FieldSpec.builder(String::class.java, "code").addModifiers(PUBLIC, FINAL).build())
+            builder.addMethod(
+                MethodSpec.constructorBuilder()
+                    .addParameter(String::class.java, "name")
+                    .addParameter(String::class.java, "code")
+                    .addStatement("this.name = name")
+                    .addStatement("this.code = code")
+                    .build()
+            )
+            return builder.build()
+        }
+    }
+
+    private class EscalationsWriter : ObjectWriter<TypeSpec.Builder> {
+
+        override val objectType = ApiObjectType.ESCALATIONS
+        override fun shouldWrite(modelApi: BpmnModelApi): Boolean = modelApi.model.escalations.isNotEmpty()
+
+        override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
+            val escalationsBuilder = TypeSpec.classBuilder("Escalations").addModifiers(PUBLIC, STATIC, FINAL)
+            escalationsBuilder.addType(buildEscalationClass())
+            modelApi.model.escalations.forEach {
+                val (escalationName, escalationCode) = it.getValue()
+                val instanceBuilder = FieldSpec.builder(ClassName.get("", "BpmnEscalation"), it.getName())
+                val variable = instanceBuilder.addModifiers(PUBLIC, STATIC, FINAL)
+                escalationsBuilder.addField(variable.initializer("new BpmnEscalation(\$S, \$S)", escalationName, escalationCode).build())
+            }
+            builder.addType(escalationsBuilder.build())
+        }
+
+        private fun buildEscalationClass(): TypeSpec {
+            val builder = TypeSpec.classBuilder("BpmnEscalation").addModifiers(PUBLIC, STATIC)
             builder.addField(FieldSpec.builder(String::class.java, "name").addModifiers(PUBLIC, FINAL).build())
             builder.addField(FieldSpec.builder(String::class.java, "code").addModifiers(PUBLIC, FINAL).build())
             builder.addMethod(

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
@@ -34,6 +34,7 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         ApiObjectType.SERVICE_TASKS to ServiceTasksWriter(),
         ApiObjectType.TIMERS to TimersWriter(),
         ApiObjectType.ERRORS to ErrorsWriter(),
+        ApiObjectType.ESCALATIONS to EscalationsWriter(),
         ApiObjectType.SIGNALS to SignalsWriter(),
         ApiObjectType.VARIABLES to VariablesWriter()
     )
@@ -295,6 +296,36 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         private fun buildErrorDataClass(): TypeSpec {
             val constructor = FunSpec.constructorBuilder().addStringParameter("name").addStringParameter("code").build()
             return TypeSpec.classBuilder("BpmnError")
+                .addModifiers(KModifier.DATA)
+                .primaryConstructor(constructor)
+                .addProperty(PropertySpec.builder("name", STRING).initializer("name").build())
+                .addProperty(PropertySpec.builder("code", STRING).initializer("code").build())
+                .build()
+        }
+
+        private fun FunSpec.Builder.addStringParameter(name: String) = addParameter(name, String::class)
+    }
+
+    private class EscalationsWriter : ObjectWriter<TypeSpec.Builder> {
+
+        override val objectType = ApiObjectType.ESCALATIONS
+        override fun shouldWrite(modelApi: BpmnModelApi): Boolean = modelApi.model.escalations.isNotEmpty()
+
+        override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
+            val escalationsBuilder = TypeSpec.objectBuilder("Escalations")
+            escalationsBuilder.addType(buildEscalationDataClass())
+            modelApi.model.escalations.forEach {
+                val (escalationName, escalationCode) = it.getValue()
+                val instanceBuilder = PropertySpec.builder(it.getName(), ClassName("", "BpmnEscalation"))
+                val variable = instanceBuilder.initializer("BpmnEscalation(\"$escalationName\", \"$escalationCode\")")
+                escalationsBuilder.addProperty(variable.build())
+            }
+            builder.addType(escalationsBuilder.build())
+        }
+
+        private fun buildEscalationDataClass(): TypeSpec {
+            val constructor = FunSpec.constructorBuilder().addStringParameter("name").addStringParameter("code").build()
+            return TypeSpec.classBuilder("BpmnEscalation")
                 .addModifiers(KModifier.DATA)
                 .primaryConstructor(constructor)
                 .addProperty(PropertySpec.builder("name", STRING).initializer("name").build())

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -8,6 +8,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstance
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
@@ -49,6 +50,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         val messageSendEvents = findMessageSendEvents(modelInstance)
         val signals = modelInstance.findSignalEventDefinitions()
         val errors = modelInstance.findErrorEventDefinition()
+        val escalations = modelInstance.findEscalationEventDefinitions()
         val timers = modelInstance.findTimerEventDefinition()
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
@@ -62,6 +64,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
             messages = allMessages,
             signals = signals,
             errors = errors,
+            escalations = escalations,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -8,6 +8,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstance
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
@@ -53,6 +54,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         val messageSendEvents = findMessageSendEvents(modelInstance)
         val signals = modelInstance.findSignalEventDefinitions()
         val errors = modelInstance.findErrorEventDefinition()
+        val escalations = modelInstance.findEscalationEventDefinitions()
         val timers = modelInstance.findTimerEventDefinition()
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
@@ -66,6 +68,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
             messages = messages,
             signals = signals,
             errors = errors,
+            escalations = escalations,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -9,6 +9,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstance
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.findFirstByType
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
@@ -43,6 +44,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         val allSequenceFlows = modelInstance.findSequenceFlows()
         val allMessages = extractZeebeMessages(modelInstance)
         val allErrorEvents = modelInstance.findErrorEventDefinition()
+        val allEscalationEvents = modelInstance.findEscalationEventDefinitions()
         val allTimerEvents = modelInstance.findTimerEventDefinition()
         val allSignalEvents = modelInstance.findSignalEventDefinitions()
         val allServiceTasks = findServiceTasks(modelInstance)
@@ -58,6 +60,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             messages = allMessages,
             signals = allSignalEvents,
             errors = allErrorEvents,
+            escalations = allEscalationEvents,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -2,20 +2,22 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.utils
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.SequenceFlowDefinition
 import io.github.emaarco.bpmn.domain.shared.SignalDefinition
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
-import org.camunda.bpm.model.bpmn.instance.ErrorEventDefinition
 import org.camunda.bpm.model.bpmn.instance.BoundaryEvent
+import org.camunda.bpm.model.bpmn.instance.ErrorEventDefinition
+import org.camunda.bpm.model.bpmn.instance.EscalationEventDefinition
 import org.camunda.bpm.model.bpmn.instance.ExclusiveGateway
 import org.camunda.bpm.model.bpmn.instance.FlowNode
 import org.camunda.bpm.model.bpmn.instance.InclusiveGateway
 import org.camunda.bpm.model.bpmn.instance.Process
 import org.camunda.bpm.model.bpmn.instance.SequenceFlow
-import org.camunda.bpm.model.bpmn.instance.SubProcess
 import org.camunda.bpm.model.bpmn.instance.SignalEventDefinition
+import org.camunda.bpm.model.bpmn.instance.SubProcess
 import org.camunda.bpm.model.bpmn.instance.TimerEventDefinition
 import org.camunda.bpm.model.xml.ModelInstance
 
@@ -38,7 +40,11 @@ object ModelInstanceUtils {
         val flowNodes = this.getModelElementsByType(FlowNode::class.java)
         return flowNodes.map {
             val id = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            val elementType = BpmnElementType.fromTypeName(it.elementType.typeName)
+            val elementType = if (it is SubProcess && it.triggeredByEvent()) {
+                BpmnElementType.EVENT_SUB_PROCESS
+            } else {
+                BpmnElementType.fromTypeName(it.elementType.typeName)
+            }
             val attachedToRef = if (it is BoundaryEvent) it.attachedTo?.id else null
             val parentId = (it.parentElement as? SubProcess)?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val incoming = it.incoming.mapNotNull { flow -> flow.source?.id }
@@ -85,6 +91,14 @@ object ModelInstanceUtils {
         return errorEvents.map {
             val elementId = it.parentElement?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             ErrorDefinition(id = elementId, name = it.error?.name, code = it.error?.errorCode)
+        }
+    }
+
+    fun ModelInstance.findEscalationEventDefinitions(): List<EscalationDefinition> {
+        val escalationEvents = this.getModelElementsByType(EscalationEventDefinition::class.java)
+        return escalationEvents.map {
+            val elementId = it.parentElement?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
+            EscalationDefinition(id = elementId, name = it.escalation?.name, code = it.escalation?.escalationCode)
         }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -40,11 +40,7 @@ object ModelInstanceUtils {
         val flowNodes = this.getModelElementsByType(FlowNode::class.java)
         return flowNodes.map {
             val id = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            val elementType = if (it is SubProcess && it.triggeredByEvent()) {
-                BpmnElementType.EVENT_SUB_PROCESS
-            } else {
-                BpmnElementType.fromTypeName(it.elementType.typeName)
-            }
+            val elementType = it.resolveElementType()
             val attachedToRef = if (it is BoundaryEvent) it.attachedTo?.id else null
             val parentId = (it.parentElement as? SubProcess)?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val incoming = it.incoming.mapNotNull { flow -> flow.source?.id }
@@ -129,6 +125,14 @@ object ModelInstanceUtils {
             Pair("Cycle", this.timeCycle.textContent)
         } else {
             null
+        }
+    }
+
+    private fun FlowNode.resolveElementType(): BpmnElementType {
+        return if (this is SubProcess && this.triggeredByEvent()) {
+            BpmnElementType.EVENT_SUB_PROCESS
+        } else {
+            BpmnElementType.fromTypeName(this.elementType.typeName)
         }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
@@ -14,6 +14,7 @@ class BpmnJsonMapper {
             messages = model.messages.mapNotNull { it.toJson() },
             signals = model.signals.mapNotNull { it.toJson() },
             errors = model.errors.mapNotNull { it.toJson() },
+            escalations = model.escalations.mapNotNull { it.toJson() },
         )
     }
 
@@ -77,5 +78,11 @@ class BpmnJsonMapper {
         val (name, code) = getValue()
         if (name.isEmpty()) return null
         return ErrorJson(id = id ?: "", name = name, code = code)
+    }
+
+    private fun EscalationDefinition.toJson(): EscalationJson? {
+        val (name, code) = getValue()
+        if (name.isEmpty()) return null
+        return EscalationJson(id = id ?: "", name = name, code = code)
     }
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
@@ -10,6 +10,7 @@ data class BpmnModelJson(
     val messages: List<MessageJson>,
     val signals: List<SignalJson>,
     val errors: List<ErrorJson>,
+    val escalations: List<EscalationJson> = emptyList(),
 )
 
 @Serializable
@@ -59,6 +60,13 @@ data class SignalJson(
 
 @Serializable
 data class ErrorJson(
+    val id: String,
+    val name: String,
+    val code: String,
+)
+
+@Serializable
+data class EscalationJson(
     val id: String,
     val name: String,
     val code: String,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
@@ -9,6 +9,7 @@ data class BpmnModel(
     val messages: List<MessageDefinition>,
     val signals: List<SignalDefinition>,
     val errors: List<ErrorDefinition>,
+    val escalations: List<EscalationDefinition> = emptyList(),
 ) {
     val serviceTasks: List<ServiceTaskDefinition>
         get() = flowNodes.mapNotNull { (it.properties as? FlowNodeProperties.ServiceTask)?.definition }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/ApiObjectType.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/ApiObjectType.kt
@@ -11,6 +11,7 @@ enum class ApiObjectType {
     SERVICE_TASKS,
     TIMERS,
     ERRORS,
+    ESCALATIONS,
     SIGNALS,
     VARIABLES
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/BpmnElementType.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/BpmnElementType.kt
@@ -34,6 +34,7 @@ enum class BpmnElementType(val bpmnTypeName: String) {
 
     // Containers
     SUB_PROCESS("subProcess"),
+    EVENT_SUB_PROCESS("eventSubProcess"),
     CALL_ACTIVITY("callActivity"),
     TRANSACTION("transaction"),
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/EscalationDefinition.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/EscalationDefinition.kt
@@ -1,0 +1,15 @@
+package io.github.emaarco.bpmn.domain.shared
+
+import io.github.emaarco.bpmn.domain.utils.StringUtils.toUpperSnakeCase
+
+data class EscalationDefinition(
+    val id: String?,
+    private val name: String?,
+    private val code: String?,
+    val customProperties: Map<String, Any?> = emptyMap(),
+) : VariableMapping<Pair<String, String>> {
+    override fun getName() = name?.toUpperSnakeCase() ?: ""
+    override fun getValue() = (name ?: "") to (code ?: "")
+    override fun getRawName() = name ?: ""
+    fun hasRequiredFields() = name != null && code != null
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilderTest.kt
@@ -1,5 +1,6 @@
 package io.github.emaarco.bpmn.adapter.outbound.codegen.builder
 
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_VALUE_KEY
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.testBpmnModelApi
@@ -24,7 +25,8 @@ class JavaApiBuilderTest {
                     welcomeMailImpl = "\${newsletterSendWelcomeMail}",
                     registrationCompletedImpl = "newsletter.registrationCompleted",
                     extraVariables = listOf(VariableDefinition("testVariable")),
-                )
+                ),
+                escalations = listOf(EscalationDefinition("EndEvent_RegistrationNotPossible", "Escalation_RegistrationFailed", "100"))
             )
         )
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilderTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.codegen.builder
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
@@ -30,7 +31,8 @@ class KotlinApiBuilderTest {
                     welcomeMailImpl = "\${newsletterSendWelcomeMail}",
                     registrationCompletedImpl = "newsletter.registrationCompleted",
                     extraVariables = listOf(VariableDefinition("testVariable")),
-                )
+                ),
+                escalations = listOf(EscalationDefinition("EndEvent_RegistrationNotPossible", "Escalation_RegistrationFailed", "100"))
             )
         )
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.SequenceFlowDefinition
@@ -120,6 +121,21 @@ class Camunda7ModelExtractorTest {
             VariableDefinition("author"),
             VariableDefinition("subscribers"),
             VariableDefinition("subscriber"),
+        )
+    }
+
+    @Test
+    fun `extract detects event subprocess type and extracts escalations`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-send-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+
+        val eventSubProcess = bpmnModel.flowNodes.first { it.id == "eventSubProcess_errorHandling" }
+        assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
+
+        assertThat(bpmnModel.escalations).containsExactlyInAnyOrder(
+            EscalationDefinition("Event_0zfsqqc", "escalation_notifySupport", "200"),
+            EscalationDefinition("Event_06asqkm", "escalation_notifySupport", "200"),
         )
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -134,8 +134,8 @@ class Camunda7ModelExtractorTest {
         assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
 
         assertThat(bpmnModel.escalations).containsExactlyInAnyOrder(
-            EscalationDefinition("Event_0zfsqqc", "escalation_notifySupport", "200"),
-            EscalationDefinition("Event_06asqkm", "escalation_notifySupport", "200"),
+            EscalationDefinition("escalationEndEvent_nofitySupport", "escalation_notifySupport", "200"),
+            EscalationDefinition("escalationEndEvent_nofitySupportAfterRepeatedError", "escalation_notifySupport", "200"),
         )
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
@@ -119,6 +120,21 @@ class OperatonModelExtractorTest {
             VariableDefinition("author"),
             VariableDefinition("subscribers"),
             VariableDefinition("subscriber"),
+        )
+    }
+
+    @Test
+    fun `extract detects event subprocess type and extracts escalations`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-send-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+
+        val eventSubProcess = bpmnModel.flowNodes.first { it.id == "eventSubProcess_errorHandling" }
+        assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
+
+        assertThat(bpmnModel.escalations).containsExactlyInAnyOrder(
+            EscalationDefinition("Event_0zfsqqc", "escalation_notifySupport", "200"),
+            EscalationDefinition("Event_06asqkm", "escalation_notifySupport", "200"),
         )
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -133,8 +133,8 @@ class OperatonModelExtractorTest {
         assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
 
         assertThat(bpmnModel.escalations).containsExactlyInAnyOrder(
-            EscalationDefinition("Event_0zfsqqc", "escalation_notifySupport", "200"),
-            EscalationDefinition("Event_06asqkm", "escalation_notifySupport", "200"),
+            EscalationDefinition("escalationEndEvent_nofitySupport", "escalation_notifySupport", "200"),
+            EscalationDefinition("escalationEndEvent_nofitySupportAfterRepeatedError", "escalation_notifySupport", "200"),
         )
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -132,8 +132,8 @@ class ZeebeModelExtractorTest {
         assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
 
         assertThat(bpmnModel.escalations).containsExactlyInAnyOrder(
-            EscalationDefinition("Event_0zfsqqc", "escalation_notifySupport", "200"),
-            EscalationDefinition("Event_06asqkm", "escalation_notifySupport", "200"),
+            EscalationDefinition("escalationEndEvent_nofitySupport", "escalation_notifySupport", "200"),
+            EscalationDefinition("escalationEndEvent_nofitySupportAfterRepeatedError", "escalation_notifySupport", "200"),
         )
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.MessageDefinition
@@ -118,6 +119,21 @@ class ZeebeModelExtractorTest {
             VariableDefinition("subscriber"),
             VariableDefinition("results"),
             VariableDefinition("result")
+        )
+    }
+
+    @Test
+    fun `extract detects event subprocess type and extracts escalations`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-send-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+
+        val eventSubProcess = bpmnModel.flowNodes.first { it.id == "eventSubProcess_errorHandling" }
+        assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
+
+        assertThat(bpmnModel.escalations).containsExactlyInAnyOrder(
+            EscalationDefinition("Event_0zfsqqc", "escalation_notifySupport", "200"),
+            EscalationDefinition("Event_06asqkm", "escalation_notifySupport", "200"),
         )
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
@@ -1,5 +1,6 @@
 package io.github.emaarco.bpmn.adapter.outbound.json
 
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.testNewsletterBpmnModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -13,7 +14,9 @@ class BpmnJsonGeneratorTest {
     fun `generates correct JSON for newsletter model`() {
 
         // given: the newsletter BPMN model
-        val model = testNewsletterBpmnModel()
+        val model = testNewsletterBpmnModel(
+            escalations = listOf(EscalationDefinition("EndEvent_RegistrationNotPossible", "Escalation_RegistrationFailed", "100"))
+        )
 
         // when: generating JSON
         val result = underTest.generate(model)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
@@ -3,6 +3,7 @@ package io.github.emaarco.bpmn.domain
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.MessageDefinition
@@ -22,6 +23,7 @@ fun testBpmnModel(
     messages: List<MessageDefinition> = listOf(MessageDefinition(id = "messageId", name = "messageName")),
     signals: List<SignalDefinition> = listOf(SignalDefinition(id = "signalId", name = "signalName")),
     errors: List<ErrorDefinition> = listOf(ErrorDefinition(id = "errorId", name = "errorName", code = "errorCode")),
+    escalations: List<EscalationDefinition> = emptyList(),
 ) = BpmnModel(
     processId = processId,
     flowNodes = flowNodes,
@@ -29,6 +31,7 @@ fun testBpmnModel(
     messages = messages,
     signals = signals,
     errors = errors,
+    escalations = escalations,
 )
 
 fun testBpmnModelApi(
@@ -120,6 +123,7 @@ fun testNewsletterBpmnModel(
     errors: List<ErrorDefinition> = listOf(
         ErrorDefinition("ErrorEvent_InvalidMail", "Error_InvalidMail", "500")
     ),
+    escalations: List<EscalationDefinition> = emptyList(),
 ) = testBpmnModel(
     processId = processId,
     flowNodes = flowNodes,
@@ -127,4 +131,5 @@ fun testNewsletterBpmnModel(
     messages = messages,
     signals = signals,
     errors = errors,
+    escalations = escalations,
 )

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -182,6 +182,21 @@ public final class NewsletterSubscriptionProcessApi {
     }
   }
 
+  public static final class Escalations {
+    public static final BpmnEscalation ESCALATION_REGISTRATION_FAILED = new BpmnEscalation("Escalation_RegistrationFailed", "100");
+
+    public static class BpmnEscalation {
+      public final String name;
+
+      public final String code;
+
+      BpmnEscalation(String name, String code) {
+        this.name = name;
+        this.code = code;
+      }
+    }
+  }
+
   public static final class Signals {
     public static final String SIGNAL_REGISTRATION_NOT_POSSIBLE = "Signal_RegistrationNotPossible";
   }

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -275,6 +275,15 @@ object NewsletterSubscriptionProcessApi {
     )
   }
 
+  object Escalations {
+    val ESCALATION_REGISTRATION_FAILED: BpmnEscalation = BpmnEscalation("Escalation_RegistrationFailed", "100")
+
+    data class BpmnEscalation(
+      val name: String,
+      val code: String,
+    )
+  }
+
   object Signals {
     const val SIGNAL_REGISTRATION_NOT_POSSIBLE: String = "Signal_RegistrationNotPossible"
   }

--- a/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
@@ -259,5 +259,12 @@
             "name": "Error_InvalidMail",
             "code": "500"
         }
+    ],
+    "escalations": [
+        {
+            "id": "EndEvent_RegistrationNotPossible",
+            "name": "Escalation_RegistrationFailed",
+            "code": "100"
+        }
     ]
 }

--- a/shared/bpmn/c7-send-newsletter.bpmn
+++ b/shared/bpmn/c7-send-newsletter.bpmn
@@ -73,7 +73,7 @@
         <bpmn:outgoing>Flow_0enjkoe</bpmn:outgoing>
         <bpmn:outgoing>Flow_081cykl</bpmn:outgoing>
       </bpmn:eventBasedGateway>
-      <bpmn:sequenceFlow id="Flow_18nf2jh" name="No" sourceRef="gateway_canSendAgain" targetRef="Event_0zfsqqc">
+      <bpmn:sequenceFlow id="Flow_18nf2jh" name="No" sourceRef="gateway_canSendAgain" targetRef="escalationEndEvent_nofitySupport">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${canBeResolved == false}</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
       <bpmn:serviceTask id="serviceTask_sendMailAgain" name="Send mail again" camunda:type="external" camunda:topic="newsletter.sendMailToSubscriber">
@@ -88,7 +88,7 @@
           <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1D</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
-      <bpmn:endEvent id="Event_0zfsqqc" name="Notify support">
+      <bpmn:endEvent id="escalationEndEvent_nofitySupport" name="Notify support">
         <bpmn:incoming>Flow_18nf2jh</bpmn:incoming>
         <bpmn:escalationEventDefinition id="EscalationEventDefinition_0v78ov7" escalationRef="Escalation_2gr27c9" />
       </bpmn:endEvent>
@@ -98,15 +98,15 @@
         <bpmn:messageEventDefinition id="MessageEventDefinition_1wq8qup" messageRef="Message_0qejt6h" />
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_081cykl" sourceRef="eventGateway_afterSendingAgain" targetRef="event_mailRejectedAgain" />
-      <bpmn:sequenceFlow id="Flow_0x9thpq" sourceRef="event_mailRejectedAgain" targetRef="Event_06asqkm" />
-      <bpmn:endEvent id="Event_06asqkm" name="Notify support">
+      <bpmn:sequenceFlow id="Flow_0x9thpq" sourceRef="event_mailRejectedAgain" targetRef="escalationEndEvent_nofitySupportAfterRepeatedError" />
+      <bpmn:endEvent id="escalationEndEvent_nofitySupportAfterRepeatedError" name="Notify support">
         <bpmn:incoming>Flow_0x9thpq</bpmn:incoming>
         <bpmn:escalationEventDefinition id="EscalationEventDefinition_0y07we7" escalationRef="Escalation_2gr27c9" />
       </bpmn:endEvent>
-      <bpmn:endEvent id="Event_13xucnu" name="Temporary issue resolved">
+      <bpmn:endEvent id="endEvent_issueResolved" name="Temporary issue resolved">
         <bpmn:incoming>Flow_0338xzf</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_0338xzf" sourceRef="timer_noRejectionForOneDay" targetRef="Event_13xucnu" />
+      <bpmn:sequenceFlow id="Flow_0338xzf" sourceRef="timer_noRejectionForOneDay" targetRef="endEvent_issueResolved" />
     </bpmn:subProcess>
   </bpmn:process>
   <bpmn:escalation id="Escalation_2gr27c9" name="escalation_notifySupport" escalationCode="200" />
@@ -178,7 +178,7 @@
           <dc:Bounds x="813" y="475" width="84" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0e276d8_di" bpmnElement="Event_0zfsqqc">
+      <bpmndi:BPMNShape id="Event_0e276d8_di" bpmnElement="escalationEndEvent_nofitySupport">
         <dc:Bounds x="597" y="542" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="581" y="585" width="68" height="14" />
@@ -190,16 +190,16 @@
           <dc:Bounds x="824" y="585" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13xucnu_di" bpmnElement="Event_13xucnu">
-        <dc:Bounds x="962" y="432" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="940" y="475" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_152e8n1_di" bpmnElement="Event_06asqkm">
+      <bpmndi:BPMNShape id="Event_152e8n1_di" bpmnElement="escalationEndEvent_nofitySupportAfterRepeatedError">
         <dc:Bounds x="962" y="542" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="946" y="585" width="68" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13xucnu_di" bpmnElement="endEvent_issueResolved">
+        <dc:Bounds x="962" y="432" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="940" y="475" width="81" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0vtppnk_di" bpmnElement="Flow_0vtppnk">
@@ -217,6 +217,10 @@
           <dc:Bounds x="529" y="432" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vym6nu_di" bpmnElement="Flow_0vym6nu">
+        <di:waypoint x="665" y="450" />
+        <di:waypoint x="720" y="450" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18nf2jh_di" bpmnElement="Flow_18nf2jh">
         <di:waypoint x="485" y="475" />
         <di:waypoint x="485" y="560" />
@@ -224,10 +228,6 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="493" y="515" width="15" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vym6nu_di" bpmnElement="Flow_0vym6nu">
-        <di:waypoint x="665" y="450" />
-        <di:waypoint x="720" y="450" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0enjkoe_di" bpmnElement="Flow_0enjkoe">
         <di:waypoint x="770" y="450" />
@@ -238,13 +238,13 @@
         <di:waypoint x="745" y="560" />
         <di:waypoint x="837" y="560" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0338xzf_di" bpmnElement="Flow_0338xzf">
-        <di:waypoint x="873" y="450" />
-        <di:waypoint x="962" y="450" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0x9thpq_di" bpmnElement="Flow_0x9thpq">
         <di:waypoint x="873" y="560" />
         <di:waypoint x="962" y="560" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0338xzf_di" bpmnElement="Flow_0338xzf">
+        <di:waypoint x="873" y="450" />
+        <di:waypoint x="962" y="450" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bianz5_di" bpmnElement="Flow_0bianz5">
         <di:waypoint x="278" y="120" />
@@ -254,13 +254,6 @@
         <di:waypoint x="430" y="120" />
         <di:waypoint x="475" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1jogut0_di" bpmnElement="Flow_1jogut0">
-        <di:waypoint x="525" y="120" />
-        <di:waypoint x="570" y="120" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="531" y="102" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ruayvl_di" bpmnElement="Flow_1ruayvl">
         <di:waypoint x="670" y="120" />
         <di:waypoint x="710" y="120" />
@@ -268,6 +261,13 @@
       <bpmndi:BPMNEdge id="Flow_0v2v55n_di" bpmnElement="Flow_0v2v55n">
         <di:waypoint x="810" y="120" />
         <di:waypoint x="872" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jogut0_di" bpmnElement="Flow_1jogut0">
+        <di:waypoint x="525" y="120" />
+        <di:waypoint x="570" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="531" y="102" width="18" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gsz7wd_di" bpmnElement="Flow_1gsz7wd">
         <di:waypoint x="500" y="145" />

--- a/shared/bpmn/c8-send-newsletter.bpmn
+++ b/shared/bpmn/c8-send-newsletter.bpmn
@@ -87,7 +87,7 @@
         <bpmn:outgoing>Flow_0enjkoe</bpmn:outgoing>
         <bpmn:outgoing>Flow_081cykl</bpmn:outgoing>
       </bpmn:eventBasedGateway>
-      <bpmn:sequenceFlow id="Flow_18nf2jh" name="No" sourceRef="gateway_canSendAgain" targetRef="Event_0zfsqqc">
+      <bpmn:sequenceFlow id="Flow_18nf2jh" name="No" sourceRef="gateway_canSendAgain" targetRef="escalationEndEvent_nofitySupport">
         <bpmn:conditionExpression>=canBeResolved = false</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
       <bpmn:serviceTask id="serviceTask_sendMailAgain" name="Send mail again">
@@ -105,7 +105,7 @@
           <bpmn:timeDuration>PT1D</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
-      <bpmn:endEvent id="Event_0zfsqqc" name="Notify support">
+      <bpmn:endEvent id="escalationEndEvent_nofitySupport" name="Notify support">
         <bpmn:incoming>Flow_18nf2jh</bpmn:incoming>
         <bpmn:escalationEventDefinition id="EscalationEventDefinition_0v78ov7" escalationRef="Escalation_2gr27c9" />
       </bpmn:endEvent>
@@ -115,15 +115,15 @@
         <bpmn:messageEventDefinition id="MessageEventDefinition_1wq8qup" messageRef="Message_0qejt6h" />
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_081cykl" sourceRef="eventGateway_afterSendingAgain" targetRef="event_mailRejectedAgain" />
-      <bpmn:sequenceFlow id="Flow_0x9thpq" sourceRef="event_mailRejectedAgain" targetRef="Event_06asqkm" />
-      <bpmn:endEvent id="Event_06asqkm" name="Notify support">
+      <bpmn:sequenceFlow id="Flow_0x9thpq" sourceRef="event_mailRejectedAgain" targetRef="escalationEndEvent_nofitySupportAfterRepeatedError" />
+      <bpmn:endEvent id="escalationEndEvent_nofitySupportAfterRepeatedError" name="Notify support">
         <bpmn:incoming>Flow_0x9thpq</bpmn:incoming>
         <bpmn:escalationEventDefinition id="EscalationEventDefinition_0y07we7" escalationRef="Escalation_2gr27c9" />
       </bpmn:endEvent>
-      <bpmn:endEvent id="Event_13xucnu" name="Temporary issue resolved">
+      <bpmn:endEvent id="endEvent_issueResolved" name="Temporary issue resolved">
         <bpmn:incoming>Flow_0338xzf</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_0338xzf" sourceRef="timer_noRejectionForOneDay" targetRef="Event_13xucnu" />
+      <bpmn:sequenceFlow id="Flow_0338xzf" sourceRef="timer_noRejectionForOneDay" targetRef="endEvent_issueResolved" />
     </bpmn:subProcess>
   </bpmn:process>
   <bpmn:escalation id="Escalation_2gr27c9" name="escalation_notifySupport" escalationCode="200" />
@@ -204,7 +204,7 @@
           <dc:Bounds x="813" y="475" width="84" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0e276d8_di" bpmnElement="Event_0zfsqqc">
+      <bpmndi:BPMNShape id="Event_0e276d8_di" bpmnElement="escalationEndEvent_nofitySupport">
         <dc:Bounds x="597" y="542" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="581" y="585" width="68" height="14" />
@@ -216,13 +216,13 @@
           <dc:Bounds x="824" y="585" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_152e8n1_di" bpmnElement="Event_06asqkm">
+      <bpmndi:BPMNShape id="Event_152e8n1_di" bpmnElement="escalationEndEvent_nofitySupportAfterRepeatedError">
         <dc:Bounds x="962" y="542" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="946" y="585" width="68" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13xucnu_di" bpmnElement="Event_13xucnu">
+      <bpmndi:BPMNShape id="Event_13xucnu_di" bpmnElement="endEvent_issueResolved">
         <dc:Bounds x="962" y="432" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="940" y="475" width="81" height="27" />

--- a/shared/bpmn/operaton-send-newsletter.bpmn
+++ b/shared/bpmn/operaton-send-newsletter.bpmn
@@ -66,7 +66,7 @@
         <bpmn:outgoing>Flow_0enjkoe</bpmn:outgoing>
         <bpmn:outgoing>Flow_081cykl</bpmn:outgoing>
       </bpmn:eventBasedGateway>
-      <bpmn:sequenceFlow id="Flow_18nf2jh" name="No" sourceRef="gateway_canSendAgain" targetRef="Event_0zfsqqc">
+      <bpmn:sequenceFlow id="Flow_18nf2jh" name="No" sourceRef="gateway_canSendAgain" targetRef="escalationEndEvent_nofitySupport">
         <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${canBeResolved == false}</bpmn:conditionExpression>
       </bpmn:sequenceFlow>
       <bpmn:serviceTask id="serviceTask_sendMailAgain" name="Send mail again" operaton:type="external" operaton:topic="newsletter.sendMailToSubscriber">
@@ -81,7 +81,7 @@
           <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1D</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
-      <bpmn:endEvent id="Event_0zfsqqc" name="Notify support">
+      <bpmn:endEvent id="escalationEndEvent_nofitySupport" name="Notify support">
         <bpmn:incoming>Flow_18nf2jh</bpmn:incoming>
         <bpmn:escalationEventDefinition id="EscalationEventDefinition_0v78ov7" escalationRef="Escalation_2gr27c9" />
       </bpmn:endEvent>
@@ -91,15 +91,15 @@
         <bpmn:messageEventDefinition id="MessageEventDefinition_1wq8qup" messageRef="Message_0qejt6h" />
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_081cykl" sourceRef="eventGateway_afterSendingAgain" targetRef="event_mailRejectedAgain" />
-      <bpmn:sequenceFlow id="Flow_0x9thpq" sourceRef="event_mailRejectedAgain" targetRef="Event_06asqkm" />
-      <bpmn:endEvent id="Event_06asqkm" name="Notify support">
+      <bpmn:sequenceFlow id="Flow_0x9thpq" sourceRef="event_mailRejectedAgain" targetRef="escalationEndEvent_nofitySupportAfterRepeatedError" />
+      <bpmn:endEvent id="escalationEndEvent_nofitySupportAfterRepeatedError" name="Notify support">
         <bpmn:incoming>Flow_0x9thpq</bpmn:incoming>
         <bpmn:escalationEventDefinition id="EscalationEventDefinition_0y07we7" escalationRef="Escalation_2gr27c9" />
       </bpmn:endEvent>
-      <bpmn:endEvent id="Event_13xucnu" name="Temporary issue resolved">
+      <bpmn:endEvent id="endEvent_issueResolved" name="Temporary issue resolved">
         <bpmn:incoming>Flow_0338xzf</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:sequenceFlow id="Flow_0338xzf" sourceRef="timer_noRejectionForOneDay" targetRef="Event_13xucnu" />
+      <bpmn:sequenceFlow id="Flow_0338xzf" sourceRef="timer_noRejectionForOneDay" targetRef="endEvent_issueResolved" />
     </bpmn:subProcess>
   </bpmn:process>
   <bpmn:escalation id="Escalation_2gr27c9" name="escalation_notifySupport" escalationCode="200" />
@@ -202,7 +202,7 @@
           <dc:Bounds x="813" y="475" width="84" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0e276d8_di" bpmnElement="Event_0zfsqqc">
+      <bpmndi:BPMNShape id="Event_0e276d8_di" bpmnElement="escalationEndEvent_nofitySupport">
         <dc:Bounds x="597" y="542" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="581" y="585" width="68" height="14" />
@@ -214,13 +214,13 @@
           <dc:Bounds x="824" y="585" width="63" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13xucnu_di" bpmnElement="Event_13xucnu">
+      <bpmndi:BPMNShape id="Event_13xucnu_di" bpmnElement="endEvent_issueResolved">
         <dc:Bounds x="962" y="432" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="940" y="475" width="81" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_152e8n1_di" bpmnElement="Event_06asqkm">
+      <bpmndi:BPMNShape id="Event_152e8n1_di" bpmnElement="escalationEndEvent_nofitySupportAfterRepeatedError">
         <dc:Bounds x="962" y="542" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="946" y="585" width="68" height="14" />


### PR DESCRIPTION
## Summary

- Add `EVENT_SUB_PROCESS` to `BpmnElementType`, detected structurally via `SubProcess.triggeredByEvent()` in `findFlowNodes()`
- Add `EscalationDefinition` domain type (mirrors `ErrorDefinition`)
- Extract escalation event definitions in all 3 engine extractors using new `findEscalationEventDefinitions()` in `ModelInstanceUtils`
- Expose escalations in JSON output (`EscalationJson`) and in the generated Kotlin/Java API (`Escalations` section with `BpmnEscalation` class)
- Add extractor tests verifying event subprocess type detection and escalation extraction for all 3 engines (Zeebe, Camunda 7, Operaton) using the send-newsletter BPMN

Closes #227

## Test plan

- [ ] `ZeebeModelExtractorTest` — new test: event subprocess type + escalations
- [ ] `Camunda7ModelExtractorTest` — new test: event subprocess type + escalations
- [ ] `OperatonModelExtractorTest` — new test: event subprocess type + escalations
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)