### PR TITLE
feat: add compensation event support

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaApiBuilder.kt
@@ -29,6 +29,7 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
         ApiObjectType.TIMERS to TimersWriter(),
         ApiObjectType.ERRORS to ErrorsWriter(),
         ApiObjectType.ESCALATIONS to EscalationsWriter(),
+        ApiObjectType.COMPENSATIONS to CompensationsWriter(),
         ApiObjectType.SIGNALS to SignalsWriter(),
         ApiObjectType.VARIABLES to VariablesWriter(),
         ApiObjectType.FLOWS to FlowsWriter(),
@@ -349,6 +350,20 @@ class JavaApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Builder
                     .build()
             )
             return builder.build()
+        }
+    }
+
+    private inner class CompensationsWriter : ObjectWriter<TypeSpec.Builder> {
+
+        override val objectType = ApiObjectType.COMPENSATIONS
+        override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model.compensations.isNotEmpty()
+
+        override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
+            val compensationsBuilder = TypeSpec.classBuilder("Compensations").addModifiers(PUBLIC, STATIC, FINAL)
+            modelApi.model.compensations.forEach { compensation ->
+                compensationsBuilder.addField(createAttribute(compensation))
+            }
+            builder.addType(compensationsBuilder.build())
         }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinApiBuilder.kt
@@ -33,6 +33,7 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         ApiObjectType.TIMERS to TimersWriter(),
         ApiObjectType.ERRORS to ErrorsWriter(),
         ApiObjectType.ESCALATIONS to EscalationsWriter(),
+        ApiObjectType.COMPENSATIONS to CompensationsWriter(),
         ApiObjectType.SIGNALS to SignalsWriter(),
         ApiObjectType.VARIABLES to VariablesWriter(),
         ApiObjectType.FLOWS to FlowsWriter(),
@@ -334,6 +335,20 @@ class KotlinApiBuilder : CodeGenerationAdapter.AbstractApiBuilder<TypeSpec.Build
         }
 
         private fun FunSpec.Builder.addStringParameter(name: String) = addParameter(name, String::class)
+    }
+
+    private inner class CompensationsWriter : ObjectWriter<TypeSpec.Builder> {
+
+        override val objectType = ApiObjectType.COMPENSATIONS
+        override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model.compensations.isNotEmpty()
+
+        override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
+            val compensationsBuilder = TypeSpec.objectBuilder("Compensations")
+            modelApi.model.compensations.forEach { compensation ->
+                compensationsBuilder.addProperty(createAttribute(compensation))
+            }
+            builder.addType(compensationsBuilder.build())
+        }
     }
 
     private inner class TimersWriter : ObjectWriter<TypeSpec.Builder> {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -7,6 +7,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.DomElementUtils.with
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.extractAttribute
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findCompensateEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
@@ -54,6 +55,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         val signals = modelInstance.findSignalEventDefinitions()
         val errors = modelInstance.findErrorEventDefinition()
         val escalations = modelInstance.findEscalationEventDefinitions()
+        val compensations = modelInstance.findCompensateEventDefinitions()
         val timers = modelInstance.findTimerEventDefinition()
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
@@ -69,6 +71,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
             signals = signals,
             errors = errors,
             escalations = escalations,
+            compensations = compensations,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -7,6 +7,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.DomElementUtils.with
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.extractAttribute
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findCompensateEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
@@ -58,6 +59,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         val signals = modelInstance.findSignalEventDefinitions()
         val errors = modelInstance.findErrorEventDefinition()
         val escalations = modelInstance.findEscalationEventDefinitions()
+        val compensations = modelInstance.findCompensateEventDefinitions()
         val timers = modelInstance.findTimerEventDefinition()
         val variablesPerNode = extractVariablesPerNode(modelInstance)
 
@@ -73,6 +75,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
             signals = signals,
             errors = errors,
             escalations = escalations,
+            compensations = compensations,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -8,6 +8,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstance
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.filterByType
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelElementInstanceUtils.findFirstByType
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.MessageUtils.findAllMessagesWithSource
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findCompensateEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findErrorEventDefinition
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findEscalationEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findFlowNodes
@@ -45,6 +46,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         val allMessages = extractZeebeMessages(modelInstance)
         val allErrorEvents = modelInstance.findErrorEventDefinition()
         val allEscalationEvents = modelInstance.findEscalationEventDefinitions()
+        val allCompensationEvents = modelInstance.findCompensateEventDefinitions()
         val allTimerEvents = modelInstance.findTimerEventDefinition()
         val allSignalEvents = modelInstance.findSignalEventDefinitions()
         val allServiceTasks = findServiceTasks(modelInstance)
@@ -61,6 +63,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             signals = allSignalEvents,
             errors = allErrorEvents,
             escalations = allEscalationEvents,
+            compensations = allCompensationEvents,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -104,7 +104,13 @@ object ModelInstanceUtils {
         val compensateEvents = this.getModelElementsByType(CompensateEventDefinition::class.java)
         return compensateEvents.map {
             val elementId = it.parentElement?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            CompensationDefinition(id = elementId, activityRef = it.activity?.id)
+            CompensationDefinition(
+                id = elementId,
+                activityRef = it.activity?.id,
+                customProperties = buildMap {
+                    put(CompensationDefinition.WAIT_FOR_COMPLETION_KEY, it.isWaitForCompletion)
+                },
+            )
         }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.utils
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationType
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
@@ -104,10 +105,12 @@ object ModelInstanceUtils {
         val compensateEvents = this.getModelElementsByType(CompensateEventDefinition::class.java)
         return compensateEvents.map {
             val elementId = it.parentElement?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
+            val type = if (it.parentElement is BoundaryEvent) CompensationType.CATCHING else CompensationType.THROWING
             CompensationDefinition(
                 id = elementId,
-                activityRef = it.activity?.id,
+                type = type,
                 customProperties = buildMap {
+                    it.activity?.id?.let { ref -> put(CompensationDefinition.ACTIVITY_REF_KEY, ref) }
                     put(CompensationDefinition.WAIT_FOR_COMPLETION_KEY, it.isWaitForCompletion)
                 },
             )

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -1,6 +1,7 @@
 package io.github.emaarco.bpmn.adapter.outbound.engine.utils
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
+import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
@@ -9,6 +10,7 @@ import io.github.emaarco.bpmn.domain.shared.SignalDefinition
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
 import org.camunda.bpm.model.bpmn.instance.BoundaryEvent
+import org.camunda.bpm.model.bpmn.instance.CompensateEventDefinition
 import org.camunda.bpm.model.bpmn.instance.ErrorEventDefinition
 import org.camunda.bpm.model.bpmn.instance.EscalationEventDefinition
 import org.camunda.bpm.model.bpmn.instance.ExclusiveGateway
@@ -95,6 +97,14 @@ object ModelInstanceUtils {
         return escalationEvents.map {
             val elementId = it.parentElement?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             EscalationDefinition(id = elementId, name = it.escalation?.name, code = it.escalation?.escalationCode)
+        }
+    }
+
+    fun ModelInstance.findCompensateEventDefinitions(): List<CompensationDefinition> {
+        val compensateEvents = this.getModelElementsByType(CompensateEventDefinition::class.java)
+        return compensateEvents.map {
+            val elementId = it.parentElement?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
+            CompensationDefinition(id = elementId, activityRef = it.activity?.id)
         }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonMapper.kt
@@ -18,6 +18,7 @@ class BpmnJsonMapper {
             signals = model.signals.mapNotNull { it.toJson() },
             errors = model.errors.mapNotNull { it.toJson() },
             escalations = model.escalations.mapNotNull { it.toJson() },
+            compensations = model.compensations.mapNotNull { it.toJson() },
         )
     }
 
@@ -96,5 +97,10 @@ class BpmnJsonMapper {
         val (name, code) = getValue()
         if (name.isEmpty()) return null
         return EscalationJson(id = id ?: "", name = name, code = code)
+    }
+
+    private fun CompensationDefinition.toJson(): CompensationJson? {
+        val activityRef = getValue().takeIf { it.isNotEmpty() } ?: return null
+        return CompensationJson(id = id ?: "", activityRef = activityRef)
     }
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/model/BpmnModelJson.kt
@@ -11,6 +11,7 @@ data class BpmnModelJson(
     val signals: List<SignalJson>,
     val errors: List<ErrorJson>,
     val escalations: List<EscalationJson> = emptyList(),
+    val compensations: List<CompensationJson> = emptyList(),
     val sequenceFlows: List<SequenceFlowJson>,
 )
 
@@ -72,4 +73,10 @@ data class EscalationJson(
     val id: String,
     val name: String,
     val code: String,
+)
+
+@Serializable
+data class CompensationJson(
+    val id: String,
+    val activityRef: String,
 )

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
@@ -10,6 +10,7 @@ data class BpmnModel(
     val signals: List<SignalDefinition>,
     val errors: List<ErrorDefinition>,
     val escalations: List<EscalationDefinition> = emptyList(),
+    val compensations: List<CompensationDefinition> = emptyList(),
 ) {
     val serviceTasks: List<ServiceTaskDefinition>
         get() = flowNodes.mapNotNull { (it.properties as? FlowNodeProperties.ServiceTask)?.definition }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerService.kt
@@ -27,6 +27,7 @@ class ModelMergerService {
         val mergedSignals = mergeDistinctBy(models) { it.signals }
         val mergedErrors = mergeDistinctBy(models) { it.errors }
         val mergedEscalations = mergeDistinctBy(models) { it.escalations }
+        val mergedCompensations = mergeDistinctBy(models) { it.compensations }
         return BpmnModel(
             processId = processId,
             flowNodes = mergedFlowNodes,
@@ -35,6 +36,7 @@ class ModelMergerService {
             signals = mergedSignals,
             errors = mergedErrors,
             escalations = mergedEscalations,
+            compensations = mergedCompensations,
         )
     }
 
@@ -63,5 +65,6 @@ class ModelMergerService {
         signals = signals.sortedBy { it.getRawName() },
         errors = errors.sortedBy { it.getRawName() },
         escalations = escalations.sortedBy { it.getRawName() },
+        compensations = compensations.sortedBy { it.getRawName() },
     )
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/ApiObjectType.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/ApiObjectType.kt
@@ -12,6 +12,7 @@ enum class ApiObjectType {
     TIMERS,
     ERRORS,
     ESCALATIONS,
+    COMPENSATIONS,
     SIGNALS,
     VARIABLES
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/BpmnElementType.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/BpmnElementType.kt
@@ -17,6 +17,7 @@ enum class BpmnElementType(val bpmnTypeName: String) {
     SCRIPT_TASK("scriptTask"),
     MANUAL_TASK("manualTask"),
     BUSINESS_RULE_TASK("businessRuleTask"),
+    TASK("task"),
 
     // Events
     START_EVENT("startEvent"),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CompensationDefinition.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CompensationDefinition.kt
@@ -1,0 +1,14 @@
+package io.github.emaarco.bpmn.domain.shared
+
+import io.github.emaarco.bpmn.domain.utils.StringUtils.toUpperSnakeCase
+
+data class CompensationDefinition(
+    val id: String?,
+    private val activityRef: String?,
+    val customProperties: Map<String, Any?> = emptyMap(),
+) : VariableMapping<String> {
+    override fun getName() = activityRef?.toUpperSnakeCase() ?: ""
+    override fun getValue() = activityRef ?: ""
+    override fun getRawName() = activityRef ?: ""
+    fun hasActivityRef() = activityRef != null
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CompensationDefinition.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CompensationDefinition.kt
@@ -4,15 +4,20 @@ import io.github.emaarco.bpmn.domain.utils.StringUtils.toUpperSnakeCase
 
 data class CompensationDefinition(
     val id: String?,
-    private val activityRef: String?,
+    val type: CompensationType,
     val customProperties: Map<String, Any?> = emptyMap(),
 ) : VariableMapping<String> {
-    override fun getName() = activityRef?.toUpperSnakeCase() ?: ""
-    override fun getValue() = activityRef ?: ""
-    override fun getRawName() = activityRef ?: ""
-    fun hasActivityRef() = activityRef != null
+    override fun getName() = id?.toUpperSnakeCase() ?: ""
+    override fun getValue() = id ?: ""
+    override fun getRawName() = id ?: ""
 
     companion object {
+        const val ACTIVITY_REF_KEY = "activityRef"
         const val WAIT_FOR_COMPLETION_KEY = "waitForCompletion"
     }
+}
+
+enum class CompensationType {
+    CATCHING,
+    THROWING,
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CompensationDefinition.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CompensationDefinition.kt
@@ -11,4 +11,8 @@ data class CompensationDefinition(
     override fun getValue() = activityRef ?: ""
     override fun getRawName() = activityRef ?: ""
     fun hasActivityRef() = activityRef != null
+
+    companion object {
+        const val WAIT_FOR_COMPLETION_KEY = "waitForCompletion"
+    }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -126,8 +126,8 @@ class Camunda7ModelExtractorTest {
                     SequenceFlowDefinition("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration"),
                 ),
                 compensations = listOf(
-                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter"),
-                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null),
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter", customProperties = mapOf("waitForCompletion" to false)),
+                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null, customProperties = mapOf("waitForCompletion" to false)),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -3,6 +3,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationType
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KEY
@@ -68,9 +69,10 @@ class Camunda7ModelExtractorTest {
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true, EXCLUSIVE_KEY to false)),
                     FlowNodeDefinition("CompensationEndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
                         incoming = listOf("CallActivity_AbortRegistration")),
-                    FlowNodeDefinition("compensationEvent_onSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
-                        attachedToRef = "serviceTask_incrementSubscriptionCounter"),
-                    FlowNodeDefinition("compensationTask_decrementSubscriptionCounter", BpmnElementType.TASK,
+                    FlowNodeDefinition("CompensationEvent_OnSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
+                        attachedToRef = "serviceTask_incrementSubscriptionCounter",
+                        customProperties = mapOf(ASYNC_AFTER_KEY to true)),
+                    FlowNodeDefinition("CompensationTask_DecrementSubscriptionCounter", BpmnElementType.TASK,
                         variables = listOf(VariableDefinition("subscriptionId"))),
                     FlowNodeDefinition("EndEvent_RegistrationCompleted", BpmnElementType.END_EVENT,
                         properties = FlowNodeProperties.ServiceTask(c7ServiceTaskById["EndEvent_RegistrationCompleted"]!!),
@@ -87,7 +89,7 @@ class Camunda7ModelExtractorTest {
                         outgoing = listOf("EndEvent_RegistrationNotPossible")),
                     FlowNodeDefinition("serviceTask_incrementSubscriptionCounter", BpmnElementType.SERVICE_TASK,
                         properties = FlowNodeProperties.ServiceTask(c7ServiceTaskById["serviceTask_incrementSubscriptionCounter"]!!),
-                        attachedElements = listOf("compensationEvent_onSubscriptionCounter"),
+                        attachedElements = listOf("CompensationEvent_OnSubscriptionCounter"),
                         incoming = listOf("StartEvent_SubmitRegistrationForm"),
                         outgoing = listOf("SubProcess_Confirmation")),
                     FlowNodeDefinition("StartEvent_RequestReceived", BpmnElementType.START_EVENT,
@@ -126,8 +128,8 @@ class Camunda7ModelExtractorTest {
                     SequenceFlowDefinition("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration"),
                 ),
                 compensations = listOf(
-                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter", customProperties = mapOf("waitForCompletion" to false)),
-                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null, customProperties = mapOf("waitForCompletion" to false)),
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", CompensationType.THROWING, customProperties = mapOf("activityRef" to "serviceTask_incrementSubscriptionCounter", "waitForCompletion" to false)),
+                    CompensationDefinition("CompensationEvent_OnSubscriptionCounter", CompensationType.CATCHING, customProperties = mapOf("waitForCompletion" to false)),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KEY
@@ -33,6 +34,7 @@ class Camunda7ModelExtractorTest {
             ServiceTaskDefinition("Activity_SendWelcomeMail", customProperties = mapOf(IMPL_VALUE_KEY to "\${newsletterSendWelcomeMail}", IMPL_KIND_KEY to "DELEGATE_EXPRESSION")),
             ServiceTaskDefinition("Activity_SendConfirmationMail", customProperties = mapOf(IMPL_VALUE_KEY to "#{newsletterSendConfirmationMail}", IMPL_KIND_KEY to "EXTERNAL_TASK")),
             ServiceTaskDefinition("EndEvent_RegistrationCompleted", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.registrationCompleted", IMPL_KIND_KEY to "EXTERNAL_TASK")),
+            ServiceTaskDefinition("serviceTask_incrementSubscriptionCounter", customProperties = mapOf(IMPL_VALUE_KEY to "counterClass", IMPL_KIND_KEY to "DELEGATE_EXPRESSION")),
         )
         val c7ServiceTaskById = c7ServiceTasks.associateBy { it.id }
 
@@ -43,7 +45,7 @@ class Camunda7ModelExtractorTest {
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
                         variables = listOf(VariableDefinition("subscriptionId"), VariableDefinition("reasonCode"), VariableDefinition("abortResult")),
                         incoming = listOf("Timer_After3Days"),
-                        outgoing = listOf("EndEvent_RegistrationAborted"),
+                        outgoing = listOf("CompensationEndEvent_RegistrationAborted"),
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true)),
                     FlowNodeDefinition("Activity_ConfirmRegistration", BpmnElementType.USER_TASK,
                         variables = listOf(VariableDefinition("subscriptionId")),
@@ -64,8 +66,12 @@ class Camunda7ModelExtractorTest {
                         incoming = listOf("SubProcess_Confirmation"),
                         outgoing = listOf("EndEvent_RegistrationCompleted"),
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true, EXCLUSIVE_KEY to false)),
-                    FlowNodeDefinition("EndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
+                    FlowNodeDefinition("CompensationEndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
                         incoming = listOf("CallActivity_AbortRegistration")),
+                    FlowNodeDefinition("compensationEvent_onSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
+                        attachedToRef = "serviceTask_incrementSubscriptionCounter"),
+                    FlowNodeDefinition("compensationTask_decrementSubscriptionCounter", BpmnElementType.TASK,
+                        variables = listOf(VariableDefinition("subscriptionId"))),
                     FlowNodeDefinition("EndEvent_RegistrationCompleted", BpmnElementType.END_EVENT,
                         properties = FlowNodeProperties.ServiceTask(c7ServiceTaskById["EndEvent_RegistrationCompleted"]!!),
                         variables = listOf(VariableDefinition("subscriptionId")),
@@ -79,6 +85,11 @@ class Camunda7ModelExtractorTest {
                     FlowNodeDefinition("ErrorEvent_InvalidMail", BpmnElementType.BOUNDARY_EVENT,
                         attachedToRef = "SubProcess_Confirmation",
                         outgoing = listOf("EndEvent_RegistrationNotPossible")),
+                    FlowNodeDefinition("serviceTask_incrementSubscriptionCounter", BpmnElementType.SERVICE_TASK,
+                        properties = FlowNodeProperties.ServiceTask(c7ServiceTaskById["serviceTask_incrementSubscriptionCounter"]!!),
+                        attachedElements = listOf("compensationEvent_onSubscriptionCounter"),
+                        incoming = listOf("StartEvent_SubmitRegistrationForm"),
+                        outgoing = listOf("SubProcess_Confirmation")),
                     FlowNodeDefinition("StartEvent_RequestReceived", BpmnElementType.START_EVENT,
                         variables = listOf(VariableDefinition("subscriptionId")),
                         parentId = "SubProcess_Confirmation",
@@ -86,10 +97,10 @@ class Camunda7ModelExtractorTest {
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true)),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnElementType.START_EVENT,
                         variables = listOf(VariableDefinition("subscriptionId")),
-                        outgoing = listOf("SubProcess_Confirmation")),
+                        outgoing = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnElementType.SUB_PROCESS,
                         attachedElements = listOf("ErrorEvent_InvalidMail", "Timer_After3Days"),
-                        incoming = listOf("StartEvent_SubmitRegistrationForm"),
+                        incoming = listOf("serviceTask_incrementSubscriptionCounter"),
                         outgoing = listOf("Activity_SendWelcomeMail")),
                     FlowNodeDefinition("Timer_After3Days", BpmnElementType.BOUNDARY_EVENT,
                         properties = FlowNodeProperties.Timer(TimerDefinition("Timer_After3Days", "Duration", "\${testVariable}")),
@@ -100,6 +111,23 @@ class Camunda7ModelExtractorTest {
                         attachedToRef = "Activity_ConfirmRegistration",
                         parentId = "SubProcess_Confirmation",
                         outgoing = listOf("Activity_SendConfirmationMail")),
+                ),
+                sequenceFlows = listOf(
+                    SequenceFlowDefinition("Flow_05i3x1y", "StartEvent_RequestReceived", "Activity_SendConfirmationMail"),
+                    SequenceFlowDefinition("Flow_09cuvzp", "SubProcess_Confirmation", "Activity_SendWelcomeMail"),
+                    SequenceFlowDefinition("Flow_0i2ctuv", "ErrorEvent_InvalidMail", "EndEvent_RegistrationNotPossible"),
+                    SequenceFlowDefinition("Flow_0x4ewvb", "Timer_EveryDay", "Activity_SendConfirmationMail"),
+                    SequenceFlowDefinition("Flow_0zdmt0t", "serviceTask_incrementSubscriptionCounter", "SubProcess_Confirmation"),
+                    SequenceFlowDefinition("Flow_1bckm43", "Activity_SendConfirmationMail", "Activity_ConfirmRegistration"),
+                    SequenceFlowDefinition("Flow_1bsb8no", "CallActivity_AbortRegistration", "CompensationEndEvent_RegistrationAborted"),
+                    SequenceFlowDefinition("Flow_1cpwe57", "Activity_ConfirmRegistration", "EndEvent_SubscriptionConfirmed"),
+                    SequenceFlowDefinition("Flow_1csfyyz", "StartEvent_SubmitRegistrationForm", "serviceTask_incrementSubscriptionCounter"),
+                    SequenceFlowDefinition("Flow_1i7hjid", "Activity_SendWelcomeMail", "EndEvent_RegistrationCompleted"),
+                    SequenceFlowDefinition("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration"),
+                ),
+                compensations = listOf(
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter"),
+                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -2,17 +2,18 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KEY
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_KEY
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.EXCLUSIVE_KEY
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
+import io.github.emaarco.bpmn.domain.shared.SequenceFlowDefinition
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_KIND_KEY
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_VALUE_KEY
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
-import io.github.emaarco.bpmn.domain.shared.SequenceFlowDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.testNewsletterBpmnModel
 import org.assertj.core.api.Assertions.assertThat
@@ -33,6 +34,7 @@ class OperatonModelExtractorTest {
             ServiceTaskDefinition("Activity_SendWelcomeMail", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendWelcomeMail", IMPL_KIND_KEY to "DELEGATE_EXPRESSION")),
             ServiceTaskDefinition("Activity_SendConfirmationMail", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendConfirmationMail", IMPL_KIND_KEY to "EXTERNAL_TASK")),
             ServiceTaskDefinition("EndEvent_RegistrationCompleted", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.registrationCompleted", IMPL_KIND_KEY to "EXTERNAL_TASK")),
+            ServiceTaskDefinition("serviceTask_incrementSubscriptionCounter", customProperties = mapOf(IMPL_VALUE_KEY to "counterClass", IMPL_KIND_KEY to "DELEGATE_EXPRESSION")),
         )
         val opServiceTaskById = opServiceTasks.associateBy { it.id }
 
@@ -43,7 +45,7 @@ class OperatonModelExtractorTest {
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
                         variables = listOf(VariableDefinition("subscriptionId"), VariableDefinition("reasonCode"), VariableDefinition("abortResult")),
                         incoming = listOf("Timer_After3Days"),
-                        outgoing = listOf("EndEvent_RegistrationAborted"),
+                        outgoing = listOf("CompensationEndEvent_RegistrationAborted"),
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true)),
                     FlowNodeDefinition("Activity_ConfirmRegistration", BpmnElementType.USER_TASK,
                         variables = listOf(VariableDefinition("subscriptionId")),
@@ -64,8 +66,12 @@ class OperatonModelExtractorTest {
                         incoming = listOf("SubProcess_Confirmation"),
                         outgoing = listOf("EndEvent_RegistrationCompleted"),
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true, EXCLUSIVE_KEY to false)),
-                    FlowNodeDefinition("EndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
+                    FlowNodeDefinition("CompensationEndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
                         incoming = listOf("CallActivity_AbortRegistration")),
+                    FlowNodeDefinition("compensationEvent_onSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
+                        attachedToRef = "serviceTask_incrementSubscriptionCounter"),
+                    FlowNodeDefinition("compensationTask_decrementSubscriptionCounter", BpmnElementType.TASK,
+                        variables = listOf(VariableDefinition("subscriptionId"))),
                     FlowNodeDefinition("EndEvent_RegistrationCompleted", BpmnElementType.END_EVENT,
                         properties = FlowNodeProperties.ServiceTask(opServiceTaskById["EndEvent_RegistrationCompleted"]!!),
                         variables = listOf(VariableDefinition("subscriptionId")),
@@ -79,6 +85,11 @@ class OperatonModelExtractorTest {
                     FlowNodeDefinition("ErrorEvent_InvalidMail", BpmnElementType.BOUNDARY_EVENT,
                         attachedToRef = "SubProcess_Confirmation",
                         outgoing = listOf("EndEvent_RegistrationNotPossible")),
+                    FlowNodeDefinition("serviceTask_incrementSubscriptionCounter", BpmnElementType.SERVICE_TASK,
+                        properties = FlowNodeProperties.ServiceTask(opServiceTaskById["serviceTask_incrementSubscriptionCounter"]!!),
+                        attachedElements = listOf("compensationEvent_onSubscriptionCounter"),
+                        incoming = listOf("StartEvent_SubmitRegistrationForm"),
+                        outgoing = listOf("SubProcess_Confirmation")),
                     FlowNodeDefinition("StartEvent_RequestReceived", BpmnElementType.START_EVENT,
                         variables = listOf(VariableDefinition("subscriptionId")),
                         parentId = "SubProcess_Confirmation",
@@ -86,10 +97,10 @@ class OperatonModelExtractorTest {
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true)),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnElementType.START_EVENT,
                         variables = listOf(VariableDefinition("subscriptionId")),
-                        outgoing = listOf("SubProcess_Confirmation")),
+                        outgoing = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnElementType.SUB_PROCESS,
                         attachedElements = listOf("ErrorEvent_InvalidMail", "Timer_After3Days"),
-                        incoming = listOf("StartEvent_SubmitRegistrationForm"),
+                        incoming = listOf("serviceTask_incrementSubscriptionCounter"),
                         outgoing = listOf("Activity_SendWelcomeMail")),
                     FlowNodeDefinition("Timer_After3Days", BpmnElementType.BOUNDARY_EVENT,
                         properties = FlowNodeProperties.Timer(TimerDefinition("Timer_After3Days", "Duration", "\${testVariable}")),
@@ -100,6 +111,23 @@ class OperatonModelExtractorTest {
                         attachedToRef = "Activity_ConfirmRegistration",
                         parentId = "SubProcess_Confirmation",
                         outgoing = listOf("Activity_SendConfirmationMail")),
+                ),
+                sequenceFlows = listOf(
+                    SequenceFlowDefinition("Flow_05i3x1y", "StartEvent_RequestReceived", "Activity_SendConfirmationMail"),
+                    SequenceFlowDefinition("Flow_09cuvzp", "SubProcess_Confirmation", "Activity_SendWelcomeMail"),
+                    SequenceFlowDefinition("Flow_0i2ctuv", "ErrorEvent_InvalidMail", "EndEvent_RegistrationNotPossible"),
+                    SequenceFlowDefinition("Flow_0x4ewvb", "Timer_EveryDay", "Activity_SendConfirmationMail"),
+                    SequenceFlowDefinition("Flow_0zdmt0t", "serviceTask_incrementSubscriptionCounter", "SubProcess_Confirmation"),
+                    SequenceFlowDefinition("Flow_1bckm43", "Activity_SendConfirmationMail", "Activity_ConfirmRegistration"),
+                    SequenceFlowDefinition("Flow_1bsb8no", "CallActivity_AbortRegistration", "CompensationEndEvent_RegistrationAborted"),
+                    SequenceFlowDefinition("Flow_1cpwe57", "Activity_ConfirmRegistration", "EndEvent_SubscriptionConfirmed"),
+                    SequenceFlowDefinition("Flow_1csfyyz", "StartEvent_SubmitRegistrationForm", "serviceTask_incrementSubscriptionCounter"),
+                    SequenceFlowDefinition("Flow_1i7hjid", "Activity_SendWelcomeMail", "EndEvent_RegistrationCompleted"),
+                    SequenceFlowDefinition("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration"),
+                ),
+                compensations = listOf(
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter"),
+                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -3,6 +3,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationType
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KEY
@@ -68,9 +69,9 @@ class OperatonModelExtractorTest {
                         customProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true, EXCLUSIVE_KEY to false)),
                     FlowNodeDefinition("CompensationEndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
                         incoming = listOf("CallActivity_AbortRegistration")),
-                    FlowNodeDefinition("compensationEvent_onSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
+                    FlowNodeDefinition("CompensationEvent_OnSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
                         attachedToRef = "serviceTask_incrementSubscriptionCounter"),
-                    FlowNodeDefinition("compensationTask_decrementSubscriptionCounter", BpmnElementType.TASK,
+                    FlowNodeDefinition("CompensationTask_DecrementSubscriptionCounter", BpmnElementType.TASK,
                         variables = listOf(VariableDefinition("subscriptionId"))),
                     FlowNodeDefinition("EndEvent_RegistrationCompleted", BpmnElementType.END_EVENT,
                         properties = FlowNodeProperties.ServiceTask(opServiceTaskById["EndEvent_RegistrationCompleted"]!!),
@@ -87,7 +88,7 @@ class OperatonModelExtractorTest {
                         outgoing = listOf("EndEvent_RegistrationNotPossible")),
                     FlowNodeDefinition("serviceTask_incrementSubscriptionCounter", BpmnElementType.SERVICE_TASK,
                         properties = FlowNodeProperties.ServiceTask(opServiceTaskById["serviceTask_incrementSubscriptionCounter"]!!),
-                        attachedElements = listOf("compensationEvent_onSubscriptionCounter"),
+                        attachedElements = listOf("CompensationEvent_OnSubscriptionCounter"),
                         incoming = listOf("StartEvent_SubmitRegistrationForm"),
                         outgoing = listOf("SubProcess_Confirmation")),
                     FlowNodeDefinition("StartEvent_RequestReceived", BpmnElementType.START_EVENT,
@@ -126,8 +127,8 @@ class OperatonModelExtractorTest {
                     SequenceFlowDefinition("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration"),
                 ),
                 compensations = listOf(
-                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter", customProperties = mapOf("waitForCompletion" to false)),
-                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null, customProperties = mapOf("waitForCompletion" to false)),
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", CompensationType.THROWING, customProperties = mapOf("activityRef" to "serviceTask_incrementSubscriptionCounter", "waitForCompletion" to false)),
+                    CompensationDefinition("CompensationEvent_OnSubscriptionCounter", CompensationType.CATCHING, customProperties = mapOf("waitForCompletion" to false)),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -126,8 +126,8 @@ class OperatonModelExtractorTest {
                     SequenceFlowDefinition("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration"),
                 ),
                 compensations = listOf(
-                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter"),
-                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null),
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter", customProperties = mapOf("waitForCompletion" to false)),
+                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null, customProperties = mapOf("waitForCompletion" to false)),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
@@ -37,6 +38,7 @@ class ZeebeModelExtractorTest {
             ServiceTaskDefinition("Activity_SendConfirmationMail", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendConfirmationMail", IMPL_KIND_KEY to "JOB_WORKER")),
             ServiceTaskDefinition("Activity_SendWelcomeMail", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendWelcomeMail", IMPL_KIND_KEY to "JOB_WORKER")),
             ServiceTaskDefinition("EndEvent_RegistrationCompleted", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.registrationCompleted", IMPL_KIND_KEY to "JOB_WORKER")),
+            ServiceTaskDefinition("serviceTask_incrementSubscriptionCounter", customProperties = mapOf(IMPL_VALUE_KEY to "newsletter.incrementCounter", IMPL_KIND_KEY to "JOB_WORKER")),
         )
         assertThat(bpmnModel).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(
             testNewsletterBpmnModel(
@@ -45,7 +47,7 @@ class ZeebeModelExtractorTest {
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
                         variables = listOf(VariableDefinition("subscriptionId")),
                         incoming = listOf("Timer_After3Days"),
-                        outgoing = listOf("EndEvent_RegistrationAborted")),
+                        outgoing = listOf("CompensationEndEvent_RegistrationAborted")),
                     FlowNodeDefinition("Activity_ConfirmRegistration", BpmnElementType.RECEIVE_TASK,
                         attachedElements = listOf("Timer_EveryDay"),
                         parentId = "SubProcess_Confirmation",
@@ -62,8 +64,12 @@ class ZeebeModelExtractorTest {
                         variables = listOf(VariableDefinition("subscriptionId")),
                         incoming = listOf("SubProcess_Confirmation"),
                         outgoing = listOf("EndEvent_RegistrationCompleted")),
-                    FlowNodeDefinition("EndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
+                    FlowNodeDefinition("CompensationEndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
                         incoming = listOf("CallActivity_AbortRegistration")),
+                    FlowNodeDefinition("compensationEvent_onSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
+                        attachedToRef = "serviceTask_incrementSubscriptionCounter"),
+                    FlowNodeDefinition("compensationTask_decrementSubscriptionCounter", BpmnElementType.TASK,
+                        variables = listOf(VariableDefinition("subscriptionId"))),
                     FlowNodeDefinition("EndEvent_RegistrationCompleted", BpmnElementType.END_EVENT,
                         properties = FlowNodeProperties.ServiceTask(zeebeServiceTasks[2]),
                         variables = listOf(VariableDefinition("subscriptionId")),
@@ -77,16 +83,21 @@ class ZeebeModelExtractorTest {
                         attachedToRef = "SubProcess_Confirmation",
                         variables = listOf(VariableDefinition("subscriptionId")),
                         outgoing = listOf("EndEvent_RegistrationNotPossible")),
+                    FlowNodeDefinition("serviceTask_incrementSubscriptionCounter", BpmnElementType.SERVICE_TASK,
+                        properties = FlowNodeProperties.ServiceTask(zeebeServiceTasks[3]),
+                        attachedElements = listOf("compensationEvent_onSubscriptionCounter"),
+                        incoming = listOf("StartEvent_SubmitRegistrationForm"),
+                        outgoing = listOf("SubProcess_Confirmation")),
                     FlowNodeDefinition("StartEvent_RequestReceived", BpmnElementType.START_EVENT,
                         variables = listOf(VariableDefinition("subscriptionId")),
                         parentId = "SubProcess_Confirmation",
                         outgoing = listOf("Activity_SendConfirmationMail")),
                     FlowNodeDefinition("StartEvent_SubmitRegistrationForm", BpmnElementType.START_EVENT,
                         variables = listOf(VariableDefinition("subscriptionId")),
-                        outgoing = listOf("SubProcess_Confirmation")),
+                        outgoing = listOf("serviceTask_incrementSubscriptionCounter")),
                     FlowNodeDefinition("SubProcess_Confirmation", BpmnElementType.SUB_PROCESS,
                         attachedElements = listOf("ErrorEvent_InvalidMail", "Timer_After3Days"),
-                        incoming = listOf("StartEvent_SubmitRegistrationForm"),
+                        incoming = listOf("serviceTask_incrementSubscriptionCounter"),
                         outgoing = listOf("Activity_SendWelcomeMail")),
                     FlowNodeDefinition("Timer_After3Days", BpmnElementType.BOUNDARY_EVENT,
                         properties = FlowNodeProperties.Timer(TimerDefinition("Timer_After3Days", "Duration", "=testVariable")),
@@ -98,10 +109,27 @@ class ZeebeModelExtractorTest {
                         parentId = "SubProcess_Confirmation",
                         outgoing = listOf("Activity_SendConfirmationMail")),
                 ),
+                sequenceFlows = listOf(
+                    SequenceFlowDefinition("Flow_05i3x1y", "StartEvent_RequestReceived", "Activity_SendConfirmationMail"),
+                    SequenceFlowDefinition("Flow_09cuvzp", "SubProcess_Confirmation", "Activity_SendWelcomeMail"),
+                    SequenceFlowDefinition("Flow_0i2ctuv", "ErrorEvent_InvalidMail", "EndEvent_RegistrationNotPossible"),
+                    SequenceFlowDefinition("Flow_0x4ewvb", "Timer_EveryDay", "Activity_SendConfirmationMail"),
+                    SequenceFlowDefinition("Flow_0zdmt0t", "serviceTask_incrementSubscriptionCounter", "SubProcess_Confirmation"),
+                    SequenceFlowDefinition("Flow_1bckm43", "Activity_SendConfirmationMail", "Activity_ConfirmRegistration"),
+                    SequenceFlowDefinition("Flow_1bsb8no", "CallActivity_AbortRegistration", "CompensationEndEvent_RegistrationAborted"),
+                    SequenceFlowDefinition("Flow_1cpwe57", "Activity_ConfirmRegistration", "EndEvent_SubscriptionConfirmed"),
+                    SequenceFlowDefinition("Flow_1csfyyz", "StartEvent_SubmitRegistrationForm", "serviceTask_incrementSubscriptionCounter"),
+                    SequenceFlowDefinition("Flow_1i7hjid", "Activity_SendWelcomeMail", "EndEvent_RegistrationCompleted"),
+                    SequenceFlowDefinition("Flow_1l1lj4m", "Timer_After3Days", "CallActivity_AbortRegistration"),
+                ),
                 messages = listOf(
                     MessageDefinition("StartEvent_SubmitRegistrationForm", "Message_FormSubmitted"),
                     MessageDefinition("Activity_ConfirmRegistration", "Message_SubscriptionConfirmed", customProperties = mapOf("correlationKey" to "=subscriptionId")),
-                )
+                ),
+                compensations = listOf(
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter"),
+                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null),
+                ),
             )
         )
     }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -127,8 +127,8 @@ class ZeebeModelExtractorTest {
                     MessageDefinition("Activity_ConfirmRegistration", "Message_SubscriptionConfirmed", customProperties = mapOf("correlationKey" to "=subscriptionId")),
                 ),
                 compensations = listOf(
-                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter"),
-                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null),
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter", customProperties = mapOf("waitForCompletion" to false)),
+                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null, customProperties = mapOf("waitForCompletion" to false)),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -3,6 +3,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationType
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
@@ -66,9 +67,9 @@ class ZeebeModelExtractorTest {
                         outgoing = listOf("EndEvent_RegistrationCompleted")),
                     FlowNodeDefinition("CompensationEndEvent_RegistrationAborted", BpmnElementType.END_EVENT,
                         incoming = listOf("CallActivity_AbortRegistration")),
-                    FlowNodeDefinition("compensationEvent_onSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
+                    FlowNodeDefinition("CompensationEvent_OnSubscriptionCounter", BpmnElementType.BOUNDARY_EVENT,
                         attachedToRef = "serviceTask_incrementSubscriptionCounter"),
-                    FlowNodeDefinition("compensationTask_decrementSubscriptionCounter", BpmnElementType.TASK,
+                    FlowNodeDefinition("CompensationTask_DecrementSubscriptionCounter", BpmnElementType.TASK,
                         variables = listOf(VariableDefinition("subscriptionId"))),
                     FlowNodeDefinition("EndEvent_RegistrationCompleted", BpmnElementType.END_EVENT,
                         properties = FlowNodeProperties.ServiceTask(zeebeServiceTasks[2]),
@@ -85,7 +86,7 @@ class ZeebeModelExtractorTest {
                         outgoing = listOf("EndEvent_RegistrationNotPossible")),
                     FlowNodeDefinition("serviceTask_incrementSubscriptionCounter", BpmnElementType.SERVICE_TASK,
                         properties = FlowNodeProperties.ServiceTask(zeebeServiceTasks[3]),
-                        attachedElements = listOf("compensationEvent_onSubscriptionCounter"),
+                        attachedElements = listOf("CompensationEvent_OnSubscriptionCounter"),
                         incoming = listOf("StartEvent_SubmitRegistrationForm"),
                         outgoing = listOf("SubProcess_Confirmation")),
                     FlowNodeDefinition("StartEvent_RequestReceived", BpmnElementType.START_EVENT,
@@ -127,8 +128,8 @@ class ZeebeModelExtractorTest {
                     MessageDefinition("Activity_ConfirmRegistration", "Message_SubscriptionConfirmed", customProperties = mapOf("correlationKey" to "=subscriptionId")),
                 ),
                 compensations = listOf(
-                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", "serviceTask_incrementSubscriptionCounter", customProperties = mapOf("waitForCompletion" to false)),
-                    CompensationDefinition("compensationEvent_onSubscriptionCounter", null, customProperties = mapOf("waitForCompletion" to false)),
+                    CompensationDefinition("CompensationEndEvent_RegistrationAborted", CompensationType.THROWING, customProperties = mapOf("activityRef" to "serviceTask_incrementSubscriptionCounter", "waitForCompletion" to false)),
+                    CompensationDefinition("CompensationEvent_OnSubscriptionCounter", CompensationType.CATCHING, customProperties = mapOf("waitForCompletion" to false)),
                 ),
             )
         )

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
@@ -3,6 +3,7 @@ package io.github.emaarco.bpmn.domain
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KEY
@@ -27,6 +28,7 @@ fun testBpmnModel(
     signals: List<SignalDefinition> = listOf(SignalDefinition(id = "signalId", name = "signalName")),
     errors: List<ErrorDefinition> = listOf(ErrorDefinition(id = "errorId", name = "errorName", code = "errorCode")),
     escalations: List<EscalationDefinition> = emptyList(),
+    compensations: List<CompensationDefinition> = emptyList(),
 ) = BpmnModel(
     processId = processId,
     flowNodes = flowNodes,
@@ -35,6 +37,7 @@ fun testBpmnModel(
     signals = signals,
     errors = errors,
     escalations = escalations,
+    compensations = compensations,
 )
 
 fun testBpmnModelApi(
@@ -127,6 +130,7 @@ fun testNewsletterBpmnModel(
         ErrorDefinition("ErrorEvent_InvalidMail", "Error_InvalidMail", "500")
     ),
     escalations: List<EscalationDefinition> = emptyList(),
+    compensations: List<CompensationDefinition> = emptyList(),
 ) = testBpmnModel(
     processId = processId,
     flowNodes = flowNodes,
@@ -135,4 +139,5 @@ fun testNewsletterBpmnModel(
     signals = signals,
     errors = errors,
     escalations = escalations,
+    compensations = compensations,
 )

--- a/shared/bpmn/c7-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c7-subscribe-newsletter.bpmn
@@ -15,7 +15,7 @@
       <bpmn:messageEventDefinition messageRef="Message_04tc0t0" />
     </bpmn:startEvent>
     <bpmn:subProcess id="SubProcess_Confirmation" name="Subscription Confirmation">
-      <bpmn:incoming>Flow_1csfyyz</bpmn:incoming>
+      <bpmn:incoming>Flow_0zdmt0t</bpmn:incoming>
       <bpmn:outgoing>Flow_09cuvzp</bpmn:outgoing>
       <bpmn:startEvent id="StartEvent_RequestReceived" name="Subscription requested" camunda:asyncBefore="true">
         <bpmn:extensionElements>
@@ -59,18 +59,15 @@
         <bpmn:outgoing>Flow_1cpwe57</bpmn:outgoing>
       </bpmn:userTask>
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_1csfyyz" sourceRef="StartEvent_SubmitRegistrationForm" targetRef="SubProcess_Confirmation" />
+    <bpmn:sequenceFlow id="Flow_1csfyyz" sourceRef="StartEvent_SubmitRegistrationForm" targetRef="serviceTask_incrementSubscriptionCounter" />
     <bpmn:boundaryEvent id="Timer_After3Days" name="After 3 days" attachedToRef="SubProcess_Confirmation">
       <bpmn:outgoing>Flow_1l1lj4m</bpmn:outgoing>
       <bpmn:timerEventDefinition>
         <bpmn:timeDuration>${testVariable}</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:endEvent id="EndEvent_RegistrationAborted" name="Registration aborted">
-      <bpmn:incoming>Flow_1bsb8no</bpmn:incoming>
-    </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1l1lj4m" sourceRef="Timer_After3Days" targetRef="CallActivity_AbortRegistration" />
-    <bpmn:sequenceFlow id="Flow_1bsb8no" sourceRef="CallActivity_AbortRegistration" targetRef="EndEvent_RegistrationAborted" />
+    <bpmn:sequenceFlow id="Flow_1bsb8no" sourceRef="CallActivity_AbortRegistration" targetRef="CompensationEndEvent_RegistrationAborted" />
     <bpmn:serviceTask id="Activity_SendWelcomeMail" name="Send Welcome-Mail" camunda:asyncBefore="true" camunda:asyncAfter="true" camunda:exclusive="false" camunda:delegateExpression="${newsletterSendWelcomeMail}">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -109,14 +106,48 @@
       <bpmn:incoming>Flow_1l1lj4m</bpmn:incoming>
       <bpmn:outgoing>Flow_1bsb8no</bpmn:outgoing>
     </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0zdmt0t" sourceRef="serviceTask_incrementSubscriptionCounter" targetRef="SubProcess_Confirmation" />
+    <bpmn:serviceTask id="serviceTask_incrementSubscriptionCounter" name="Increment subscription counter" camunda:delegateExpression="counterClass">
+      <bpmn:incoming>Flow_1csfyyz</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zdmt0t</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="CompensationEndEvent_RegistrationAborted" name="Registration aborted">
+      <bpmn:incoming>Flow_1bsb8no</bpmn:incoming>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0ych49i" activityRef="serviceTask_incrementSubscriptionCounter" />
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="compensationEvent_onSubscriptionCounter" name="Registration aborted" camunda:asyncAfter="true" attachedToRef="serviceTask_incrementSubscriptionCounter">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ffa569" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="compensationTask_decrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="subscriptionId">${subscriptionId}</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="compensationEvent_onSubscriptionCounter" targetRef="compensationTask_decrementSubscriptionCounter" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newsletterSubscription">
+      <bpmndi:BPMNShape id="Activity_1urwd9r_di" bpmnElement="serviceTask_incrementSubscriptionCounter">
+        <dc:Bounds x="140" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_12xytcj_di" bpmnElement="StartEvent_SubmitRegistrationForm">
-        <dc:Bounds x="182" y="302" width="36" height="36" />
+        <dc:Bounds x="42" y="302" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="156" y="345" width="88" height="27" />
+          <dc:Bounds x="16" y="345" width="88" height="27" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1geox7n_di" bpmnElement="CompensationEndEvent_RegistrationAborted">
+        <dc:Bounds x="982" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="971" y="145" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="compensationTask_decrementSubscriptionCounter">
+        <dc:Bounds x="290" y="470" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1gbt6dx_di" bpmnElement="SubProcess_Confirmation" isExpanded="true">
         <dc:Bounds x="290" y="220" width="480" height="218" />
@@ -165,12 +196,6 @@
         <di:waypoint x="650" y="320" />
         <di:waypoint x="692" y="320" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1ew0xir_di" bpmnElement="EndEvent_RegistrationAborted">
-        <dc:Bounds x="982" y="102" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="971" y="145" width="59" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_105q7u2_di" bpmnElement="Activity_SendWelcomeMail">
         <dc:Bounds x="820" y="280" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -190,6 +215,11 @@
       <bpmndi:BPMNShape id="Activity_0b3apez_di" bpmnElement="CallActivity_AbortRegistration">
         <dc:Bounds x="820" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0vlmtgi_di" bpmnElement="Association_0vlmtgi">
+        <di:waypoint x="190" y="378" />
+        <di:waypoint x="190" y="510" />
+        <di:waypoint x="290" y="510" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1yodhht_di" bpmnElement="ErrorEvent_InvalidMail">
         <dc:Bounds x="692" y="420" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -202,9 +232,15 @@
           <dc:Bounds x="690" y="193" width="59" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="compensationEvent_onSubscriptionCounter">
+        <dc:Bounds x="172" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="385" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1csfyyz_di" bpmnElement="Flow_1csfyyz">
-        <di:waypoint x="218" y="320" />
-        <di:waypoint x="290" y="320" />
+        <di:waypoint x="78" y="320" />
+        <di:waypoint x="140" y="320" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1l1lj4m_di" bpmnElement="Flow_1l1lj4m">
         <di:waypoint x="670" y="202" />
@@ -227,6 +263,10 @@
         <di:waypoint x="710" y="456" />
         <di:waypoint x="710" y="520" />
         <di:waypoint x="852" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zdmt0t_di" bpmnElement="Flow_0zdmt0t">
+        <di:waypoint x="240" y="320" />
+        <di:waypoint x="290" y="320" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/shared/bpmn/c7-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c7-subscribe-newsletter.bpmn
@@ -115,39 +115,25 @@
       <bpmn:incoming>Flow_1bsb8no</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_0ych49i" activityRef="serviceTask_incrementSubscriptionCounter" />
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="compensationEvent_onSubscriptionCounter" name="Registration aborted" camunda:asyncAfter="true" attachedToRef="serviceTask_incrementSubscriptionCounter">
+    <bpmn:boundaryEvent id="CompensationEvent_OnSubscriptionCounter" name="Registration aborted" camunda:asyncAfter="true" attachedToRef="serviceTask_incrementSubscriptionCounter">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ffa569" />
     </bpmn:boundaryEvent>
-    <bpmn:task id="compensationTask_decrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
+    <bpmn:task id="CompensationTask_DecrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="subscriptionId">${subscriptionId}</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
     </bpmn:task>
-    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="compensationEvent_onSubscriptionCounter" targetRef="compensationTask_decrementSubscriptionCounter" />
+    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="CompensationEvent_OnSubscriptionCounter" targetRef="CompensationTask_DecrementSubscriptionCounter" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newsletterSubscription">
-      <bpmndi:BPMNShape id="Activity_1urwd9r_di" bpmnElement="serviceTask_incrementSubscriptionCounter">
-        <dc:Bounds x="140" y="280" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_12xytcj_di" bpmnElement="StartEvent_SubmitRegistrationForm">
         <dc:Bounds x="42" y="302" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="16" y="345" width="88" height="27" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1geox7n_di" bpmnElement="CompensationEndEvent_RegistrationAborted">
-        <dc:Bounds x="982" y="102" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="971" y="145" width="59" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="compensationTask_decrementSubscriptionCounter">
-        <dc:Bounds x="290" y="470" width="100" height="80" />
-        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1gbt6dx_di" bpmnElement="SubProcess_Confirmation" isExpanded="true">
         <dc:Bounds x="290" y="220" width="480" height="218" />
@@ -215,11 +201,26 @@
       <bpmndi:BPMNShape id="Activity_0b3apez_di" bpmnElement="CallActivity_AbortRegistration">
         <dc:Bounds x="820" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0vlmtgi_di" bpmnElement="Association_0vlmtgi">
-        <di:waypoint x="190" y="378" />
-        <di:waypoint x="190" y="510" />
-        <di:waypoint x="290" y="510" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1urwd9r_di" bpmnElement="serviceTask_incrementSubscriptionCounter">
+        <dc:Bounds x="140" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1geox7n_di" bpmnElement="CompensationEndEvent_RegistrationAborted">
+        <dc:Bounds x="982" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="971" y="145" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="CompensationTask_DecrementSubscriptionCounter">
+        <dc:Bounds x="290" y="470" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="CompensationEvent_OnSubscriptionCounter">
+        <dc:Bounds x="172" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="385" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1yodhht_di" bpmnElement="ErrorEvent_InvalidMail">
         <dc:Bounds x="692" y="420" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -230,12 +231,6 @@
         <dc:Bounds x="652" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="690" y="193" width="59" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="compensationEvent_onSubscriptionCounter">
-        <dc:Bounds x="172" y="342" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="200" y="385" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1csfyyz_di" bpmnElement="Flow_1csfyyz">
@@ -267,6 +262,11 @@
       <bpmndi:BPMNEdge id="Flow_0zdmt0t_di" bpmnElement="Flow_0zdmt0t">
         <di:waypoint x="240" y="320" />
         <di:waypoint x="290" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0vlmtgi_di" bpmnElement="Association_0vlmtgi">
+        <di:waypoint x="190" y="378" />
+        <di:waypoint x="190" y="510" />
+        <di:waypoint x="290" y="510" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/shared/bpmn/c8-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c8-subscribe-newsletter.bpmn
@@ -7,10 +7,7 @@
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmn:process id="newsletterSubscription" isExecutable="true">
-    <bpmn:endEvent id="EndEvent_RegistrationAborted" name="Registration aborted">
-      <bpmn:incoming>Flow_1bsb8no</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1bsb8no" sourceRef="CallActivity_AbortRegistration" targetRef="EndEvent_RegistrationAborted" />
+    <bpmn:sequenceFlow id="Flow_1bsb8no" sourceRef="CallActivity_AbortRegistration" targetRef="CompensationEndEvent_RegistrationAborted" />
     <bpmn:serviceTask id="Activity_SendWelcomeMail" name="Send Welcome-Mail">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="newsletter.sendWelcomeMail" />
@@ -32,7 +29,7 @@
       <bpmn:messageEventDefinition id="MessageEventDefinition_0u15bi8" messageRef="Message_04tc0t0" />
     </bpmn:startEvent>
     <bpmn:subProcess id="SubProcess_Confirmation" name="Subscription Confirmation">
-      <bpmn:incoming>Flow_1csfyyz</bpmn:incoming>
+      <bpmn:incoming>Flow_0zdmt0t</bpmn:incoming>
       <bpmn:outgoing>Flow_09cuvzp</bpmn:outgoing>
       <bpmn:serviceTask id="Activity_SendConfirmationMail" name="Send confirmation mail">
         <bpmn:extensionElements>
@@ -72,7 +69,7 @@
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_1cpwe57" sourceRef="Activity_ConfirmRegistration" targetRef="EndEvent_SubscriptionConfirmed" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_1csfyyz" sourceRef="StartEvent_SubmitRegistrationForm" targetRef="SubProcess_Confirmation" />
+    <bpmn:sequenceFlow id="Flow_1csfyyz" sourceRef="StartEvent_SubmitRegistrationForm" targetRef="serviceTask_incrementSubscriptionCounter" />
     <bpmn:sequenceFlow id="Flow_1l1lj4m" sourceRef="Timer_After3Days" targetRef="CallActivity_AbortRegistration" />
     <bpmn:sequenceFlow id="Flow_09cuvzp" sourceRef="SubProcess_Confirmation" targetRef="Activity_SendWelcomeMail" />
     <bpmn:boundaryEvent id="Timer_After3Days" name="After 3 days" attachedToRef="SubProcess_Confirmation">
@@ -115,25 +112,56 @@
       <bpmn:incoming>Flow_1l1lj4m</bpmn:incoming>
       <bpmn:outgoing>Flow_1bsb8no</bpmn:outgoing>
     </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0zdmt0t" sourceRef="serviceTask_incrementSubscriptionCounter" targetRef="SubProcess_Confirmation" />
+    <bpmn:serviceTask id="serviceTask_incrementSubscriptionCounter" name="Increment subscription counter">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="newsletter.incrementCounter" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1csfyyz</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zdmt0t</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="CompensationEndEvent_RegistrationAborted" name="Registration aborted">
+      <bpmn:incoming>Flow_1bsb8no</bpmn:incoming>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0ych49i" activityRef="serviceTask_incrementSubscriptionCounter" />
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="compensationEvent_onSubscriptionCounter" name="Registration aborted" attachedToRef="serviceTask_incrementSubscriptionCounter">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ffa569" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="compensationTask_decrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=subscriptionId" target="subscriptionId" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="compensationEvent_onSubscriptionCounter" targetRef="compensationTask_decrementSubscriptionCounter" />
   </bpmn:process>
   <bpmn:signal id="Signal_14g8ki5" name="Signal_RegistrationNotPossible" />
   <bpmn:error id="Error_0uxgmyc" name="Error_InvalidMail" errorCode="500" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newsletterSubscription">
-      <bpmndi:BPMNShape id="Event_1ew0xir_di" bpmnElement="EndEvent_RegistrationAborted">
+      <bpmndi:BPMNShape id="Activity_1urwd9r_di" bpmnElement="serviceTask_incrementSubscriptionCounter">
+        <dc:Bounds x="140" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1geox7n_di" bpmnElement="CompensationEndEvent_RegistrationAborted">
         <dc:Bounds x="982" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="971" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="compensationTask_decrementSubscriptionCounter">
+        <dc:Bounds x="290" y="470" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_105q7u2_di" bpmnElement="Activity_SendWelcomeMail">
         <dc:Bounds x="820" y="280" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_12xytcj_di" bpmnElement="StartEvent_SubmitRegistrationForm">
-        <dc:Bounds x="182" y="302" width="36" height="36" />
+        <dc:Bounds x="42" y="302" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="156" y="345" width="88" height="27" />
+          <dc:Bounds x="16" y="345" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1gbt6dx_di" bpmnElement="SubProcess_Confirmation" isExpanded="true">
@@ -219,8 +247,23 @@
         <di:waypoint x="920" y="320" />
         <di:waypoint x="982" y="320" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="compensationEvent_onSubscriptionCounter">
+        <dc:Bounds x="172" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="385" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0vlmtgi_di" bpmnElement="Association_0vlmtgi">
+        <di:waypoint x="190" y="378" />
+        <di:waypoint x="190" y="510" />
+        <di:waypoint x="290" y="510" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1csfyyz_di" bpmnElement="Flow_1csfyyz">
-        <di:waypoint x="218" y="320" />
+        <di:waypoint x="78" y="320" />
+        <di:waypoint x="140" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zdmt0t_di" bpmnElement="Flow_0zdmt0t">
+        <di:waypoint x="240" y="320" />
         <di:waypoint x="290" y="320" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1l1lj4m_di" bpmnElement="Flow_1l1lj4m">

--- a/shared/bpmn/c8-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c8-subscribe-newsletter.bpmn
@@ -124,17 +124,17 @@
       <bpmn:incoming>Flow_1bsb8no</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_0ych49i" activityRef="serviceTask_incrementSubscriptionCounter" />
     </bpmn:endEvent>
-    <bpmn:boundaryEvent id="compensationEvent_onSubscriptionCounter" name="Registration aborted" attachedToRef="serviceTask_incrementSubscriptionCounter">
+    <bpmn:boundaryEvent id="CompensationEvent_OnSubscriptionCounter" name="Registration aborted" attachedToRef="serviceTask_incrementSubscriptionCounter">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ffa569" />
     </bpmn:boundaryEvent>
-    <bpmn:task id="compensationTask_decrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
+    <bpmn:task id="CompensationTask_DecrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:input source="=subscriptionId" target="subscriptionId" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
     </bpmn:task>
-    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="compensationEvent_onSubscriptionCounter" targetRef="compensationTask_decrementSubscriptionCounter" />
+    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="CompensationEvent_OnSubscriptionCounter" targetRef="CompensationTask_DecrementSubscriptionCounter" />
   </bpmn:process>
   <bpmn:signal id="Signal_14g8ki5" name="Signal_RegistrationNotPossible" />
   <bpmn:error id="Error_0uxgmyc" name="Error_InvalidMail" errorCode="500" />
@@ -150,7 +150,7 @@
           <dc:Bounds x="971" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="compensationTask_decrementSubscriptionCounter">
+      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="CompensationTask_DecrementSubscriptionCounter">
         <dc:Bounds x="290" y="470" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -247,7 +247,7 @@
         <di:waypoint x="920" y="320" />
         <di:waypoint x="982" y="320" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="compensationEvent_onSubscriptionCounter">
+      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="CompensationEvent_OnSubscriptionCounter">
         <dc:Bounds x="172" y="342" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="200" y="385" width="59" height="27" />

--- a/shared/bpmn/operaton-subscribe-newsletter.bpmn
+++ b/shared/bpmn/operaton-subscribe-newsletter.bpmn
@@ -115,17 +115,17 @@
       <bpmn:incoming>Flow_1csfyyz</bpmn:incoming>
       <bpmn:outgoing>Flow_0zdmt0t</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="compensationEvent_onSubscriptionCounter" name="Registration aborted" attachedToRef="serviceTask_incrementSubscriptionCounter">
+    <bpmn:boundaryEvent id="CompensationEvent_OnSubscriptionCounter" name="Registration aborted" attachedToRef="serviceTask_incrementSubscriptionCounter">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ffa569" />
     </bpmn:boundaryEvent>
-    <bpmn:task id="compensationTask_decrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
+    <bpmn:task id="CompensationTask_DecrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
       <bpmn:extensionElements>
         <operaton:inputOutput>
           <operaton:inputParameter name="subscriptionId">${subscriptionId}</operaton:inputParameter>
         </operaton:inputOutput>
       </bpmn:extensionElements>
     </bpmn:task>
-    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="compensationEvent_onSubscriptionCounter" targetRef="compensationTask_decrementSubscriptionCounter" />
+    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="CompensationEvent_OnSubscriptionCounter" targetRef="CompensationTask_DecrementSubscriptionCounter" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newsletterSubscription">
@@ -196,7 +196,7 @@
           <dc:Bounds x="971" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="compensationTask_decrementSubscriptionCounter">
+      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="CompensationTask_DecrementSubscriptionCounter">
         <dc:Bounds x="290" y="470" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -228,7 +228,7 @@
           <dc:Bounds x="690" y="193" width="59" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="compensationEvent_onSubscriptionCounter">
+      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="CompensationEvent_OnSubscriptionCounter">
         <dc:Bounds x="172" y="342" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="200" y="385" width="59" height="27" />

--- a/shared/bpmn/operaton-subscribe-newsletter.bpmn
+++ b/shared/bpmn/operaton-subscribe-newsletter.bpmn
@@ -15,7 +15,7 @@
       <bpmn:messageEventDefinition messageRef="Message_04tc0t0" />
     </bpmn:startEvent>
     <bpmn:subProcess id="SubProcess_Confirmation" name="Subscription Confirmation">
-      <bpmn:incoming>Flow_1csfyyz</bpmn:incoming>
+      <bpmn:incoming>Flow_0zdmt0t</bpmn:incoming>
       <bpmn:outgoing>Flow_09cuvzp</bpmn:outgoing>
       <bpmn:startEvent id="StartEvent_RequestReceived" name="Subscription requested" operaton:asyncBefore="true">
         <bpmn:extensionElements>
@@ -59,18 +59,19 @@
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_1cpwe57" sourceRef="Activity_ConfirmRegistration" targetRef="EndEvent_SubscriptionConfirmed" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_1csfyyz" sourceRef="StartEvent_SubmitRegistrationForm" targetRef="SubProcess_Confirmation" />
+    <bpmn:sequenceFlow id="Flow_1csfyyz" sourceRef="StartEvent_SubmitRegistrationForm" targetRef="serviceTask_incrementSubscriptionCounter" />
     <bpmn:boundaryEvent id="Timer_After3Days" name="After 3 days" attachedToRef="SubProcess_Confirmation">
       <bpmn:outgoing>Flow_1l1lj4m</bpmn:outgoing>
       <bpmn:timerEventDefinition>
         <bpmn:timeDuration>${testVariable}</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:endEvent id="EndEvent_RegistrationAborted" name="Registration aborted">
+    <bpmn:endEvent id="CompensationEndEvent_RegistrationAborted" name="Registration aborted">
       <bpmn:incoming>Flow_1bsb8no</bpmn:incoming>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0ych49i" activityRef="serviceTask_incrementSubscriptionCounter" />
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1l1lj4m" sourceRef="Timer_After3Days" targetRef="CallActivity_AbortRegistration" />
-    <bpmn:sequenceFlow id="Flow_1bsb8no" sourceRef="CallActivity_AbortRegistration" targetRef="EndEvent_RegistrationAborted" />
+    <bpmn:sequenceFlow id="Flow_1bsb8no" sourceRef="CallActivity_AbortRegistration" targetRef="CompensationEndEvent_RegistrationAborted" />
     <bpmn:serviceTask id="Activity_SendWelcomeMail" name="Send Welcome-Mail" operaton:asyncBefore="true" operaton:asyncAfter="true" operaton:exclusive="false" operaton:delegateExpression="newsletter.sendWelcomeMail">
       <bpmn:extensionElements>
         <operaton:inputOutput>
@@ -109,13 +110,33 @@
       <bpmn:incoming>Flow_1l1lj4m</bpmn:incoming>
       <bpmn:outgoing>Flow_1bsb8no</bpmn:outgoing>
     </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0zdmt0t" sourceRef="serviceTask_incrementSubscriptionCounter" targetRef="SubProcess_Confirmation" />
+    <bpmn:serviceTask id="serviceTask_incrementSubscriptionCounter" name="Increment subscription counter" operaton:delegateExpression="counterClass">
+      <bpmn:incoming>Flow_1csfyyz</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zdmt0t</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="compensationEvent_onSubscriptionCounter" name="Registration aborted" attachedToRef="serviceTask_incrementSubscriptionCounter">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ffa569" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="compensationTask_decrementSubscriptionCounter" name="Decrement subscription counter" isForCompensation="true">
+      <bpmn:extensionElements>
+        <operaton:inputOutput>
+          <operaton:inputParameter name="subscriptionId">${subscriptionId}</operaton:inputParameter>
+        </operaton:inputOutput>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:association id="Association_0vlmtgi" associationDirection="One" sourceRef="compensationEvent_onSubscriptionCounter" targetRef="compensationTask_decrementSubscriptionCounter" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newsletterSubscription">
+      <bpmndi:BPMNShape id="Activity_1urwd9r_di" bpmnElement="serviceTask_incrementSubscriptionCounter">
+        <dc:Bounds x="140" y="280" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_12xytcj_di" bpmnElement="StartEvent_SubmitRegistrationForm">
-        <dc:Bounds x="182" y="302" width="36" height="36" />
+        <dc:Bounds x="42" y="302" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="156" y="345" width="88" height="27" />
+          <dc:Bounds x="16" y="345" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0dsl2pc_di" bpmnElement="CallActivity_AbortRegistration">
@@ -169,11 +190,15 @@
         <di:waypoint x="650" y="320" />
         <di:waypoint x="692" y="320" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1ew0xir_di" bpmnElement="EndEvent_RegistrationAborted">
+      <bpmndi:BPMNShape id="Event_1geox7n_di" bpmnElement="CompensationEndEvent_RegistrationAborted">
         <dc:Bounds x="982" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="971" y="145" width="59" height="27" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d3wq3r_di" bpmnElement="compensationTask_decrementSubscriptionCounter">
+        <dc:Bounds x="290" y="470" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_105q7u2_di" bpmnElement="Activity_SendWelcomeMail">
         <dc:Bounds x="820" y="280" width="100" height="80" />
@@ -203,8 +228,23 @@
           <dc:Bounds x="690" y="193" width="59" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_182nhy4_di" bpmnElement="compensationEvent_onSubscriptionCounter">
+        <dc:Bounds x="172" y="342" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="385" width="59" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0vlmtgi_di" bpmnElement="Association_0vlmtgi">
+        <di:waypoint x="190" y="378" />
+        <di:waypoint x="190" y="510" />
+        <di:waypoint x="290" y="510" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1csfyyz_di" bpmnElement="Flow_1csfyyz">
-        <di:waypoint x="218" y="320" />
+        <di:waypoint x="78" y="320" />
+        <di:waypoint x="140" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zdmt0t_di" bpmnElement="Flow_0zdmt0t">
+        <di:waypoint x="240" y="320" />
         <di:waypoint x="290" y="320" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1l1lj4m_di" bpmnElement="Flow_1l1lj4m">


### PR DESCRIPTION
## Summary
- Add full compensation event support across all layers: domain model, extraction, merging, API code generation, and JSON output
- Add `TASK("task")` to `BpmnElementType` for compensation handler tasks
- Update all 3 subscribe-newsletter BPMN models (C7, C8, Operaton) with compensation elements

Closes #230

## Test plan
- [x] All 108+ core tests pass
- [x] Full project build passes
- [ ] Verify generated API output includes `Compensations` section when compensation events are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)