### PR TITLE
feat: extract variantName from process-level extension properties

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/BpmnExtensionConstants.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/BpmnExtensionConstants.kt
@@ -1,0 +1,9 @@
+package io.github.emaarco.bpmn.adapter.outbound.engine.constants
+
+/**
+ * Extension property names that apply across all process engines.
+ */
+object BpmnExtensionConstants {
+
+    const val VARIANT_NAME_PROPERTY_NAME = "variantName"
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/CamundaModelConstants.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/CamundaModelConstants.kt
@@ -9,6 +9,7 @@ import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
 object CamundaModelConstants {
 
     const val ADDITIONAL_VARIABLES_PROPERTY_NAME = "additionalVariables"
+    const val VARIANT_NAME_PROPERTY_NAME = "variantName"
 
     val inputOutputParameters = listOf(
         BpmnModelConstants.CAMUNDA_ELEMENT_INPUT_PARAMETER,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/CamundaModelConstants.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/CamundaModelConstants.kt
@@ -9,7 +9,6 @@ import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
 object CamundaModelConstants {
 
     const val ADDITIONAL_VARIABLES_PROPERTY_NAME = "additionalVariables"
-    const val VARIANT_NAME_PROPERTY_NAME = "variantName"
 
     val inputOutputParameters = listOf(
         BpmnModelConstants.CAMUNDA_ELEMENT_INPUT_PARAMETER,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -14,6 +14,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.f
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
@@ -46,6 +47,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
     override fun extract(inputStream: InputStream): BpmnModel {
         val modelInstance = Bpmn.readModelFromStream(inputStream)
         val processId = modelInstance.getProcessId()
+        val variantName = modelInstance.extractVariantName()
         val allMessages = findMessages(modelInstance)
         val allFlowNodes = modelInstance.findFlowNodes()
         val allSequenceFlows = modelInstance.findSequenceFlows()
@@ -65,6 +67,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
 
         return BpmnModel(
             processId = processId,
+            variantName = variantName,
             flowNodes = enrichedFlowNodes,
             sequenceFlows = allSequenceFlows,
             messages = allMessages,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -14,6 +14,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.f
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
@@ -50,6 +51,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
     override fun extract(inputStream: InputStream): BpmnModel {
         val modelInstance = Bpmn.readModelFromStream(inputStream)
         val processId = modelInstance.getProcessId()
+        val variantName = modelInstance.extractVariantName()
         val messages = findMessages(modelInstance)
         val flowNodes = modelInstance.findFlowNodes()
         val allSequenceFlows = modelInstance.findSequenceFlows()
@@ -69,6 +71,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
 
         return BpmnModel(
             processId = processId,
+            variantName = variantName,
             flowNodes = enrichedFlowNodes,
             sequenceFlows = allSequenceFlows,
             messages = messages,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -15,6 +15,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.f
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSequenceFlows
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findSignalEventDefinitions
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.findTimerEventDefinition
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.extractVariantName
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
@@ -41,6 +42,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
     override fun extract(inputStream: InputStream): BpmnModel {
         val modelInstance = Bpmn.readModelFromStream(inputStream)
         val processId = modelInstance.getProcessId()
+        val variantName = modelInstance.extractVariantName()
         val allFlowNodes = modelInstance.findFlowNodes()
         val allSequenceFlows = modelInstance.findSequenceFlows()
         val allMessages = extractZeebeMessages(modelInstance)
@@ -57,6 +59,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
 
         return BpmnModel(
             processId = processId,
+            variantName = variantName,
             flowNodes = enrichedFlowNodes,
             sequenceFlows = allSequenceFlows,
             messages = allMessages,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -1,5 +1,7 @@
 package io.github.emaarco.bpmn.adapter.outbound.engine.utils
 
+import io.github.emaarco.bpmn.adapter.outbound.engine.constants.CamundaModelConstants
+import io.github.emaarco.bpmn.adapter.outbound.engine.utils.BaseElementUtils.findExtensionElements
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.CompensationType
@@ -31,12 +33,27 @@ import org.camunda.bpm.model.xml.ModelInstance
 object ModelInstanceUtils {
 
     fun ModelInstance.getProcessId(): String {
-        val processType = this.model.getType(Process::class.java)
-        val process = this.getModelElementsByType(processType).firstOrNull()
-        val processId = process?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-        requireNotNull(process) { "BPMN model does not contain a Process element" }
+        val process = this.findProcess()
+        val processId = process.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
         requireNotNull(processId) { "Process element is missing an 'id' attribute" }
         return processId
+    }
+
+    fun ModelInstance.extractVariantName(): String? {
+        val process = this.findProcess()
+        val extensions = process.findExtensionElements()
+        val propertiesContainers = extensions.filter { it.domElement.localName == "properties" }
+        val allProperties = propertiesContainers.flatMap { it.domElement.childElements }
+        val variantProperty = allProperties
+            .filter { it.localName == "property" }
+            .firstOrNull { it.getAttribute("name") == CamundaModelConstants.VARIANT_NAME_PROPERTY_NAME }
+        return variantProperty?.getAttribute("value")?.takeIf { it.isNotBlank() }
+    }
+
+    private fun ModelInstance.findProcess(): Process {
+        val process = this.getModelElementsByType(Process::class.java).firstOrNull()
+        requireNotNull(process) { "BPMN model does not contain a Process element" }
+        return process
     }
 
     fun ModelInstance.findFlowNodes(): List<FlowNodeDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -1,6 +1,6 @@
 package io.github.emaarco.bpmn.adapter.outbound.engine.utils
 
-import io.github.emaarco.bpmn.adapter.outbound.engine.constants.CamundaModelConstants
+import io.github.emaarco.bpmn.adapter.outbound.engine.constants.BpmnExtensionConstants
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.BaseElementUtils.findExtensionElements
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
@@ -46,7 +46,7 @@ object ModelInstanceUtils {
         val allProperties = propertiesContainers.flatMap { it.domElement.childElements }
         val variantProperty = allProperties
             .filter { it.localName == "property" }
-            .firstOrNull { it.getAttribute("name") == CamundaModelConstants.VARIANT_NAME_PROPERTY_NAME }
+            .firstOrNull { it.getAttribute("name") == BpmnExtensionConstants.VARIANT_NAME_PROPERTY_NAME }
         return variantProperty?.getAttribute("value")?.takeIf { it.isNotBlank() }
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
@@ -4,6 +4,7 @@ import io.github.emaarco.bpmn.domain.shared.*
 
 data class BpmnModel(
     val processId: String,
+    val variantName: String? = null,
     val flowNodes: List<FlowNodeDefinition>,
     val sequenceFlows: List<SequenceFlowDefinition> = emptyList(),
     val messages: List<MessageDefinition>,

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -41,6 +41,7 @@ class Camunda7ModelExtractorTest {
 
         assertThat(bpmnModel).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(
             testNewsletterBpmnModel(
+                variantName = "withApproval",
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
@@ -133,6 +134,22 @@ class Camunda7ModelExtractorTest {
                 ),
             )
         )
+    }
+
+    @Test
+    fun `extract returns variantName from process-level extension properties`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+        assertThat(bpmnModel.variantName).isEqualTo("withApproval")
+    }
+
+    @Test
+    fun `extract returns null variantName when not specified`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-send-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+        assertThat(bpmnModel.variantName).isNull()
     }
 
     @Test

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -41,6 +41,7 @@ class OperatonModelExtractorTest {
 
         assertThat(bpmnModel).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(
             testNewsletterBpmnModel(
+                variantName = "withApproval",
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
@@ -132,6 +133,22 @@ class OperatonModelExtractorTest {
                 ),
             )
         )
+    }
+
+    @Test
+    fun `extract returns variantName from process-level extension properties`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-subscribe-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+        assertThat(bpmnModel.variantName).isEqualTo("withApproval")
+    }
+
+    @Test
+    fun `extract returns null variantName when not specified`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-send-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+        assertThat(bpmnModel.variantName).isNull()
     }
 
     @Test

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -43,6 +43,7 @@ class ZeebeModelExtractorTest {
         )
         assertThat(bpmnModel).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(
             testNewsletterBpmnModel(
+                variantName = "withApproval",
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
@@ -133,6 +134,22 @@ class ZeebeModelExtractorTest {
                 ),
             )
         )
+    }
+
+    @Test
+    fun `extract returns variantName from process-level extension properties`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-subscribe-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+        assertThat(bpmnModel.variantName).isEqualTo("withApproval")
+    }
+
+    @Test
+    fun `extract returns null variantName when not specified`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-send-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.inputStream())
+        assertThat(bpmnModel.variantName).isNull()
     }
 
     @Test

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
@@ -22,6 +22,7 @@ import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 
 fun testBpmnModel(
     processId: String = "order",
+    variantName: String? = null,
     flowNodes: List<FlowNodeDefinition> = listOf(FlowNodeDefinition(id = "create-order")),
     sequenceFlows: List<SequenceFlowDefinition> = emptyList(),
     messages: List<MessageDefinition> = listOf(MessageDefinition(id = "messageId", name = "messageName")),
@@ -31,6 +32,7 @@ fun testBpmnModel(
     compensations: List<CompensationDefinition> = emptyList(),
 ) = BpmnModel(
     processId = processId,
+    variantName = variantName,
     flowNodes = flowNodes,
     sequenceFlows = sequenceFlows,
     messages = messages,
@@ -54,6 +56,7 @@ fun testBpmnModelApi(
 
 fun testNewsletterBpmnModel(
     processId: String = "newsletterSubscription",
+    variantName: String? = null,
     testVariableForTimer: String = "$" + "{testVariable}",
     flowNodes: List<FlowNodeDefinition> = listOf(
         FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
@@ -133,6 +136,7 @@ fun testNewsletterBpmnModel(
     compensations: List<CompensationDefinition> = emptyList(),
 ) = testBpmnModel(
     processId = processId,
+    variantName = variantName,
     flowNodes = flowNodes,
     sequenceFlows = sequenceFlows,
     messages = messages,

--- a/shared/bpmn/c7-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c7-subscribe-newsletter.bpmn
@@ -5,6 +5,11 @@
   <bpmn:signal id="Signal_14g8ki5" name="Signal_RegistrationNotPossible" />
   <bpmn:error id="Error_0uxgmyc" name="Error_InvalidMail" errorCode="500" />
   <bpmn:process id="newsletterSubscription" isExecutable="true">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="variantName" value="withApproval" />
+      </camunda:properties>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_SubmitRegistrationForm" name="Submit newsletter form">
       <bpmn:extensionElements>
         <camunda:inputOutput>

--- a/shared/bpmn/c8-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c8-subscribe-newsletter.bpmn
@@ -7,6 +7,11 @@
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmn:process id="newsletterSubscription" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:properties>
+        <zeebe:property name="variantName" value="withApproval" />
+      </zeebe:properties>
+    </bpmn:extensionElements>
     <bpmn:sequenceFlow id="Flow_1bsb8no" sourceRef="CallActivity_AbortRegistration" targetRef="CompensationEndEvent_RegistrationAborted" />
     <bpmn:serviceTask id="Activity_SendWelcomeMail" name="Send Welcome-Mail">
       <bpmn:extensionElements>

--- a/shared/bpmn/operaton-subscribe-newsletter.bpmn
+++ b/shared/bpmn/operaton-subscribe-newsletter.bpmn
@@ -5,6 +5,11 @@
   <bpmn:signal id="Signal_14g8ki5" name="Signal_RegistrationNotPossible" />
   <bpmn:error id="Error_0uxgmyc" name="Error_InvalidMail" errorCode="500" />
   <bpmn:process id="newsletterSubscription" isExecutable="true">
+    <bpmn:extensionElements>
+      <operaton:properties>
+        <operaton:property name="variantName" value="withApproval" />
+      </operaton:properties>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_SubmitRegistrationForm" name="Submit newsletter form">
       <bpmn:extensionElements>
         <operaton:inputOutput>


### PR DESCRIPTION
## Summary
- Adds `variantName: String?` field to `BpmnModel` domain entity
- Extracts `variantName` from process-level extension properties across all three engines (Camunda 7, Zeebe, Operaton)
- Shared namespace-agnostic extraction via `ModelInstanceUtils.extractVariantName()`

First step toward resolving #244 — subsequent PRs will add validation and variant-aware JSON filenames.

## Test plan
- [x] Extractor tests verify `variantName` is extracted from subscribe-newsletter fixtures (all 3 engines)
- [x] Extractor tests verify `variantName` is null when not present (send-newsletter fixtures)
- [x] Full `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)