### PR TITLE
fix: include escalations in model merge and sort

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerService.kt
@@ -26,6 +26,7 @@ class ModelMergerService {
         val mergedMessages = mergeDistinctBy(models) { it.messages }
         val mergedSignals = mergeDistinctBy(models) { it.signals }
         val mergedErrors = mergeDistinctBy(models) { it.errors }
+        val mergedEscalations = mergeDistinctBy(models) { it.escalations }
         return BpmnModel(
             processId = processId,
             flowNodes = mergedFlowNodes,
@@ -33,6 +34,7 @@ class ModelMergerService {
             messages = mergedMessages,
             signals = mergedSignals,
             errors = mergedErrors,
+            escalations = mergedEscalations,
         )
     }
 
@@ -60,5 +62,6 @@ class ModelMergerService {
         messages = messages.sortedBy { it.getRawName() },
         signals = signals.sortedBy { it.getRawName() },
         errors = errors.sortedBy { it.getRawName() },
+        escalations = escalations.sortedBy { it.getRawName() },
     )
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerServiceTest.kt
@@ -1,6 +1,7 @@
 package io.github.emaarco.bpmn.domain.service
 
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.MessageDefinition
@@ -30,23 +31,29 @@ class ModelMergerServiceTest {
             properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "update-order", customProperties = mapOf(IMPL_VALUE_KEY to "secondTaskType"))))
         val thirdFlowNode = FlowNodeDefinition(id = "delete-order",
             properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "delete-order", customProperties = mapOf(IMPL_VALUE_KEY to "thirdTaskType"))))
+        val firstEscalation = EscalationDefinition(id = "ESC_1", name = "firstEscalation", code = "100")
+        val secondEscalation = EscalationDefinition(id = "ESC_2", name = "secondEscalation", code = "200")
+        val thirdEscalation = EscalationDefinition(id = "ESC_3", name = "thirdEscalation", code = "300")
 
         val firstModel = testBpmnModel(
             processId = "order-process",
             flowNodes = listOf(firstFlowNode, secondFlowNode),
             messages = listOf(firstMessage, secondMessage),
+            escalations = listOf(firstEscalation, secondEscalation),
         )
 
         val secondModel = testBpmnModel(
             processId = "order-process",
             flowNodes = listOf(secondFlowNode, thirdFlowNode),
             messages = listOf(secondMessage, thirdMessage),
+            escalations = listOf(secondEscalation, thirdEscalation),
         )
 
         val otherModel = testBpmnModel(
             processId = "other-order-process",
             flowNodes = listOf(firstFlowNode, secondFlowNode),
             messages = listOf(firstMessage, secondMessage),
+            escalations = listOf(firstEscalation),
         )
 
         // when
@@ -58,11 +65,13 @@ class ModelMergerServiceTest {
                 processId = "order-process",
                 flowNodes = listOf(firstFlowNode, thirdFlowNode, secondFlowNode),
                 messages = listOf(firstMessage, secondMessage, thirdMessage),
+                escalations = listOf(firstEscalation, secondEscalation, thirdEscalation),
             ),
             testBpmnModel(
                 processId = "other-order-process",
                 flowNodes = listOf(firstFlowNode, secondFlowNode),
                 messages = listOf(firstMessage, secondMessage),
+                escalations = listOf(firstEscalation),
             )
         )
     }
@@ -78,6 +87,11 @@ class ModelMergerServiceTest {
                 FlowNodeDefinition(id = "a-node", variables = listOf(VariableDefinition("zetaVar"))),
                 FlowNodeDefinition(id = "m-node")
             ),
+            escalations = listOf(
+                EscalationDefinition(id = "ESC_Z", name = "zEscalation", code = "300"),
+                EscalationDefinition(id = "ESC_A", name = "aEscalation", code = "100"),
+                EscalationDefinition(id = "ESC_M", name = "mEscalation", code = "200"),
+            ),
         )
 
         // when
@@ -87,8 +101,10 @@ class ModelMergerServiceTest {
         val sortedModel = result.first()
         val actualFlowNodes = sortedModel.flowNodes.map { it.getRawName() }
         val actualVariables = sortedModel.variables.map { it.getRawName() }
+        val actualEscalations = sortedModel.escalations.map { it.getRawName() }
         Assertions.assertThat(actualFlowNodes).containsExactly("a-node", "m-node", "z-node")
         Assertions.assertThat(actualVariables).containsExactly("alphaVar", "zetaVar")
+        Assertions.assertThat(actualEscalations).containsExactly("aEscalation", "mEscalation", "zEscalation")
     }
 
     @Test
@@ -115,7 +131,11 @@ class ModelMergerServiceTest {
                 FlowNodeDefinition(id = "node-1"), // duplicate
                 timerFlowNode,
                 timerFlowNode // duplicate
-            )
+            ),
+            escalations = listOf(
+                EscalationDefinition(id = "TEST_ESC", name = "TEST_ESC", code = "500"),
+                EscalationDefinition(id = "TEST_ESC", name = "TEST_ESC", code = "500") // duplicate
+            ),
         )
 
         // when: merging models
@@ -131,7 +151,8 @@ class ModelMergerServiceTest {
                 flowNodes = listOf(
                     timerFlowNode,
                     FlowNodeDefinition(id = "node-1")
-                )
+                ),
+                escalations = listOf(EscalationDefinition(id = "TEST_ESC", name = "TEST_ESC", code = "500")),
             )
         )
     }
@@ -157,7 +178,11 @@ class ModelMergerServiceTest {
             flowNodes = listOf(
                 FlowNodeDefinition(id = "node-1"),
                 FlowNodeDefinition(id = "node-2")
-            )
+            ),
+            escalations = listOf(
+                EscalationDefinition(id = "ESC_1", name = "ESC_1", code = "100"),
+                EscalationDefinition(id = "ESC_2", name = "ESC_2", code = "200"),
+            ),
         )
 
         val secondModel = testBpmnModel(
@@ -177,7 +202,11 @@ class ModelMergerServiceTest {
             flowNodes = listOf(
                 FlowNodeDefinition(id = "node-2"), // duplicate from first model
                 FlowNodeDefinition(id = "node-3")
-            )
+            ),
+            escalations = listOf(
+                EscalationDefinition(id = "ESC_2", name = "ESC_2", code = "200"), // duplicate from first model
+                EscalationDefinition(id = "ESC_3", name = "ESC_3", code = "300"),
+            ),
         )
 
         // when: merging models
@@ -206,7 +235,12 @@ class ModelMergerServiceTest {
                     FlowNodeDefinition(id = "node-1"),
                     FlowNodeDefinition(id = "node-2"),
                     FlowNodeDefinition(id = "node-3")
-                )
+                ),
+                escalations = listOf(
+                    EscalationDefinition(id = "ESC_1", name = "ESC_1", code = "100"),
+                    EscalationDefinition(id = "ESC_2", name = "ESC_2", code = "200"),
+                    EscalationDefinition(id = "ESC_3", name = "ESC_3", code = "300"),
+                ),
             )
         )
     }


### PR DESCRIPTION
Closes #240

## Summary
- `mergeModelsWithSameProcessId()`: escalations were not merged across models with the same process ID — now uses `mergeDistinctBy` like all other types
- `sortContent()`: escalations were not sorted — now sorted by `getRawName()`
- Updated all four existing `ModelMergerServiceTest` cases to cover escalations (merge, sort, dedup within single model, dedup across models)

Non-breaking fix — purely additive.