### PR TITLE
refactor: move Flows & Relations to end of generated API and JSON

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
@@ -23,8 +23,6 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
         ApiObjectType.PROCESS_ID to ProcessIdWriter(),
         ApiObjectType.PROCESS_ENGINE to ProcessEngineWriter(),
         ApiObjectType.ELEMENTS to ElementsWriter(),
-        ApiObjectType.FLOWS to FlowsWriter(),
-        ApiObjectType.RELATIONS to RelationsWriter(),
         ApiObjectType.CALL_ACTIVITIES to CallActivitiesWriter(),
         ApiObjectType.MESSAGES to MessagesWriter(),
         ApiObjectType.SERVICE_TASKS to ServiceTasksWriter(),
@@ -32,7 +30,9 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
         ApiObjectType.ERRORS to ErrorsWriter(),
         ApiObjectType.ESCALATIONS to EscalationsWriter(),
         ApiObjectType.SIGNALS to SignalsWriter(),
-        ApiObjectType.VARIABLES to VariablesWriter()
+        ApiObjectType.VARIABLES to VariablesWriter(),
+        ApiObjectType.FLOWS to FlowsWriter(),
+        ApiObjectType.RELATIONS to RelationsWriter(),
     )
 
     override fun buildApiFile(modelApi: BpmnModelApi): GeneratedApiFile {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
@@ -27,8 +27,6 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         ApiObjectType.PROCESS_ID to ProcessIdWriter(),
         ApiObjectType.PROCESS_ENGINE to ProcessEngineWriter(),
         ApiObjectType.ELEMENTS to ElementsWriter(),
-        ApiObjectType.FLOWS to FlowsWriter(),
-        ApiObjectType.RELATIONS to RelationsWriter(),
         ApiObjectType.CALL_ACTIVITIES to CallActivitiesWriter(),
         ApiObjectType.MESSAGES to MessagesWriter(),
         ApiObjectType.SERVICE_TASKS to ServiceTasksWriter(),
@@ -36,7 +34,9 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         ApiObjectType.ERRORS to ErrorsWriter(),
         ApiObjectType.ESCALATIONS to EscalationsWriter(),
         ApiObjectType.SIGNALS to SignalsWriter(),
-        ApiObjectType.VARIABLES to VariablesWriter()
+        ApiObjectType.VARIABLES to VariablesWriter(),
+        ApiObjectType.FLOWS to FlowsWriter(),
+        ApiObjectType.RELATIONS to RelationsWriter(),
     )
 
     override fun buildApiFile(modelApi: BpmnModelApi): GeneratedApiFile {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
@@ -6,11 +6,11 @@ import kotlinx.serialization.Serializable
 data class BpmnModelJson(
     val processId: String,
     val flowNodes: List<FlowNodeJson>,
-    val sequenceFlows: List<SequenceFlowJson>,
     val messages: List<MessageJson>,
     val signals: List<SignalJson>,
     val errors: List<ErrorJson>,
     val escalations: List<EscalationJson> = emptyList(),
+    val sequenceFlows: List<SequenceFlowJson>,
 )
 
 @Serializable

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -39,99 +39,6 @@ public final class NewsletterSubscriptionProcessApi {
     public static final String TIMER_EVERY_DAY = "Timer_EveryDay";
   }
 
-  public static final class Flows {
-    public static final BpmnFlow FLOW_05_I_3_X_1_Y = new BpmnFlow("Flow_05i3x1y", "StartEvent_RequestReceived", "Activity_SendConfirmationMail", null, false);
-
-    public static final BpmnFlow FLOW_09_CUVZP = new BpmnFlow("Flow_09cuvzp", "SubProcess_Confirmation", "Activity_SendWelcomeMail", null, false);
-
-    public static final BpmnFlow FLOW_0_I_2_CTUV = new BpmnFlow("Flow_0i2ctuv", "ErrorEvent_InvalidMail", "EndEvent_RegistrationNotPossible", null, false);
-
-    public static final BpmnFlow FLOW_0_X_4_EWVB = new BpmnFlow("Flow_0x4ewvb", "Timer_EveryDay", "Activity_SendConfirmationMail", null, false);
-
-    public static final BpmnFlow FLOW_1_BCKM_43 = new BpmnFlow("Flow_1bckm43", "Activity_SendConfirmationMail", "Activity_ConfirmRegistration", null, false);
-
-    public static final BpmnFlow FLOW_1_BSB_8_NO = new BpmnFlow("Flow_1bsb8no", "CallActivity_AbortRegistration", "EndEvent_RegistrationAborted", null, false);
-
-    public static final BpmnFlow FLOW_1_CPWE_57 = new BpmnFlow("Flow_1cpwe57", "Activity_ConfirmRegistration", "EndEvent_SubscriptionConfirmed", null, false);
-
-    public static final BpmnFlow FLOW_1_CSFYYZ = new BpmnFlow("Flow_1csfyyz", "StartEvent_SubmitRegistrationForm", "SubProcess_Confirmation", null, false);
-
-    public static final BpmnFlow FLOW_1_I_7_HJID = new BpmnFlow("Flow_1i7hjid", "Activity_SendWelcomeMail", "EndEvent_RegistrationCompleted", null, false);
-
-    public static final BpmnFlow FLOW_1_L_1_LJ_4_M = new BpmnFlow("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration", null, false);
-
-    public static class BpmnFlow {
-      public final String id;
-
-      public final String sourceRef;
-
-      public final String targetRef;
-
-      public final String condition;
-
-      public final boolean isDefault;
-
-      BpmnFlow(String id, String sourceRef, String targetRef, String condition, boolean isDefault) {
-        this.id = id;
-        this.sourceRef = sourceRef;
-        this.targetRef = targetRef;
-        this.condition = condition;
-        this.isDefault = isDefault;
-      }
-    }
-  }
-
-  public static final class Relations {
-    public static final BpmnRelations ACTIVITY_CONFIRM_REGISTRATION = new BpmnRelations(List.of("Activity_SendConfirmationMail"), List.of("EndEvent_SubscriptionConfirmed"), "SubProcess_Confirmation", null, List.of("Timer_EveryDay"));
-
-    public static final BpmnRelations ACTIVITY_SEND_CONFIRMATION_MAIL = new BpmnRelations(List.of("StartEvent_RequestReceived", "Timer_EveryDay"), List.of("Activity_ConfirmRegistration"), "SubProcess_Confirmation", null, List.of());
-
-    public static final BpmnRelations ACTIVITY_SEND_WELCOME_MAIL = new BpmnRelations(List.of("SubProcess_Confirmation"), List.of("EndEvent_RegistrationCompleted"), null, null, List.of());
-
-    public static final BpmnRelations CALL_ACTIVITY_ABORT_REGISTRATION = new BpmnRelations(List.of("Timer_After3Days"), List.of("EndEvent_RegistrationAborted"), null, null, List.of());
-
-    public static final BpmnRelations END_EVENT_REGISTRATION_ABORTED = new BpmnRelations(List.of("CallActivity_AbortRegistration"), List.of(), null, null, List.of());
-
-    public static final BpmnRelations END_EVENT_REGISTRATION_COMPLETED = new BpmnRelations(List.of("Activity_SendWelcomeMail"), List.of(), null, null, List.of());
-
-    public static final BpmnRelations END_EVENT_REGISTRATION_NOT_POSSIBLE = new BpmnRelations(List.of("ErrorEvent_InvalidMail"), List.of(), null, null, List.of());
-
-    public static final BpmnRelations END_EVENT_SUBSCRIPTION_CONFIRMED = new BpmnRelations(List.of("Activity_ConfirmRegistration"), List.of(), "SubProcess_Confirmation", null, List.of());
-
-    public static final BpmnRelations ERROR_EVENT_INVALID_MAIL = new BpmnRelations(List.of(), List.of("EndEvent_RegistrationNotPossible"), null, "SubProcess_Confirmation", List.of());
-
-    public static final BpmnRelations START_EVENT_REQUEST_RECEIVED = new BpmnRelations(List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", null, List.of());
-
-    public static final BpmnRelations START_EVENT_SUBMIT_REGISTRATION_FORM = new BpmnRelations(List.of(), List.of("SubProcess_Confirmation"), null, null, List.of());
-
-    public static final BpmnRelations SUB_PROCESS_CONFIRMATION = new BpmnRelations(List.of("StartEvent_SubmitRegistrationForm"), List.of("Activity_SendWelcomeMail"), null, null, List.of("ErrorEvent_InvalidMail", "Timer_After3Days"));
-
-    public static final BpmnRelations TIMER_AFTER_3_DAYS = new BpmnRelations(List.of(), List.of("CallActivity_AbortRegistration"), null, "SubProcess_Confirmation", List.of());
-
-    public static final BpmnRelations TIMER_EVERY_DAY = new BpmnRelations(List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", "Activity_ConfirmRegistration", List.of());
-
-    public static class BpmnRelations {
-      public final List<String> incoming;
-
-      public final List<String> outgoing;
-
-      public final String parentId;
-
-      public final String attachedToRef;
-
-      public final List<String> attachedElements;
-
-      BpmnRelations(List<String> incoming, List<String> outgoing, String parentId,
-          String attachedToRef, List<String> attachedElements) {
-        this.incoming = incoming;
-        this.outgoing = outgoing;
-        this.parentId = parentId;
-        this.attachedToRef = attachedToRef;
-        this.attachedElements = attachedElements;
-      }
-    }
-  }
-
   public static final class CallActivities {
     public static final String CALL_ACTIVITY_ABORT_REGISTRATION = "abort-registration";
   }
@@ -230,6 +137,99 @@ public final class NewsletterSubscriptionProcessApi {
 
     public static final class StartEventSubmitRegistrationForm {
       public static final String SUBSCRIPTION_ID = "subscriptionId";
+    }
+  }
+
+  public static final class Flows {
+    public static final BpmnFlow FLOW_05_I_3_X_1_Y = new BpmnFlow("Flow_05i3x1y", "StartEvent_RequestReceived", "Activity_SendConfirmationMail", null, false);
+
+    public static final BpmnFlow FLOW_09_CUVZP = new BpmnFlow("Flow_09cuvzp", "SubProcess_Confirmation", "Activity_SendWelcomeMail", null, false);
+
+    public static final BpmnFlow FLOW_0_I_2_CTUV = new BpmnFlow("Flow_0i2ctuv", "ErrorEvent_InvalidMail", "EndEvent_RegistrationNotPossible", null, false);
+
+    public static final BpmnFlow FLOW_0_X_4_EWVB = new BpmnFlow("Flow_0x4ewvb", "Timer_EveryDay", "Activity_SendConfirmationMail", null, false);
+
+    public static final BpmnFlow FLOW_1_BCKM_43 = new BpmnFlow("Flow_1bckm43", "Activity_SendConfirmationMail", "Activity_ConfirmRegistration", null, false);
+
+    public static final BpmnFlow FLOW_1_BSB_8_NO = new BpmnFlow("Flow_1bsb8no", "CallActivity_AbortRegistration", "EndEvent_RegistrationAborted", null, false);
+
+    public static final BpmnFlow FLOW_1_CPWE_57 = new BpmnFlow("Flow_1cpwe57", "Activity_ConfirmRegistration", "EndEvent_SubscriptionConfirmed", null, false);
+
+    public static final BpmnFlow FLOW_1_CSFYYZ = new BpmnFlow("Flow_1csfyyz", "StartEvent_SubmitRegistrationForm", "SubProcess_Confirmation", null, false);
+
+    public static final BpmnFlow FLOW_1_I_7_HJID = new BpmnFlow("Flow_1i7hjid", "Activity_SendWelcomeMail", "EndEvent_RegistrationCompleted", null, false);
+
+    public static final BpmnFlow FLOW_1_L_1_LJ_4_M = new BpmnFlow("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration", null, false);
+
+    public static class BpmnFlow {
+      public final String id;
+
+      public final String sourceRef;
+
+      public final String targetRef;
+
+      public final String condition;
+
+      public final boolean isDefault;
+
+      BpmnFlow(String id, String sourceRef, String targetRef, String condition, boolean isDefault) {
+        this.id = id;
+        this.sourceRef = sourceRef;
+        this.targetRef = targetRef;
+        this.condition = condition;
+        this.isDefault = isDefault;
+      }
+    }
+  }
+
+  public static final class Relations {
+    public static final BpmnRelations ACTIVITY_CONFIRM_REGISTRATION = new BpmnRelations(List.of("Activity_SendConfirmationMail"), List.of("EndEvent_SubscriptionConfirmed"), "SubProcess_Confirmation", null, List.of("Timer_EveryDay"));
+
+    public static final BpmnRelations ACTIVITY_SEND_CONFIRMATION_MAIL = new BpmnRelations(List.of("StartEvent_RequestReceived", "Timer_EveryDay"), List.of("Activity_ConfirmRegistration"), "SubProcess_Confirmation", null, List.of());
+
+    public static final BpmnRelations ACTIVITY_SEND_WELCOME_MAIL = new BpmnRelations(List.of("SubProcess_Confirmation"), List.of("EndEvent_RegistrationCompleted"), null, null, List.of());
+
+    public static final BpmnRelations CALL_ACTIVITY_ABORT_REGISTRATION = new BpmnRelations(List.of("Timer_After3Days"), List.of("EndEvent_RegistrationAborted"), null, null, List.of());
+
+    public static final BpmnRelations END_EVENT_REGISTRATION_ABORTED = new BpmnRelations(List.of("CallActivity_AbortRegistration"), List.of(), null, null, List.of());
+
+    public static final BpmnRelations END_EVENT_REGISTRATION_COMPLETED = new BpmnRelations(List.of("Activity_SendWelcomeMail"), List.of(), null, null, List.of());
+
+    public static final BpmnRelations END_EVENT_REGISTRATION_NOT_POSSIBLE = new BpmnRelations(List.of("ErrorEvent_InvalidMail"), List.of(), null, null, List.of());
+
+    public static final BpmnRelations END_EVENT_SUBSCRIPTION_CONFIRMED = new BpmnRelations(List.of("Activity_ConfirmRegistration"), List.of(), "SubProcess_Confirmation", null, List.of());
+
+    public static final BpmnRelations ERROR_EVENT_INVALID_MAIL = new BpmnRelations(List.of(), List.of("EndEvent_RegistrationNotPossible"), null, "SubProcess_Confirmation", List.of());
+
+    public static final BpmnRelations START_EVENT_REQUEST_RECEIVED = new BpmnRelations(List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", null, List.of());
+
+    public static final BpmnRelations START_EVENT_SUBMIT_REGISTRATION_FORM = new BpmnRelations(List.of(), List.of("SubProcess_Confirmation"), null, null, List.of());
+
+    public static final BpmnRelations SUB_PROCESS_CONFIRMATION = new BpmnRelations(List.of("StartEvent_SubmitRegistrationForm"), List.of("Activity_SendWelcomeMail"), null, null, List.of("ErrorEvent_InvalidMail", "Timer_After3Days"));
+
+    public static final BpmnRelations TIMER_AFTER_3_DAYS = new BpmnRelations(List.of(), List.of("CallActivity_AbortRegistration"), null, "SubProcess_Confirmation", List.of());
+
+    public static final BpmnRelations TIMER_EVERY_DAY = new BpmnRelations(List.of(), List.of("Activity_SendConfirmationMail"), "SubProcess_Confirmation", "Activity_ConfirmRegistration", List.of());
+
+    public static class BpmnRelations {
+      public final List<String> incoming;
+
+      public final List<String> outgoing;
+
+      public final String parentId;
+
+      public final String attachedToRef;
+
+      public final List<String> attachedElements;
+
+      BpmnRelations(List<String> incoming, List<String> outgoing, String parentId,
+          String attachedToRef, List<String> attachedElements) {
+        this.incoming = incoming;
+        this.outgoing = outgoing;
+        this.parentId = parentId;
+        this.attachedToRef = attachedToRef;
+        this.attachedElements = attachedElements;
+      }
     }
   }
 }

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -45,6 +45,89 @@ object NewsletterSubscriptionProcessApi {
     const val TIMER_EVERY_DAY: String = "Timer_EveryDay"
   }
 
+  object CallActivities {
+    const val CALL_ACTIVITY_ABORT_REGISTRATION: String = "abort-registration"
+  }
+
+  object Messages {
+    const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
+
+    const val MESSAGE_SUBSCRIPTION_CONFIRMED: String = "Message_SubscriptionConfirmed"
+  }
+
+  object TaskTypes {
+    const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"
+
+    const val NEWSLETTER_SEND_WELCOME_MAIL: String = "\${newsletterSendWelcomeMail}"
+
+    const val NEWSLETTER_REGISTRATION_COMPLETED: String = "newsletter.registrationCompleted"
+  }
+
+  object Timers {
+    val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", "\${testVariable}")
+
+    val TIMER_EVERY_DAY: BpmnTimer = BpmnTimer("Duration", "PT1M")
+
+    data class BpmnTimer(
+      val type: String,
+      val timerValue: String,
+    )
+  }
+
+  object Errors {
+    val ERROR_INVALID_MAIL: BpmnError = BpmnError("Error_InvalidMail", "500")
+
+    data class BpmnError(
+      val name: String,
+      val code: String,
+    )
+  }
+
+  object Escalations {
+    val ESCALATION_REGISTRATION_FAILED: BpmnEscalation = BpmnEscalation("Escalation_RegistrationFailed", "100")
+
+    data class BpmnEscalation(
+      val name: String,
+      val code: String,
+    )
+  }
+
+  object Signals {
+    const val SIGNAL_REGISTRATION_NOT_POSSIBLE: String = "Signal_RegistrationNotPossible"
+  }
+
+  object Variables {
+    const val SUBSCRIPTION_ID: String = "subscriptionId"
+
+    const val TEST_VARIABLE: String = "testVariable"
+
+    object ActivitySendConfirmationMail {
+      const val SUBSCRIPTION_ID: String = "subscriptionId"
+
+      const val TEST_VARIABLE: String = "testVariable"
+    }
+
+    object ActivitySendWelcomeMail {
+      const val SUBSCRIPTION_ID: String = "subscriptionId"
+    }
+
+    object CallActivityAbortRegistration {
+      const val SUBSCRIPTION_ID: String = "subscriptionId"
+    }
+
+    object EndEventRegistrationCompleted {
+      const val SUBSCRIPTION_ID: String = "subscriptionId"
+    }
+
+    object StartEventRequestReceived {
+      const val SUBSCRIPTION_ID: String = "subscriptionId"
+    }
+
+    object StartEventSubmitRegistrationForm {
+      const val SUBSCRIPTION_ID: String = "subscriptionId"
+    }
+  }
+
   object Flows {
     val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
             id = "Flow_05i3x1y",
@@ -235,88 +318,5 @@ object NewsletterSubscriptionProcessApi {
       val attachedToRef: String?,
       val attachedElements: List<String>,
     )
-  }
-
-  object CallActivities {
-    const val CALL_ACTIVITY_ABORT_REGISTRATION: String = "abort-registration"
-  }
-
-  object Messages {
-    const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
-
-    const val MESSAGE_SUBSCRIPTION_CONFIRMED: String = "Message_SubscriptionConfirmed"
-  }
-
-  object TaskTypes {
-    const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"
-
-    const val NEWSLETTER_SEND_WELCOME_MAIL: String = "\${newsletterSendWelcomeMail}"
-
-    const val NEWSLETTER_REGISTRATION_COMPLETED: String = "newsletter.registrationCompleted"
-  }
-
-  object Timers {
-    val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", "\${testVariable}")
-
-    val TIMER_EVERY_DAY: BpmnTimer = BpmnTimer("Duration", "PT1M")
-
-    data class BpmnTimer(
-      val type: String,
-      val timerValue: String,
-    )
-  }
-
-  object Errors {
-    val ERROR_INVALID_MAIL: BpmnError = BpmnError("Error_InvalidMail", "500")
-
-    data class BpmnError(
-      val name: String,
-      val code: String,
-    )
-  }
-
-  object Escalations {
-    val ESCALATION_REGISTRATION_FAILED: BpmnEscalation = BpmnEscalation("Escalation_RegistrationFailed", "100")
-
-    data class BpmnEscalation(
-      val name: String,
-      val code: String,
-    )
-  }
-
-  object Signals {
-    const val SIGNAL_REGISTRATION_NOT_POSSIBLE: String = "Signal_RegistrationNotPossible"
-  }
-
-  object Variables {
-    const val SUBSCRIPTION_ID: String = "subscriptionId"
-
-    const val TEST_VARIABLE: String = "testVariable"
-
-    object ActivitySendConfirmationMail {
-      const val SUBSCRIPTION_ID: String = "subscriptionId"
-
-      const val TEST_VARIABLE: String = "testVariable"
-    }
-
-    object ActivitySendWelcomeMail {
-      const val SUBSCRIPTION_ID: String = "subscriptionId"
-    }
-
-    object CallActivityAbortRegistration {
-      const val SUBSCRIPTION_ID: String = "subscriptionId"
-    }
-
-    object EndEventRegistrationCompleted {
-      const val SUBSCRIPTION_ID: String = "subscriptionId"
-    }
-
-    object StartEventRequestReceived {
-      const val SUBSCRIPTION_ID: String = "subscriptionId"
-    }
-
-    object StartEventSubmitRegistrationForm {
-      const val SUBSCRIPTION_ID: String = "subscriptionId"
-    }
   }
 }

--- a/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/NewsletterSubscriptionProcess.json
@@ -175,6 +175,36 @@
             }
         }
     ],
+    "messages": [
+        {
+            "id": "StartEvent_SubmitRegistrationForm",
+            "name": "Message_FormSubmitted"
+        },
+        {
+            "id": "Activity_ConfirmRegistration",
+            "name": "Message_SubscriptionConfirmed"
+        }
+    ],
+    "signals": [
+        {
+            "id": "EndEvent_RegistrationNotPossible",
+            "name": "Signal_RegistrationNotPossible"
+        }
+    ],
+    "errors": [
+        {
+            "id": "ErrorEvent_InvalidMail",
+            "name": "Error_InvalidMail",
+            "code": "500"
+        }
+    ],
+    "escalations": [
+        {
+            "id": "EndEvent_RegistrationNotPossible",
+            "name": "Escalation_RegistrationFailed",
+            "code": "100"
+        }
+    ],
     "sequenceFlows": [
         {
             "id": "Flow_05i3x1y",
@@ -235,36 +265,6 @@
             "sourceRef": "Timer_After3Days",
             "targetRef": "CallActivity_AbortRegistration",
             "isDefault": false
-        }
-    ],
-    "messages": [
-        {
-            "id": "StartEvent_SubmitRegistrationForm",
-            "name": "Message_FormSubmitted"
-        },
-        {
-            "id": "Activity_ConfirmRegistration",
-            "name": "Message_SubscriptionConfirmed"
-        }
-    ],
-    "signals": [
-        {
-            "id": "EndEvent_RegistrationNotPossible",
-            "name": "Signal_RegistrationNotPossible"
-        }
-    ],
-    "errors": [
-        {
-            "id": "ErrorEvent_InvalidMail",
-            "name": "Error_InvalidMail",
-            "code": "500"
-        }
-    ],
-    "escalations": [
-        {
-            "id": "EndEvent_RegistrationNotPossible",
-            "name": "Escalation_RegistrationFailed",
-            "code": "100"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- `Flows` and `Relations` sections now appear at the end of the generated Kotlin/Java API (after `Variables`), rather than right after `Elements`
- `sequenceFlows` field moved to last position in the JSON output (after `escalations`)
- Updated test fixtures to match the new output order

## Test plan
- [x] `./gradlew :bpmn-to-code-core:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)