### PR TITLE
refactor: standardize unit test style across all modules

### DIFF
--- a/.agent/skills/create-unit-test/SKILL.md
+++ b/.agent/skills/create-unit-test/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: create-unit-test
+description: "Write or refactor unit tests following the canonical project pattern. Use when adding new unit tests or standardizing existing ones."
+risk: safe
+---
+
+# Create Unit Test Skill
+
+Write and refactor unit tests following the canonical pattern used in this project.
+
+## When to Use
+
+- Writing a new unit test class
+- Refactoring an existing test to conform to project style
+- Reviewing a test and deciding whether it needs updates
+
+## Canonical Pattern
+
+```kotlin
+class FooServiceTest {
+
+    // Mocks declared as private val at the top
+    private val somePort = mockk<SomePort>(relaxed = true)
+
+    // Subject under test is always named `underTest`
+    private val underTest = FooService(somePort = somePort)
+
+    @Test
+    fun `does something when condition is met`() {
+
+        // given: set up inputs and mock behaviour (omit section if single-line)
+        val input = SomeInput(
+            id = "order-42",
+            value = "test",
+        )
+        every { somePort.fetch(any()) } returns SomeResult(ok = true)
+
+        // when: the action is taken
+        val actual = underTest.doSomething(input)
+
+        // then: verify the result and all interactions
+        assertThat(actual).isEqualTo(SomeResult(ok = true))
+        verify { somePort.fetch(input) }
+        confirmVerified(somePort)
+    }
+}
+```
+
+## Rules
+
+### Structure
+- `private val underTest` — always this name for the subject under test
+- `private val <dep> = mockk<T>(relaxed = true)` — one line per mock, declared before `underTest`
+- Static / reusable test data as `private val` fields at the bottom of the class
+- Helper builder functions as `private fun` at the bottom of the class
+
+### Given / When / Then Comments
+- Add `// given:` / `// when:` / `// then:` comments when a section spans more than one line
+- Omit them entirely for trivial single-assertion tests where the structure is obvious
+- Put a blank line before each section comment
+
+### Parameters
+- Use **named parameters** everywhere — constructor calls, function calls, data class instantiation
+- Multi-argument calls always use trailing commas and one arg per line
+
+### Mocks
+- Use `mockk<T>(relaxed = true)` — never strict mocks unless you have a specific reason
+- Use `every { ... } returns ...` for stubbing
+- Use `verify { ... }` to assert interactions
+- Always call `confirmVerified(dep1, dep2, ...)` at the end to catch unexpected calls
+
+### Assertions
+- Use AssertJ: `assertThat(actual).isEqualTo(expected)` — never bare `assert()` or `assertEquals()`
+- Prefer fluent assertion chains over multiple individual asserts
+
+### Builders
+- If a builder / helper already exists (e.g. `testBpmnModel()`, `testBpmnModelApi()`, `node()`), use it
+- If none exists and the class is small, use its constructor directly with named parameters
+- If none exists and the class is large/complex, use `AskUserQuestion` to decide whether to create a builder
+
+### Function Bodies
+- Always use block body with explicit return: `fun foo(): Bar { return ... }`
+- Never use expression body: `fun foo(): Bar = ...`
+
+### KDoc
+- Always use multiline style: `/** \n * description\n */`
+- Never use single-line: `/** description */`
+
+## Implementation Checklist
+
+- [ ] Class name ends in `Test`
+- [ ] `private val underTest` is present and named correctly
+- [ ] All dependencies are mocked with `mockk<T>(relaxed = true)`
+- [ ] `// given:` / `// when:` / `// then:` comments present where sections are multi-line
+- [ ] Named parameters used everywhere
+- [ ] AssertJ assertions used (no bare `assert()`)
+- [ ] `confirmVerified(...)` called after all `verify` blocks when mocks are used
+- [ ] Test names written in backtick style describing behaviour
+- [ ] No production code is changed
+- [ ] All tests pass after refactoring

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/ValidateBpmnFilesystemPluginTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/ValidateBpmnFilesystemPluginTest.kt
@@ -13,18 +13,18 @@ import org.junit.jupiter.api.Test
 
 class ValidateBpmnFilesystemPluginTest {
 
-    private val useCase = mockk<ValidateBpmnFromFilesystemUseCase>()
-    private val underTest = ValidateBpmnFilesystemPlugin(useCase)
+    private val useCase = mockk<ValidateBpmnFromFilesystemUseCase>(relaxed = true)
+    private val underTest = ValidateBpmnFilesystemPlugin(useCase = useCase)
 
     @Test
     fun `execute delegates to use case with correct command`() {
 
-        // given
+        // given: a config and an expected validation result
+        val config = ValidationConfig(failOnWarning = true, disabledRules = setOf("missing-element-id"))
         val expectedResult = ValidationResult(emptyList())
         every { useCase.validateBpmn(any()) } returns expectedResult
 
-        // when
-        val config = ValidationConfig(failOnWarning = true, disabledRules = setOf("missing-element-id"))
+        // when: execute is called with all parameters
         val result = underTest.execute(
             baseDir = "/path/to/bpmn",
             filePattern = "*.bpmn",
@@ -32,7 +32,7 @@ class ValidateBpmnFilesystemPluginTest {
             validationConfig = config,
         )
 
-        // then
+        // then: use case is called with the correct command and result is returned
         verify {
             useCase.validateBpmn(
                 ValidateBpmnFromFilesystemUseCase.Command(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/CodeGenerationAdapterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/CodeGenerationAdapterTest.kt
@@ -3,8 +3,12 @@ package io.github.emaarco.bpmn.adapter.outbound.codegen
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.testBpmnModelApi
-import io.mockk.*
-import org.junit.jupiter.api.Assertions.assertThrows
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 class CodeGenerationAdapterTest {
@@ -17,27 +21,43 @@ class CodeGenerationAdapterTest {
     )
 
     @Test
-    fun `creates api-file using builders`() {
-        val modelApi = testBpmnModelApi()
-        val processFile = GeneratedApiFile(fileName = "TestApi.kt", packagePath = "packagePath", content = "content", language = OutputLanguage.KOTLIN)
-        val typeFile = GeneratedApiFile(fileName = "BpmnTimer.kt", packagePath = "packagePath.types", content = "content", language = OutputLanguage.KOTLIN)
+    fun `generateCode delegates to builders and returns combined files`() {
 
+        // given: a model API and stubbed builder responses
+        val modelApi = testBpmnModelApi()
+        val processFile = GeneratedApiFile(
+            fileName = "TestApi.kt",
+            packagePath = "packagePath",
+            content = "content",
+            language = OutputLanguage.KOTLIN,
+        )
+        val typeFile = GeneratedApiFile(
+            fileName = "BpmnTimer.kt",
+            packagePath = "packagePath.types",
+            content = "content",
+            language = OutputLanguage.KOTLIN,
+        )
         every { kotlinProcessBuilder.buildApiFile(modelApi) } returns processFile
         every { kotlinTypesBuilder.buildTypeFiles("packagePath", OutputLanguage.KOTLIN) } returns listOf(typeFile)
 
+        // when: generating code for a Kotlin model
         val result = underTest.generateCode(modelApi)
 
+        // then: both builders are called and their files are combined
         verify { kotlinProcessBuilder.buildApiFile(modelApi) }
         verify { kotlinTypesBuilder.buildTypeFiles("packagePath", OutputLanguage.KOTLIN) }
-        assert(result == listOf(processFile, typeFile))
+        assertThat(result).isEqualTo(listOf(processFile, typeFile))
         confirmVerified(kotlinProcessBuilder, kotlinTypesBuilder)
     }
 
     @Test
-    fun `throws exception when output language is not supported`() {
+    fun `generateCode throws when output language is not supported`() {
+
+        // given: a model API with an unsupported language
         val modelApi = testBpmnModelApi(language = OutputLanguage.JAVA)
-        assertThrows(IllegalArgumentException::class.java) {
-            underTest.generateCode(modelApi)
-        }
+
+        // when / then: an exception is thrown
+        assertThatThrownBy { underTest.generateCode(modelApi) }
+            .isInstanceOf(IllegalArgumentException::class.java)
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
@@ -8,47 +8,49 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.File
 
 class ExtractBpmnAdapterTest {
 
-    private val extractor = mockk<EngineSpecificExtractor>()
+    private val extractor = mockk<EngineSpecificExtractor>(relaxed = true)
     private val underTest = ExtractBpmnAdapter(
         extractors = mapOf(ProcessEngine.ZEEBE to extractor)
     )
 
     @Test
-    fun `extract returns model using correct extractor`() {
+    fun `extract returns model using the correct extractor`() {
 
-        // given: a dummy extractor that returns an expected BpmnModel
+        // given: a dummy BPMN resource and a stubbed extractor
         val expectedModel = testBpmnModel(processId = "dummyProcess")
-        val dummyFile = File.createTempFile("dummy", ".bpmn").apply { deleteOnExit() }
-        val inputStream = dummyFile.inputStream()
-        val bpmnFile = BpmnResource(fileName = "dummy.bpmn", content = inputStream)
+        val tempFile = File.createTempFile("dummy", ".bpmn").apply { deleteOnExit() }
+        val bpmnResource = BpmnResource(
+            fileName = "dummy.bpmn",
+            content = tempFile.inputStream(),
+        )
         every { extractor.extract(any()) } returns expectedModel
 
-        // when: extract is invoked
-        val result = underTest.extract(bpmnFile, ProcessEngine.ZEEBE)
+        // when: extracting with a supported engine
+        val result = underTest.extract(bpmnFile = bpmnResource, engine = ProcessEngine.ZEEBE)
 
-        // then: the extractor is used and the expected model is returned
+        // then: the extractor is called and the model is returned
         verify { extractor.extract(any()) }
         assertThat(result).isEqualTo(expectedModel)
     }
 
     @Test
-    fun `throws exception when no extractor found for engine`() {
-        val dummyFile = File.createTempFile("dummy", ".bpmn").apply { deleteOnExit() }
-        val inputStream = dummyFile.inputStream()
-        assertThrows(IllegalStateException::class.java) {
-            underTest.extract(
-                BpmnResource(
-                    fileName = "dummy.bpmn",
-                    content = inputStream,
-                ),
-                ProcessEngine.CAMUNDA_7
-            )
-        }
+    fun `extract throws when no extractor is registered for the engine`() {
+
+        // given: a resource targeting an engine with no registered extractor
+        val tempFile = File.createTempFile("dummy", ".bpmn").apply { deleteOnExit() }
+        val bpmnResource = BpmnResource(
+            fileName = "dummy.bpmn",
+            content = tempFile.inputStream(),
+        )
+
+        // when / then: an exception is thrown
+        assertThatThrownBy { underTest.extract(bpmnFile = bpmnResource, engine = ProcessEngine.CAMUNDA_7) }
+            .isInstanceOf(IllegalStateException::class.java)
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -27,10 +27,15 @@ class Camunda7ModelExtractorTest {
 
     @Test
     fun `extract returns valid BpmnModel`() {
+
+        // given: the Camunda 7 newsletter BPMN file from classpath
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
+
+        // when: extracting the model
         val bpmnModel = underTest.extract(file.inputStream())
 
+        // then: the model matches the expected structure
         val c7ServiceTasks = listOf(
             ServiceTaskDefinition("Activity_SendWelcomeMail", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "\${newsletterSendWelcomeMail}", IMPL_KIND_KEY to "DELEGATE_EXPRESSION")),
             ServiceTaskDefinition("Activity_SendConfirmationMail", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "#{newsletterSendConfirmationMail}", IMPL_KIND_KEY to "EXTERNAL_TASK")),

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -27,10 +27,15 @@ class OperatonModelExtractorTest {
 
     @Test
     fun `extract returns valid BpmnModel with operaton namespace`() {
+
+        // given: the Operaton newsletter BPMN file from classpath
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-subscribe-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
+
+        // when: extracting the model
         val bpmnModel = underTest.extract(file.inputStream())
 
+        // then: the model matches the expected structure
         val opServiceTasks = listOf(
             ServiceTaskDefinition("Activity_SendWelcomeMail", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendWelcomeMail", IMPL_KIND_KEY to "DELEGATE_EXPRESSION")),
             ServiceTaskDefinition("Activity_SendConfirmationMail", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendConfirmationMail", IMPL_KIND_KEY to "EXTERNAL_TASK")),

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/FlowNodeSorterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/FlowNodeSorterTest.kt
@@ -14,101 +14,132 @@ class FlowNodeSorterTest {
         outgoing: List<String> = emptyList(),
         parentId: String? = null,
         attachedToRef: String? = null,
-    ) = FlowNodeDefinition(id = id, elementType = type, incoming = incoming, outgoing = outgoing, parentId = parentId, attachedToRef = attachedToRef)
+    ) = FlowNodeDefinition(
+        id = id,
+        elementType = type,
+        incoming = incoming,
+        outgoing = outgoing,
+        parentId = parentId,
+        attachedToRef = attachedToRef,
+    )
 
     @Test
     fun `linear chain is sorted start to end`() {
-        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
-        val task = node("Task", incoming = listOf("Start"), outgoing = listOf("End"))
-        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
 
+        // given: a linear start → task → end chain
+        val start = node(id = "Start", type = BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node(id = "Task", incoming = listOf("Start"), outgoing = listOf("End"))
+        val end = node(id = "End", type = BpmnElementType.END_EVENT, incoming = listOf("Task"))
+
+        // when: sorting the unsorted list
         val result = FlowNodeSorter.sort(listOf(task, end, start))
 
+        // then: nodes appear in process order
         assertThat(result.map { it.id }).containsExactly("Start", "Task", "End")
     }
 
     @Test
     fun `start events are visited before other top-level nodes`() {
-        val startA = node("Start_A", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
-        val startB = node("Start_B", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
-        val task = node("Task", incoming = listOf("Start_A", "Start_B"), outgoing = listOf("End"))
-        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
 
+        // given: two start events feeding the same task
+        val startA = node(id = "Start_A", type = BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val startB = node(id = "Start_B", type = BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node(id = "Task", incoming = listOf("Start_A", "Start_B"), outgoing = listOf("End"))
+        val end = node(id = "End", type = BpmnElementType.END_EVENT, incoming = listOf("Task"))
+
+        // when: sorting
         val result = FlowNodeSorter.sort(listOf(task, end, startB, startA))
         val ids = result.map { it.id }
 
-        // Start_A (alphabetically first) is the first element
+        // then: Start_A (alphabetically first) leads, all nodes appear exactly once
         assertThat(ids.first()).isEqualTo("Start_A")
-        // All nodes appear exactly once
         assertThat(ids).containsExactlyInAnyOrder("Start_A", "Start_B", "Task", "End")
     }
 
     @Test
     fun `boundary event appears after its parent`() {
-        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
-        val task = node("Task", incoming = listOf("Start"), outgoing = listOf("End"))
-        val boundary = node("Boundary", BpmnElementType.BOUNDARY_EVENT, attachedToRef = "Task", outgoing = listOf("ErrorEnd"))
-        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
-        val errorEnd = node("ErrorEnd", BpmnElementType.END_EVENT, incoming = listOf("Boundary"))
 
+        // given: a task with an attached boundary event
+        val start = node(id = "Start", type = BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node(id = "Task", incoming = listOf("Start"), outgoing = listOf("End"))
+        val boundary = node(id = "Boundary", type = BpmnElementType.BOUNDARY_EVENT, attachedToRef = "Task", outgoing = listOf("ErrorEnd"))
+        val end = node(id = "End", type = BpmnElementType.END_EVENT, incoming = listOf("Task"))
+        val errorEnd = node(id = "ErrorEnd", type = BpmnElementType.END_EVENT, incoming = listOf("Boundary"))
+
+        // when: sorting
         val result = FlowNodeSorter.sort(listOf(end, errorEnd, boundary, task, start))
         val ids = result.map { it.id }
 
+        // then: Boundary comes after Task, ErrorEnd comes after Boundary
         assertThat(ids.indexOf("Boundary")).isGreaterThan(ids.indexOf("Task"))
         assertThat(ids.indexOf("ErrorEnd")).isGreaterThan(ids.indexOf("Boundary"))
     }
 
     @Test
     fun `subprocess children are inlined after subprocess`() {
-        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Sub"))
-        val sub = node("Sub", BpmnElementType.SUB_PROCESS, incoming = listOf("Start"), outgoing = listOf("End"))
-        val subStart = node("SubStart", BpmnElementType.START_EVENT, parentId = "Sub", outgoing = listOf("SubTask"))
-        val subTask = node("SubTask", parentId = "Sub", incoming = listOf("SubStart"), outgoing = listOf("SubEnd"))
-        val subEnd = node("SubEnd", BpmnElementType.END_EVENT, parentId = "Sub", incoming = listOf("SubTask"))
-        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Sub"))
 
+        // given: a subprocess with child nodes
+        val start = node(id = "Start", type = BpmnElementType.START_EVENT, outgoing = listOf("Sub"))
+        val sub = node(id = "Sub", type = BpmnElementType.SUB_PROCESS, incoming = listOf("Start"), outgoing = listOf("End"))
+        val subStart = node(id = "SubStart", type = BpmnElementType.START_EVENT, parentId = "Sub", outgoing = listOf("SubTask"))
+        val subTask = node(id = "SubTask", parentId = "Sub", incoming = listOf("SubStart"), outgoing = listOf("SubEnd"))
+        val subEnd = node(id = "SubEnd", type = BpmnElementType.END_EVENT, parentId = "Sub", incoming = listOf("SubTask"))
+        val end = node(id = "End", type = BpmnElementType.END_EVENT, incoming = listOf("Sub"))
+
+        // when: sorting
         val result = FlowNodeSorter.sort(listOf(end, subEnd, subTask, subStart, sub, start))
-        val ids = result.map { it.id }
 
-        assertThat(ids).containsExactly("Start", "Sub", "SubStart", "SubTask", "SubEnd", "End")
+        // then: subprocess children are inlined immediately after the subprocess
+        assertThat(result.map { it.id }).containsExactly("Start", "Sub", "SubStart", "SubTask", "SubEnd", "End")
     }
 
     @Test
     fun `cycles do not cause infinite loops`() {
-        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("A"))
-        val a = node("A", incoming = listOf("Start", "B"), outgoing = listOf("B"))
-        val b = node("B", incoming = listOf("A"), outgoing = listOf("A", "End"))
-        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("B"))
 
+        // given: a cyclic A ↔ B loop
+        val start = node(id = "Start", type = BpmnElementType.START_EVENT, outgoing = listOf("A"))
+        val a = node(id = "A", incoming = listOf("Start", "B"), outgoing = listOf("B"))
+        val b = node(id = "B", incoming = listOf("A"), outgoing = listOf("A", "End"))
+        val end = node(id = "End", type = BpmnElementType.END_EVENT, incoming = listOf("B"))
+
+        // when: sorting
         val result = FlowNodeSorter.sort(listOf(b, a, end, start))
 
-        // Should not throw or loop; each node appears exactly once
+        // then: no exception; each node appears exactly once
         assertThat(result.map { it.id }).containsExactlyInAnyOrder("Start", "A", "B", "End")
         assertThat(result).hasSize(4)
     }
 
     @Test
     fun `already sorted input is idempotent`() {
-        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("Task"))
-        val task = node("Task", incoming = listOf("Start"), outgoing = listOf("End"))
-        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Task"))
 
+        // given: nodes already in correct order
+        val start = node(id = "Start", type = BpmnElementType.START_EVENT, outgoing = listOf("Task"))
+        val task = node(id = "Task", incoming = listOf("Start"), outgoing = listOf("End"))
+        val end = node(id = "End", type = BpmnElementType.END_EVENT, incoming = listOf("Task"))
+
+        // when: sorting
         val result = FlowNodeSorter.sort(listOf(start, task, end))
 
+        // then: order is unchanged
         assertThat(result.map { it.id }).containsExactly("Start", "Task", "End")
     }
 
     @Test
     fun `exclusive gateway branches appear after gateway`() {
-        val start = node("Start", BpmnElementType.START_EVENT, outgoing = listOf("GW"))
-        val gw = node("GW", BpmnElementType.EXCLUSIVE_GATEWAY, incoming = listOf("Start"), outgoing = listOf("Branch_A", "Branch_B"))
-        val branchA = node("Branch_A", incoming = listOf("GW"), outgoing = listOf("End"))
-        val branchB = node("Branch_B", incoming = listOf("GW"), outgoing = listOf("End"))
-        val end = node("End", BpmnElementType.END_EVENT, incoming = listOf("Branch_A", "Branch_B"))
 
+        // given: a gateway splitting into two branches
+        val start = node(id = "Start", type = BpmnElementType.START_EVENT, outgoing = listOf("GW"))
+        val gw = node(id = "GW", type = BpmnElementType.EXCLUSIVE_GATEWAY, incoming = listOf("Start"), outgoing = listOf("Branch_A", "Branch_B"))
+        val branchA = node(id = "Branch_A", incoming = listOf("GW"), outgoing = listOf("End"))
+        val branchB = node(id = "Branch_B", incoming = listOf("GW"), outgoing = listOf("End"))
+        val end = node(id = "End", type = BpmnElementType.END_EVENT, incoming = listOf("Branch_A", "Branch_B"))
+
+        // when: sorting
         val result = FlowNodeSorter.sort(listOf(end, branchB, gw, branchA, start))
         val ids = result.map { it.id }
 
+        // then: both branches appear after their gateway
         assertThat(ids.indexOf("GW")).isGreaterThan(ids.indexOf("Start"))
         assertThat(ids.indexOf("Branch_A")).isGreaterThan(ids.indexOf("GW"))
         assertThat(ids.indexOf("Branch_B")).isGreaterThan(ids.indexOf("GW"))

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/BpmnModelApiTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/BpmnModelApiTest.kt
@@ -5,16 +5,23 @@ import org.junit.jupiter.api.Test
 
 class BpmnModelApiTest {
 
-    val processIds = listOf("newsletterSubscription", "newsletter-subscription", "newsletter_subscription")
+    private val processIds = listOf(
+        "newsletterSubscription",
+        "newsletter-subscription",
+        "newsletter_subscription",
+    )
 
     @Test
-    fun `should return expected file name`() {
+    fun `fileName returns PascalCase class name regardless of ID separator style`() {
+
+        // given: the expected file name
         val expectedFileName = "NewsletterSubscriptionProcessApi"
+
+        // when / then: all separator variants produce the same file name
         processIds.forEach { id ->
             val model = testBpmnModel(processId = id)
             val api = testBpmnModelApi(model = model)
             assertThat(api.fileName()).isEqualTo(expectedFileName)
         }
     }
-
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationServiceTest.kt
@@ -16,72 +16,100 @@ import org.junit.jupiter.api.assertThrows
 
 class BpmnValidationServiceTest {
 
+    private val underTest = BpmnValidationService()
+
     @Test
     fun `valid model passes all pre-merge rules`() {
-        val service = BpmnValidationService()
+
+        // given: a valid BPMN model
         val model = testBpmnModel()
-        assertDoesNotThrow {
-            service.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
-        }
+
+        // when / then: no exception is thrown
+        assertDoesNotThrow { underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE) }
     }
 
     @Test
-    fun `throws BpmnValidationException for missing implementation`() {
-        val service = BpmnValidationService()
+    fun `throws BpmnValidationException for missing service task implementation`() {
+
+        // given: a model with a service task that has no implementation
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "task1", properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")))
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")),
+                )
             )
         )
+
+        // when: validating pre-merge
         val exception = assertThrows<BpmnValidationException> {
-            service.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
+            underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
         }
+
+        // then: the missing-implementation rule fires
         assertThat(exception.violations).anyMatch { it.ruleId == "missing-service-task-implementation" }
     }
 
     @Test
-    fun `disabled rule is skipped`() {
-        val config = ValidationConfig(disabledRules = setOf("missing-service-task-implementation"))
-        val service = BpmnValidationService(config)
+    fun `disabled rule is skipped during validation`() {
+
+        // given: a service with the implementation rule disabled and a model that would violate it
+        val underTest = BpmnValidationService(
+            ValidationConfig(disabledRules = setOf("missing-service-task-implementation"))
+        )
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "task1", properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")))
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")),
+                )
             )
         )
-        assertDoesNotThrow {
-            service.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
-        }
+
+        // when / then: no exception is thrown because the rule is disabled
+        assertDoesNotThrow { underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE) }
     }
 
     @Test
     fun `warnings do not throw by default`() {
-        val service = BpmnValidationService()
+
+        // given: a model that produces only warnings (empty process)
         val model = testBpmnModel(flowNodes = emptyList())
-        assertDoesNotThrow {
-            service.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
-        }
+
+        // when / then: no exception is thrown
+        assertDoesNotThrow { underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE) }
     }
 
     @Test
     fun `failOnWarning promotes warnings to failures`() {
-        val config = ValidationConfig(failOnWarning = true)
-        val service = BpmnValidationService(config)
+
+        // given: a service with failOnWarning and a model with an empty process
+        val underTest = BpmnValidationService(ValidationConfig(failOnWarning = true))
         val model = testBpmnModel(flowNodes = emptyList())
+
+        // when: validating pre-merge
         val exception = assertThrows<BpmnValidationException> {
-            service.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
+            underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
         }
+
+        // then: the empty-process warning is treated as a failure
         assertThat(exception.violations).anyMatch { it.ruleId == "empty-process" }
     }
 
     @Test
-    fun `throws BpmnValidationException for null element id`() {
-        val service = BpmnValidationService()
+    fun `throws BpmnValidationException for flow node with null element id`() {
+
+        // given: a model containing a flow node without an ID
         val model = testBpmnModel(
             flowNodes = listOf(FlowNodeDefinition(id = null))
         )
+
+        // when: validating pre-merge
         val exception = assertThrows<BpmnValidationException> {
-            service.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
+            underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE)
         }
+
+        // then: the missing-element-id rule fires with ERROR severity
         assertThat(exception.violations).anyMatch {
             it.ruleId == "missing-element-id" && it.severity == Severity.ERROR
         }
@@ -89,16 +117,21 @@ class BpmnValidationServiceTest {
 
     @Test
     fun `post-merge collision detection detects collisions`() {
-        val service = BpmnValidationService()
+
+        // given: a model with two flow nodes that produce the same constant name
         val model = testBpmnModel(
             flowNodes = listOf(
                 FlowNodeDefinition(id = "endEvent_complete"),
                 FlowNodeDefinition(id = "endEvent-complete"),
             )
         )
+
+        // when: validating post-merge
         val exception = assertThrows<BpmnValidationException> {
-            service.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.POST_MERGE)
+            underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.POST_MERGE)
         }
+
+        // then: the collision-detection rule fires
         assertThat(exception.violations).anyMatch { it.ruleId == "collision-detection" }
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/CollisionDetectionServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/CollisionDetectionServiceTest.kt
@@ -1,6 +1,5 @@
 package io.github.emaarco.bpmn.domain.service
 
-import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
@@ -10,62 +9,82 @@ import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL
 import io.github.emaarco.bpmn.domain.shared.SignalDefinition
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
+import io.github.emaarco.bpmn.domain.testBpmnModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class CollisionDetectionServiceTest {
 
-    private val service = CollisionDetectionService()
+    private val underTest = CollisionDetectionService()
 
     @Test
     fun `findCollisions returns empty when no collisions exist`() {
+
+        // given: a model with distinct constant names across all element types
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("Activity_Task1"),
-                FlowNodeDefinition("Activity_Task2"),
-                FlowNodeDefinition("Task1",
-                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition("Task1", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendMail")))),
-                FlowNodeDefinition("Task2",
-                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition("Task2", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendConfirmationMail")))),
+                FlowNodeDefinition(id = "Activity_Task1"),
+                FlowNodeDefinition(id = "Activity_Task2"),
+                FlowNodeDefinition(
+                    id = "Task1",
+                    properties = FlowNodeProperties.ServiceTask(
+                        ServiceTaskDefinition(id = "Task1", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendMail"))
+                    ),
+                ),
+                FlowNodeDefinition(
+                    id = "Task2",
+                    properties = FlowNodeProperties.ServiceTask(
+                        ServiceTaskDefinition(id = "Task2", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendConfirmationMail"))
+                    ),
+                ),
             ),
             messages = listOf(
-                MessageDefinition("Message_FormSubmitted", "Message_FormSubmitted"),
-                MessageDefinition("Message_SubscriptionConfirmed", "Message_SubscriptionConfirmed"),
+                MessageDefinition(id = "Message_FormSubmitted", name = "Message_FormSubmitted"),
+                MessageDefinition(id = "Message_SubscriptionConfirmed", name = "Message_SubscriptionConfirmed"),
             ),
         )
 
-        assertThat(service.findCollisions(model)).isEmpty()
+        // when / then: no collisions are detected
+        assertThat(underTest.findCollisions(model)).isEmpty()
     }
 
     @Test
     fun `findCollisions allows true duplicates with same original ID`() {
+
+        // given: a model with exact duplicate elements (same id)
         val model = testBpmnModel(
             processId = "TestProcess",
             messages = listOf(
-                MessageDefinition("Message_Test", "Message_Test"),
-                MessageDefinition("Message_Test", "Message_Test"),
+                MessageDefinition(id = "Message_Test", name = "Message_Test"),
+                MessageDefinition(id = "Message_Test", name = "Message_Test"),
             ),
             flowNodes = listOf(
-                FlowNodeDefinition("Activity_SendMail"),
-                FlowNodeDefinition("Activity_SendMail"),
+                FlowNodeDefinition(id = "Activity_SendMail"),
+                FlowNodeDefinition(id = "Activity_SendMail"),
             ),
         )
 
-        assertThat(service.findCollisions(model)).isEmpty()
+        // when / then: true duplicates are not treated as collisions
+        assertThat(underTest.findCollisions(model)).isEmpty()
     }
 
     @Test
     fun `findCollisions detects collision with case variation in FlowNodes`() {
+
+        // given: two flow nodes that differ only in case
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("eventData"),
-                FlowNodeDefinition("EventData"),
+                FlowNodeDefinition(id = "eventData"),
+                FlowNodeDefinition(id = "EventData"),
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one collision is reported with the expected constant name
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("FlowNode")
         assertThat(collisions[0].constantName).isEqualTo("EVENT_DATA")
@@ -75,15 +94,20 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collision with separator variation in FlowNodes`() {
+
+        // given: two flow nodes that differ only in separator character
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("endEvent_dataProcessed"),
-                FlowNodeDefinition("endEvent-dataProcessed"),
+                FlowNodeDefinition(id = "endEvent_dataProcessed"),
+                FlowNodeDefinition(id = "endEvent-dataProcessed"),
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one collision is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("FlowNode")
         assertThat(collisions[0].constantName).isEqualTo("END_EVENT_DATA_PROCESSED")
@@ -95,16 +119,21 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collision with mixed case and separator variation`() {
+
+        // given: three flow nodes that all normalize to the same constant
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("eventData"),
-                FlowNodeDefinition("event-data"),
-                FlowNodeDefinition("event_Data"),
+                FlowNodeDefinition(id = "eventData"),
+                FlowNodeDefinition(id = "event-data"),
+                FlowNodeDefinition(id = "event_Data"),
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one collision groups all three IDs
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("FlowNode")
         assertThat(collisions[0].constantName).isEqualTo("EVENT_DATA")
@@ -117,6 +146,8 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collisions in Messages`() {
+
+        // given: two messages that normalize to the same constant
         val model = testBpmnModel(
             processId = "TestProcess",
             messages = listOf(
@@ -125,7 +156,10 @@ class CollisionDetectionServiceTest {
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one Message collision is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("Message")
         assertThat(collisions[0].constantName).isEqualTo("MESSAGE_FORM_SUBMITTED")
@@ -133,17 +167,30 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collisions in ServiceTasks`() {
+
+        // given: two service tasks with implementations that normalize to the same constant
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("task1",
-                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition("task1", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendMail")))),
-                FlowNodeDefinition("task2",
-                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition("task2", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter_sendMail")))),
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(
+                        ServiceTaskDefinition(id = "task1", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter.sendMail"))
+                    ),
+                ),
+                FlowNodeDefinition(
+                    id = "task2",
+                    properties = FlowNodeProperties.ServiceTask(
+                        ServiceTaskDefinition(id = "task2", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "newsletter_sendMail"))
+                    ),
+                ),
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one ServiceTask collision is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("ServiceTask")
         assertThat(collisions[0].constantName).isEqualTo("NEWSLETTER_SEND_MAIL")
@@ -151,6 +198,8 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collisions in Signals`() {
+
+        // given: two signals that normalize to the same constant
         val model = testBpmnModel(
             processId = "TestProcess",
             signals = listOf(
@@ -159,7 +208,10 @@ class CollisionDetectionServiceTest {
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one Signal collision is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("Signal")
         assertThat(collisions[0].constantName).isEqualTo("SIGNAL_COMPLETE")
@@ -167,6 +219,8 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collisions in Errors`() {
+
+        // given: two errors that normalize to the same constant
         val model = testBpmnModel(
             processId = "TestProcess",
             errors = listOf(
@@ -175,7 +229,10 @@ class CollisionDetectionServiceTest {
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one Error collision is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("Error")
         assertThat(collisions[0].constantName).isEqualTo("ERROR_INVALID_MAIL")
@@ -183,17 +240,26 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collisions in Timers`() {
+
+        // given: two timer flow nodes that normalize to the same constant
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("timer1",
-                    properties = FlowNodeProperties.Timer(TimerDefinition("Duration", "Duration", "PT1M"))),
-                FlowNodeDefinition("timer2",
-                    properties = FlowNodeProperties.Timer(TimerDefinition("duration", "Duration", "PT2M"))),
+                FlowNodeDefinition(
+                    id = "timer1",
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = "Duration", type = "Duration", value = "PT1M")),
+                ),
+                FlowNodeDefinition(
+                    id = "timer2",
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = "duration", type = "Duration", value = "PT2M")),
+                ),
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one Timer collision is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("Timer")
         assertThat(collisions[0].constantName).isEqualTo("DURATION")
@@ -201,15 +267,20 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects collisions in Variables`() {
+
+        // given: two nodes with variables that normalize to the same constant
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("node1", variables = listOf(VariableDefinition("userId"))),
-                FlowNodeDefinition("node2", variables = listOf(VariableDefinition("user_id"))),
+                FlowNodeDefinition(id = "node1", variables = listOf(VariableDefinition(name = "userId"))),
+                FlowNodeDefinition(id = "node2", variables = listOf(VariableDefinition(name = "user_id"))),
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: one Variable collision is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].variableType).isEqualTo("Variable")
         assertThat(collisions[0].constantName).isEqualTo("USER_ID")
@@ -217,11 +288,13 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions detects multiple collisions across different variable types`() {
+
+        // given: a model with collisions in FlowNodes, Messages, and Signals simultaneously
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("endEvent_complete"),
-                FlowNodeDefinition("endEvent-complete"),
+                FlowNodeDefinition(id = "endEvent_complete"),
+                FlowNodeDefinition(id = "endEvent-complete"),
             ),
             messages = listOf(
                 MessageDefinition(id = "msg1", name = "message_sent"),
@@ -233,7 +306,10 @@ class CollisionDetectionServiceTest {
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: three collisions are detected, one per type
         assertThat(collisions).hasSize(3)
         assertThat(collisions.map { it.variableType }).containsExactlyInAnyOrder(
             "FlowNode",
@@ -244,33 +320,24 @@ class CollisionDetectionServiceTest {
 
     @Test
     fun `findCollisions handles mixed valid and collision cases`() {
+
+        // given: a model where most nodes are unique but two share a constant name
         val model = testBpmnModel(
             processId = "TestProcess",
             flowNodes = listOf(
-                FlowNodeDefinition("Activity_Task1"),
-                FlowNodeDefinition("Activity_Task2"),
-                FlowNodeDefinition("Activity_Task3"),
-                FlowNodeDefinition("endEvent_complete"),
-                FlowNodeDefinition("endEvent-complete"),
+                FlowNodeDefinition(id = "Activity_Task1"),
+                FlowNodeDefinition(id = "Activity_Task2"),
+                FlowNodeDefinition(id = "Activity_Task3"),
+                FlowNodeDefinition(id = "endEvent_complete"),
+                FlowNodeDefinition(id = "endEvent-complete"),
             ),
         )
 
-        val collisions = service.findCollisions(model)
+        // when: checking for collisions
+        val collisions = underTest.findCollisions(model)
+
+        // then: only the colliding pair is reported
         assertThat(collisions).hasSize(1)
         assertThat(collisions[0].constantName).isEqualTo("END_EVENT_COMPLETE")
     }
-
-    private fun testBpmnModel(
-        processId: String,
-        flowNodes: List<FlowNodeDefinition> = emptyList(),
-        messages: List<MessageDefinition> = emptyList(),
-        signals: List<SignalDefinition> = emptyList(),
-        errors: List<ErrorDefinition> = emptyList(),
-    ) = BpmnModel(
-        processId = processId,
-        flowNodes = flowNodes,
-        messages = messages,
-        signals = signals,
-        errors = errors,
-    )
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerServiceTest.kt
@@ -11,7 +11,7 @@ import io.github.emaarco.bpmn.domain.shared.SignalDefinition
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ModelMergerServiceTest {
@@ -60,7 +60,7 @@ class ModelMergerServiceTest {
         val result = underTest.mergeModels(listOf(firstModel, secondModel, otherModel))
 
         // then
-        Assertions.assertThat(result).containsExactlyInAnyOrder(
+        assertThat(result).containsExactlyInAnyOrder(
             testBpmnModel(
                 processId = "order-process",
                 flowNodes = listOf(firstFlowNode, thirdFlowNode, secondFlowNode),
@@ -102,9 +102,9 @@ class ModelMergerServiceTest {
         val actualFlowNodes = sortedModel.flowNodes.map { it.getRawName() }
         val actualVariables = sortedModel.variables.map { it.getRawName() }
         val actualEscalations = sortedModel.escalations.map { it.getRawName() }
-        Assertions.assertThat(actualFlowNodes).containsExactly("a-node", "m-node", "z-node")
-        Assertions.assertThat(actualVariables).containsExactly("alphaVar", "zetaVar")
-        Assertions.assertThat(actualEscalations).containsExactly("aEscalation", "mEscalation", "zEscalation")
+        assertThat(actualFlowNodes).containsExactly("a-node", "m-node", "z-node")
+        assertThat(actualVariables).containsExactly("alphaVar", "zetaVar")
+        assertThat(actualEscalations).containsExactly("aEscalation", "mEscalation", "zEscalation")
     }
 
     @Test
@@ -142,7 +142,7 @@ class ModelMergerServiceTest {
         val result = underTest.mergeModels(listOf(model))
 
         // then: duplicates should be removed from all element types (sorted alphabetically)
-        Assertions.assertThat(result).containsExactly(
+        assertThat(result).containsExactly(
             testBpmnModel(
                 processId = "test-process",
                 errors = listOf(ErrorDefinition(id = "TEST_ERROR", name = "TEST_ERROR", code = "400")),
@@ -213,7 +213,7 @@ class ModelMergerServiceTest {
         val result = underTest.mergeModels(listOf(firstModel, secondModel))
 
         // then: should merge into a single model with deduplicated elements
-        Assertions.assertThat(result).containsExactly(
+        assertThat(result).containsExactly(
             testBpmnModel(
                 processId = "test-process",
                 errors = listOf(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
@@ -11,22 +11,28 @@ import org.junit.jupiter.api.Test
 
 class CollisionDetectionRuleTest {
 
-    private val rule = CollisionDetectionRule()
+    private val underTest = CollisionDetectionRule()
 
     @Test
     fun `phase is POST_MERGE`() {
-        assertThat(rule.phase).isEqualTo(ValidationPhase.POST_MERGE)
+        assertThat(underTest.phase).isEqualTo(ValidationPhase.POST_MERGE)
     }
 
     @Test
     fun `reports collision when different IDs normalize to same constant`() {
+
+        // given: two flow nodes that differ only in separator
         val model = testBpmnModel(
             flowNodes = listOf(
                 FlowNodeDefinition(id = "endEvent_complete"),
                 FlowNodeDefinition(id = "endEvent-complete"),
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when: validating
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+
+        // then: one error violation referencing conflicting IDs
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
         assertThat(violations[0].message).contains("conflicting IDs")
@@ -34,13 +40,17 @@ class CollisionDetectionRuleTest {
 
     @Test
     fun `no violations when no collisions`() {
+
+        // given: two flow nodes with distinct constant names
         val model = testBpmnModel(
             flowNodes = listOf(
                 FlowNodeDefinition(id = "Activity_One"),
                 FlowNodeDefinition(id = "Activity_Two"),
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EmptyProcessRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EmptyProcessRuleTest.kt
@@ -10,22 +10,30 @@ import org.junit.jupiter.api.Test
 
 class EmptyProcessRuleTest {
 
-    private val rule = EmptyProcessRule()
+    private val underTest = EmptyProcessRule()
 
     @Test
     fun `reports warning for process with no elements`() {
+
+        // given: a model with no flow nodes
         val model = testBpmnModel(flowNodes = emptyList())
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: a WARN violation is reported
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.WARN)
     }
 
     @Test
     fun `no violations for process with elements`() {
+
+        // given: a model with at least one flow node
         val model = testBpmnModel(
             flowNodes = listOf(FlowNodeDefinition(id = "Activity_Task1"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
@@ -12,14 +12,20 @@ import org.junit.jupiter.api.Test
 
 class InvalidIdentifierRuleTest {
 
-    private val rule = InvalidIdentifierRule()
+    private val underTest = InvalidIdentifierRule()
 
     @Test
     fun `reports warning for flow node producing invalid identifier`() {
+
+        // given: a flow node whose ID starts with a digit
         val model = testBpmnModel(
             flowNodes = listOf(FlowNodeDefinition(id = "123-invalid"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when: validating
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+
+        // then: a WARN violation mentioning "invalid identifier"
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.WARN)
         assertThat(violations[0].message).contains("invalid identifier")
@@ -27,12 +33,21 @@ class InvalidIdentifierRuleTest {
 
     @Test
     fun `reports warning for timer producing invalid identifier`() {
+
+        // given: a timer flow node whose ID starts with a digit
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "123-timer", properties = FlowNodeProperties.Timer(TimerDefinition(id = "123-timer", type = "Duration", value = "PT1H")))
+                FlowNodeDefinition(
+                    id = "123-timer",
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = "123-timer", type = "Duration", value = "PT1H")),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when: validating
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+
+        // then: a WARN violation mentioning "invalid identifier"
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.WARN)
         assertThat(violations[0].message).contains("invalid identifier")
@@ -40,21 +55,32 @@ class InvalidIdentifierRuleTest {
 
     @Test
     fun `no violations for valid identifiers`() {
+
+        // given: a flow node with a valid ID
         val model = testBpmnModel(
             flowNodes = listOf(FlowNodeDefinition(id = "Activity_SendMail"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 
     @Test
     fun `no violations for timer with valid identifier`() {
+
+        // given: a timer flow node with a valid ID
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "Timer_After3Days", properties = FlowNodeProperties.Timer(TimerDefinition(id = "Timer_After3Days", type = "Duration", value = "PT1H")))
+                FlowNodeDefinition(
+                    id = "Timer_After3Days",
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = "Timer_After3Days", type = "Duration", value = "PT1H")),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingCalledElementRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingCalledElementRuleTest.kt
@@ -12,28 +12,42 @@ import org.junit.jupiter.api.Test
 
 class MissingCalledElementRuleTest {
 
-    private val rule = MissingCalledElementRule()
+    private val underTest = MissingCalledElementRule()
 
     @Test
     fun `reports error for call activity with null calledElement`() {
+
+        // given: a call activity with no calledElement set
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "call1", properties = FlowNodeProperties.CallActivity(CallActivityDefinition(id = "call1", calledElement = null)))
+                FlowNodeDefinition(
+                    id = "call1",
+                    properties = FlowNodeProperties.CallActivity(CallActivityDefinition(id = "call1", calledElement = null)),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: an ERROR violation is reported
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
 
     @Test
     fun `no violations for call activity with calledElement`() {
+
+        // given: a call activity with a valid calledElement reference
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "call1", properties = FlowNodeProperties.CallActivity(CallActivityDefinition(id = "call1", calledElement = "my-sub-process")))
+                FlowNodeDefinition(
+                    id = "call1",
+                    properties = FlowNodeProperties.CallActivity(CallActivityDefinition(id = "call1", calledElement = "my-sub-process")),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingElementIdRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingElementIdRuleTest.kt
@@ -10,14 +10,18 @@ import org.junit.jupiter.api.Test
 
 class MissingElementIdRuleTest {
 
-    private val rule = MissingElementIdRule()
+    private val underTest = MissingElementIdRule()
 
     @Test
     fun `reports error for flow node with null id`() {
+
+        // given: a model containing a flow node without an ID
         val model = testBpmnModel(
             flowNodes = listOf(FlowNodeDefinition(id = null))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: an ERROR violation mentioning "FlowNode has no ID"
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
         assertThat(violations[0].message).contains("FlowNode has no ID")
@@ -25,10 +29,14 @@ class MissingElementIdRuleTest {
 
     @Test
     fun `no violations for elements with valid ids`() {
+
+        // given: a flow node with a valid ID
         val model = testBpmnModel(
             flowNodes = listOf(FlowNodeDefinition(id = "Activity_SendMail"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingErrorDefinitionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingErrorDefinitionRuleTest.kt
@@ -10,33 +10,45 @@ import org.junit.jupiter.api.Test
 
 class MissingErrorDefinitionRuleTest {
 
-    private val rule = MissingErrorDefinitionRule()
+    private val underTest = MissingErrorDefinitionRule()
 
     @Test
     fun `reports error for error with null name`() {
+
+        // given: an error element with no name
         val model = testBpmnModel(
             errors = listOf(ErrorDefinition(id = "err1", name = null, code = "500"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: an ERROR violation is reported
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
 
     @Test
     fun `reports error for error with null code`() {
+
+        // given: an error element with no code
         val model = testBpmnModel(
             errors = listOf(ErrorDefinition(id = "err1", name = "MyError", code = null))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: a violation is reported
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
     }
 
     @Test
     fun `no violations for error with all fields`() {
+
+        // given: a fully defined error element
         val model = testBpmnModel(
             errors = listOf(ErrorDefinition(id = "err1", name = "MyError", code = "500"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingMessageNameRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingMessageNameRuleTest.kt
@@ -10,14 +10,18 @@ import org.junit.jupiter.api.Test
 
 class MissingMessageNameRuleTest {
 
-    private val rule = MissingMessageNameRule()
+    private val underTest = MissingMessageNameRule()
 
     @Test
     fun `reports error for message with null name`() {
+
+        // given: a message element with no name
         val model = testBpmnModel(
             messages = listOf(MessageDefinition(id = "msg1", name = null))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: an ERROR violation is reported for the message element
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
         assertThat(violations[0].elementId).isEqualTo("msg1")
@@ -25,10 +29,14 @@ class MissingMessageNameRuleTest {
 
     @Test
     fun `no violations for message with valid name`() {
+
+        // given: a message element with a valid name
         val model = testBpmnModel(
             messages = listOf(MessageDefinition(id = "msg1", name = "MyMessage"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingProcessIdRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingProcessIdRuleTest.kt
@@ -9,20 +9,28 @@ import org.junit.jupiter.api.Test
 
 class MissingProcessIdRuleTest {
 
-    private val rule = MissingProcessIdRule()
+    private val underTest = MissingProcessIdRule()
 
     @Test
     fun `reports error for blank process id`() {
+
+        // given: a model with an empty process ID
         val model = testBpmnModel(processId = "")
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: an ERROR violation is reported
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
 
     @Test
     fun `no violations for valid process id`() {
+
+        // given: a model with a non-blank process ID
         val model = testBpmnModel(processId = "my-process")
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingServiceTaskImplementationRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingServiceTaskImplementationRuleTest.kt
@@ -13,16 +13,25 @@ import org.junit.jupiter.api.Test
 
 class MissingServiceTaskImplementationRuleTest {
 
-    private val rule = MissingServiceTaskImplementationRule()
+    private val underTest = MissingServiceTaskImplementationRule()
 
     @Test
     fun `reports error for service task with null type`() {
+
+        // given: a service task with no implementation
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "task1", properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")))
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when: validating against Zeebe
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+
+        // then: an ERROR violation mentioning zeebe:taskDefinition
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
         assertThat(violations[0].elementId).isEqualTo("task1")
@@ -31,34 +40,57 @@ class MissingServiceTaskImplementationRuleTest {
 
     @Test
     fun `no violations for service task with valid type`() {
+
+        // given: a service task with a valid implementation
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "task1", properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "myWorker"))))
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(
+                        ServiceTaskDefinition(id = "task1", engineSpecificProperties = mapOf(IMPL_VALUE_KEY to "myWorker"))
+                    ),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.CAMUNDA_7))
+
+        // when / then: no violations (for any engine)
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
         assertThat(violations).isEmpty()
     }
 
     @Test
     fun `engine-specific hint for Camunda 7`() {
+
+        // given: a service task with no implementation validated against Camunda 7
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "task1", properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")))
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.CAMUNDA_7))
+
+        // when / then: the violation message mentions camunda:topic
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
         assertThat(violations[0].message).contains("camunda:topic")
     }
 
     @Test
     fun `engine-specific hint for Operaton`() {
+
+        // given: a service task with no implementation validated against Operaton
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "task1", properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")))
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.OPERATON))
+
+        // when / then: the violation message mentions operaton:topic
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.OPERATON))
         assertThat(violations[0].message).contains("operaton:topic")
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingSignalNameRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingSignalNameRuleTest.kt
@@ -10,24 +10,32 @@ import org.junit.jupiter.api.Test
 
 class MissingSignalNameRuleTest {
 
-    private val rule = MissingSignalNameRule()
+    private val underTest = MissingSignalNameRule()
 
     @Test
     fun `reports error for signal with null name`() {
+
+        // given: a signal element with no name
         val model = testBpmnModel(
             signals = listOf(SignalDefinition(id = "sig1", name = null))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: an ERROR violation is reported
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
 
     @Test
     fun `no violations for signal with name`() {
+
+        // given: a signal element with a valid name
         val model = testBpmnModel(
             signals = listOf(SignalDefinition(id = "sig1", name = "MySignal"))
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingTimerDefinitionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingTimerDefinitionRuleTest.kt
@@ -12,28 +12,42 @@ import org.junit.jupiter.api.Test
 
 class MissingTimerDefinitionRuleTest {
 
-    private val rule = MissingTimerDefinitionRule()
+    private val underTest = MissingTimerDefinitionRule()
 
     @Test
     fun `reports error for timer with null type`() {
+
+        // given: a timer flow node with no type or value
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "timer1", properties = FlowNodeProperties.Timer(TimerDefinition(id = "timer1", type = null, value = null)))
+                FlowNodeDefinition(
+                    id = "timer1",
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = "timer1", type = null, value = null)),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: an ERROR violation is reported
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
     }
 
     @Test
     fun `no violations for timer with type and value`() {
+
+        // given: a timer flow node with a valid type and value
         val model = testBpmnModel(
             flowNodes = listOf(
-                FlowNodeDefinition(id = "timer1", properties = FlowNodeProperties.Timer(TimerDefinition(id = "timer1", type = "Duration", value = "PT1H")))
+                FlowNodeDefinition(
+                    id = "timer1",
+                    properties = FlowNodeProperties.Timer(TimerDefinition(id = "timer1", type = "Duration", value = "PT1H")),
+                )
             )
         )
-        val violations = rule.validate(ValidationContext(model, ProcessEngine.ZEEBE))
+
+        // when / then: no violations
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
         assertThat(violations).isEmpty()
     }
 }

--- a/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginDependencyResolutionSmokeTest.kt
+++ b/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginDependencyResolutionSmokeTest.kt
@@ -23,12 +23,11 @@ class GradlePluginDependencyResolutionSmokeTest {
 
     @Test
     fun `plugin resolves all dependencies from published artifact`(@TempDir projectDir: File) {
-        // Copy BPMN file into the temp project
+
+        // given: a minimal project configured to resolve the plugin from mavenLocal
         val resourcesDir = File(projectDir, "src/main/resources").also { it.mkdirs() }
         val bpmnStream = requireNotNull(javaClass.classLoader.getResourceAsStream("bpmn/c8-subscribe-newsletter.bpmn"))
         File(resourcesDir, "c8-subscribe-newsletter.bpmn").writeBytes(bpmnStream.readBytes())
-
-        // Write settings.gradle with pluginManagement resolving from mavenLocal
         File(projectDir, "settings.gradle").writeText(
             """
             pluginManagement {
@@ -40,8 +39,6 @@ class GradlePluginDependencyResolutionSmokeTest {
             }
             """.trimIndent()
         )
-
-        // Write build.gradle that applies the plugin by ID + version (resolved from mavenLocal)
         File(projectDir, "build.gradle").writeText(
             """
             plugins {
@@ -59,14 +56,14 @@ class GradlePluginDependencyResolutionSmokeTest {
             """.trimIndent()
         )
 
-        // Run WITHOUT withPluginClasspath() — Gradle resolves from mavenLocal
+        // when: running WITHOUT withPluginClasspath() so Gradle resolves from mavenLocal
         val result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments("generateBpmnModelApi")
             .build()
 
+        // then: the task succeeds and generates Kotlin files
         assertThat(result.task(":generateBpmnModelApi")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
         val packageDir = File(projectDir, "build/generated/io/github/emaarco/smoketest")
         assertThat(packageDir).isDirectory()
         val generatedFiles = requireNotNull(packageDir.listFiles())

--- a/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginSmokeTest.kt
+++ b/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginSmokeTest.kt
@@ -23,15 +23,11 @@ class GradlePluginSmokeTest {
         bpmnFile: String,
         @TempDir projectDir: File,
     ) {
-        // Copy BPMN file into the temp project
+        // given: a minimal Gradle project with the plugin applied and a BPMN resource
         val resourcesDir = File(projectDir, "src/main/resources").also { it.mkdirs() }
         val bpmnStream = requireNotNull(javaClass.classLoader.getResourceAsStream("bpmn/$bpmnFile"))
         File(resourcesDir, bpmnFile).writeBytes(bpmnStream.readBytes())
-
-        // Write settings.gradle
         File(projectDir, "settings.gradle").writeText("")
-
-        // Write build.gradle (Groovy DSL — avoids classpath issues with typed imports)
         File(projectDir, "build.gradle").writeText(
             """
             plugins {
@@ -49,22 +45,19 @@ class GradlePluginSmokeTest {
             """.trimIndent()
         )
 
-        // Run the task
+        // when: running the generateBpmnModelApi task
         val result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withPluginClasspath()
             .withArguments("generateBpmnModelApi")
             .build()
 
-        // Verify task succeeded
+        // then: the task succeeds and generates the expected files
         assertThat(result.task(":generateBpmnModelApi")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        // Verify output files were generated
         val packageDir = File(projectDir, "build/generated/io/github/emaarco/smoketest")
         assertThat(packageDir).isDirectory()
         val generatedFiles = requireNotNull(packageDir.listFiles())
         assertThat(generatedFiles).isNotEmpty()
-
         val expectedExt = if (language == "KOTLIN") ".kt" else ".java"
         val modelFiles = generatedFiles.filter { it.isFile }
         assertThat(modelFiles).allSatisfy { file -> assertThat(file.name).endsWith(expectedExt) }

--- a/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradleValidationSmokeTest.kt
+++ b/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradleValidationSmokeTest.kt
@@ -21,15 +21,11 @@ class GradleValidationSmokeTest {
         bpmnFile: String,
         @TempDir projectDir: File,
     ) {
-        // Copy BPMN file into the temp project
+        // given: a minimal project with a valid BPMN file for the given engine
         val resourcesDir = File(projectDir, "src/main/resources").also { it.mkdirs() }
         val bpmnStream = javaClass.classLoader.getResourceAsStream("bpmn/$bpmnFile")!!
         File(resourcesDir, bpmnFile).writeBytes(bpmnStream.readBytes())
-
-        // Write settings.gradle
         File(projectDir, "settings.gradle").writeText("")
-
-        // Write build.gradle
         File(projectDir, "build.gradle").writeText(
             """
             plugins {
@@ -44,14 +40,14 @@ class GradleValidationSmokeTest {
             """.trimIndent()
         )
 
-        // Run the task
+        // when: running the validateBpmnModels task
         val result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withPluginClasspath()
             .withArguments("validateBpmnModels")
             .build()
 
-        // Verify task succeeded
+        // then: the task succeeds with a validation passed message
         assertThat(result.task(":validateBpmnModels")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
         assertThat(result.output).contains("BPMN validation passed")
     }

--- a/bpmn-to-code-maven/src/test/kotlin/io/github/emaarco/bpmn/adapter/MavenMojoSmokeTest.kt
+++ b/bpmn-to-code-maven/src/test/kotlin/io/github/emaarco/bpmn/adapter/MavenMojoSmokeTest.kt
@@ -21,14 +21,11 @@ class MavenMojoSmokeTest {
         bpmnFile: String,
         @TempDir projectDir: File,
     ) {
-        // Copy BPMN file into the temp project
+        // given: a temp project directory with a BPMN resource and a configured mojo
         val resourcesDir = File(projectDir, "src/main/resources").also { it.mkdirs() }
         val bpmnStream = requireNotNull(javaClass.classLoader.getResourceAsStream("bpmn/$bpmnFile"))
         File(resourcesDir, bpmnFile).writeBytes(bpmnStream.readBytes())
-
         val outputDir = File(projectDir, "build/generated")
-
-        // Instantiate Mojo and set fields via reflection
         val mojo = BpmnModelMojo()
         setField(mojo, "baseDir", projectDir.absolutePath)
         setField(mojo, "filePattern", "src/main/resources/*.bpmn")
@@ -37,15 +34,14 @@ class MavenMojoSmokeTest {
         setField(mojo, "outputLanguage", language)
         setField(mojo, "processEngine", engine)
 
-        // Execute
+        // when: executing the mojo
         mojo.execute()
 
-        // Verify output files were generated
+        // then: the expected output files are generated
         val packageDir = File(outputDir, "io/github/emaarco/smoketest")
         assertThat(packageDir).isDirectory()
         val generatedFiles = requireNotNull(packageDir.listFiles())
         assertThat(generatedFiles).isNotEmpty()
-
         val expectedExt = if (language == "KOTLIN") ".kt" else ".java"
         val modelFiles = generatedFiles.filter { it.isFile }
         assertThat(modelFiles).allSatisfy { file -> assertThat(file.name).endsWith(expectedExt) }

--- a/bpmn-to-code-maven/src/test/kotlin/io/github/emaarco/bpmn/adapter/MavenValidateMojoSmokeTest.kt
+++ b/bpmn-to-code-maven/src/test/kotlin/io/github/emaarco/bpmn/adapter/MavenValidateMojoSmokeTest.kt
@@ -1,6 +1,5 @@
 package io.github.emaarco.bpmn.adapter
 
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -20,19 +19,17 @@ class MavenValidateMojoSmokeTest {
         bpmnFile: String,
         @TempDir projectDir: File,
     ) {
-        // Copy BPMN file into the temp project
+        // given: a temp project directory with a valid BPMN resource and a configured mojo
         val resourcesDir = File(projectDir, "src/main/resources").also { it.mkdirs() }
         val bpmnStream = javaClass.classLoader.getResourceAsStream("bpmn/$bpmnFile")!!
         File(resourcesDir, bpmnFile).writeBytes(bpmnStream.readBytes())
-
-        // Instantiate Mojo and set fields via reflection
         val mojo = BpmnValidateMojo()
         setField(mojo, "baseDir", projectDir.absolutePath)
         setField(mojo, "filePattern", "src/main/resources/*.bpmn")
         setField(mojo, "processEngine", engine)
         setField(mojo, "failOnWarning", false)
 
-        // Execute — should not throw
+        // when / then: executing the mojo does not throw
         assertThatCode { mojo.execute() }.doesNotThrowAnyException()
     }
 

--- a/bpmn-to-code-mcp/src/test/kotlin/io/github/emaarco/bpmn/mcp/tools/GenerateProcessApiToolTest.kt
+++ b/bpmn-to-code-mcp/src/test/kotlin/io/github/emaarco/bpmn/mcp/tools/GenerateProcessApiToolTest.kt
@@ -8,14 +8,18 @@ import org.junit.jupiter.api.Test
 
 class GenerateProcessApiToolTest {
 
-    private val plugin = CreateProcessApiInMemoryPlugin()
+    private val underTest = CreateProcessApiInMemoryPlugin()
 
     @Test
     fun `generates Kotlin API from Zeebe BPMN`() {
+
+        // when: generating a Kotlin API from a Zeebe BPMN file
         val result = generate(
             bpmnFile = "c8-subscribe-newsletter.bpmn",
             processName = "newsletter-subscription",
         )
+
+        // then: a Kotlin process API file is produced in the correct package
         assertThat(result).isNotEmpty()
         assertThat(result.any { it.fileName.contains("NewsletterSubscriptionProcessApi") }).isTrue()
         assertThat(result.any { it.fileName.endsWith(".kt") }).isTrue()
@@ -24,11 +28,15 @@ class GenerateProcessApiToolTest {
 
     @Test
     fun `generates Java API from Zeebe BPMN`() {
+
+        // when: generating a Java API from a Zeebe BPMN file
         val result = generate(
             bpmnFile = "c8-subscribe-newsletter.bpmn",
             processName = "newsletter-subscription",
             outputLanguage = OutputLanguage.JAVA,
         )
+
+        // then: a Java process API file is produced
         assertThat(result).isNotEmpty()
         assertThat(result.any { it.fileName.contains("NewsletterSubscriptionProcessApi") }).isTrue()
         assertThat(result.any { it.fileName.endsWith(".java") }).isTrue()
@@ -36,44 +44,60 @@ class GenerateProcessApiToolTest {
 
     @Test
     fun `generates API for Camunda 7 engine`() {
+
+        // when: generating for a Camunda 7 BPMN file
         val result = generate(
             bpmnFile = "c7-subscribe-newsletter.bpmn",
             processName = "newsletter-subscription",
             processEngine = ProcessEngine.CAMUNDA_7,
         )
+
+        // then: the process API file is produced
         assertThat(result).isNotEmpty()
         assertThat(result.any { it.fileName.contains("NewsletterSubscriptionProcessApi") }).isTrue()
     }
 
     @Test
     fun `generates API for Operaton engine`() {
+
+        // when: generating for an Operaton BPMN file
         val result = generate(
             bpmnFile = "operaton-subscribe-newsletter.bpmn",
             processName = "newsletter-subscription",
             processEngine = ProcessEngine.OPERATON,
         )
+
+        // then: the process API file is produced
         assertThat(result).isNotEmpty()
         assertThat(result.any { it.fileName.contains("NewsletterSubscriptionProcessApi") }).isTrue()
     }
 
     @Test
     fun `uses custom packagePath`() {
+
+        // when: generating with a custom package path
         val result = generate(
             bpmnFile = "c8-subscribe-newsletter.bpmn",
             processName = "newsletter-subscription",
             packagePath = "com.myapp.workflows",
         )
+
+        // then: all files are in the custom package
         assertThat(result).isNotEmpty()
         assertThat(result.all { it.content.contains("package com.myapp.workflows") }).isTrue()
     }
 
     @Test
     fun `formats output with filename headers`() {
+
+        // when: generating and formatting with headers
         val result = generate(
             bpmnFile = "c8-subscribe-newsletter.bpmn",
             processName = "newsletter-subscription",
         )
         val formatted = result.joinToString("\n\n") { "// === ${it.fileName} ===\n${it.content}" }
+
+        // then: formatted output contains file headers and the process API class
         assertThat(formatted).contains("// === ")
         assertThat(formatted).contains("NewsletterSubscriptionProcessApi")
     }
@@ -84,7 +108,7 @@ class GenerateProcessApiToolTest {
         outputLanguage: OutputLanguage = OutputLanguage.KOTLIN,
         processEngine: ProcessEngine = ProcessEngine.ZEEBE,
         packagePath: String = "com.example.process",
-    ) = plugin.execute(
+    ) = underTest.execute(
         bpmnContents = listOf(
             CreateProcessApiInMemoryPlugin.BpmnInput(
                 bpmnXml = loadBpmn(bpmnFile),

--- a/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnProcessArchitectureTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnProcessArchitectureTest.kt
@@ -43,6 +43,10 @@ class BpmnProcessArchitectureTest {
 
     @Test
     fun `validate shared bpmn files with Camunda 7 using built-in and custom rules`() {
+
+        // given: a Camunda 7 BPMN file validated with built-in and custom rules
+
+        // when: running validation
         val assert = BpmnValidator
             .fromClasspath("bpmn/c7-subscribe-newsletter.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
@@ -54,6 +58,7 @@ class BpmnProcessArchitectureTest {
             )
             .validate()
 
+        // then: no errors or violations for the relevant rules
         assert.assertNoErrors()
         assert.assertNoViolations("missing-service-task-implementation")
         assert.assertNoViolations("missing-message-name")
@@ -62,6 +67,8 @@ class BpmnProcessArchitectureTest {
 
     @Test
     fun `validate shared bpmn files with Zeebe`() {
+
+        // when: running validation on a Zeebe BPMN file
         val assert = BpmnValidator
             .fromClasspath("bpmn/c8-subscribe-newsletter.bpmn")
             .engine(ProcessEngine.ZEEBE)
@@ -72,11 +79,16 @@ class BpmnProcessArchitectureTest {
             )
             .validate()
 
+        // then: no errors
         assert.assertNoErrors()
     }
 
     @Test
     fun `disableRules filters violations and assertNoViolations confirms`() {
+
+        // given: an invalid BPMN file with the implementation rule disabled
+
+        // when: running validation
         val assert = BpmnValidator
             .fromClasspath("bpmn/invalid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
@@ -84,30 +96,35 @@ class BpmnProcessArchitectureTest {
             .disableRules("missing-service-task-implementation")
             .validate()
 
+        // then: the disabled rule produces no violations
         assert.assertNoViolations("missing-service-task-implementation")
     }
 
     @Test
     fun `compose built-in and custom rules in single validation`() {
-        val allRules = BpmnRules.all() + serviceTaskNamingRule
 
+        // when: running all built-in and custom rules against a valid process
         val assert = BpmnValidator
             .fromClasspath("bpmn/valid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
-            .withRules(allRules)
+            .withRules(BpmnRules.all() + serviceTaskNamingRule)
             .validate()
 
+        // then: no errors
         assert.assertNoErrors()
     }
 
     @Test
     fun `result escape hatch provides raw ValidationResult`() {
+
+        // when: validating a valid process and accessing the raw result
         val assert = BpmnValidator
             .fromClasspath("bpmn/valid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
             .withRules(BpmnRules.MISSING_SERVICE_TASK_IMPLEMENTATION)
             .validate()
 
+        // then: raw result reports as valid
         val result = assert.result()
         assertThat(result.isValid).isTrue()
     }

--- a/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoaderTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoaderTest.kt
@@ -18,9 +18,8 @@ class BpmnResourceLoaderTest {
 
     @Test
     fun `fromClasspath throws on missing classpath path`() {
-        assertThatThrownBy {
-            BpmnResourceLoader.fromClasspath("nonexistent/path")
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { BpmnResourceLoader.fromClasspath("nonexistent/path") }
+            .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("No classpath resources found")
     }
 
@@ -32,23 +31,29 @@ class BpmnResourceLoaderTest {
 
     @Test
     fun `fromDirectory loads all bpmn files recursively`(@TempDir tempDir: Path) {
+
+        // given: a directory with BPMN files in root and subdirectory, plus a non-BPMN file
         val subDir = Files.createDirectory(tempDir.resolve("sub"))
         Files.createFile(tempDir.resolve("root.bpmn"))
         Files.createFile(subDir.resolve("nested.bpmn"))
         Files.createFile(tempDir.resolve("other.xml"))
 
+        // when: loading from the directory
         val resources = BpmnResourceLoader.fromDirectory(tempDir)
 
+        // then: only the BPMN files are returned
         assertThat(resources.map { it.fileName }).containsExactlyInAnyOrder("root.bpmn", "nested.bpmn")
     }
 
     @Test
     fun `fromDirectory throws when path is not a directory`(@TempDir tempDir: Path) {
+
+        // given: a regular file (not a directory)
         val file = Files.createFile(tempDir.resolve("process.bpmn"))
 
-        assertThatThrownBy {
-            BpmnResourceLoader.fromDirectory(file)
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        // when / then: an exception is thrown
+        assertThatThrownBy { BpmnResourceLoader.fromDirectory(file) }
+            .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Path is not a directory")
     }
 }

--- a/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnValidatorTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnValidatorTest.kt
@@ -11,6 +11,8 @@ class BpmnValidatorTest {
 
     @Test
     fun `valid bpmn passes assertNoErrors`() {
+
+        // when / then: a valid BPMN file produces no errors
         BpmnValidator
             .fromClasspath("bpmn/valid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
@@ -21,6 +23,8 @@ class BpmnValidatorTest {
 
     @Test
     fun `invalid bpmn detects violations`() {
+
+        // when / then: an invalid BPMN file produces at least one violation
         BpmnValidator
             .fromClasspath("bpmn/invalid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
@@ -31,6 +35,8 @@ class BpmnValidatorTest {
 
     @Test
     fun `custom rules are applied via withRules`() {
+
+        // when / then: the empty-process rule does not trigger for a valid process
         BpmnValidator
             .fromClasspath("bpmn/valid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
@@ -41,6 +47,10 @@ class BpmnValidatorTest {
 
     @Test
     fun `disableRules filters out specified rules`() {
+
+        // given: an invalid process with the implementation rule disabled
+
+        // when / then: the disabled rule produces no violations
         BpmnValidator
             .fromClasspath("bpmn/invalid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)
@@ -52,6 +62,8 @@ class BpmnValidatorTest {
 
     @Test
     fun `missing engine throws clear error`() {
+
+        // when / then: validating without setting an engine throws with a clear message
         assertThatThrownBy {
             BpmnValidator
                 .fromClasspath("bpmn/valid-process.bpmn")
@@ -62,9 +74,12 @@ class BpmnValidatorTest {
 
     @Test
     fun `fromDirectory loads bpmn files`(@TempDir tempDir: Path) {
+
+        // given: a BPMN file copied into a temp directory
         val bpmnContent = javaClass.classLoader.getResourceAsStream("bpmn/valid-process.bpmn")!!
         Files.copy(bpmnContent, tempDir.resolve("test.bpmn"))
 
+        // when / then: validation succeeds when loading from the directory
         BpmnValidator
             .fromDirectory(tempDir)
             .engine(ProcessEngine.CAMUNDA_7)
@@ -75,6 +90,8 @@ class BpmnValidatorTest {
 
     @Test
     fun `defaults to all rules when withRules is not called`() {
+
+        // when / then: a valid process passes all default rules without errors
         BpmnValidator
             .fromClasspath("bpmn/valid-process.bpmn")
             .engine(ProcessEngine.CAMUNDA_7)

--- a/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
+++ b/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
@@ -9,38 +9,32 @@ import java.util.*
 
 class WebGenerationServiceTest {
 
-    private val service = WebGenerationService()
-
-    private fun loadBpmnBase64(resourcePath: String): String {
-        val bytes = javaClass.classLoader.getResourceAsStream(resourcePath)!!.readBytes()
-        return Base64.getEncoder().encodeToString(bytes)
-    }
+    private val underTest = WebGenerationService()
 
     @Test
     fun `should generate Kotlin API from BPMN file`() {
-        val base64Content = loadBpmnBase64("bpmn/c8-subscribe-newsletter.bpmn")
 
+        // given: a valid Zeebe BPMN file encoded as Base64
         val request = GenerateRequest(
             files = listOf(
                 GenerateRequest.BpmnFileData(
                     fileName = "c8-subscribe-newsletter.bpmn",
-                    content = base64Content
+                    content = loadBpmnBase64("bpmn/c8-subscribe-newsletter.bpmn"),
                 )
             ),
             config = GenerateRequest.GenerationConfig(
                 outputLanguage = OutputLanguage.KOTLIN,
-                processEngine = ProcessEngine.ZEEBE
+                processEngine = ProcessEngine.ZEEBE,
             )
         )
 
-        // Execute
-        val response = service.generate(request)
+        // when: generating the API
+        val response = underTest.generate(request)
 
-        // Verify
+        // then: a Kotlin file is generated containing the process constant
         assertThat(response.success).describedAs("Generation should succeed").isTrue()
         assertThat(response.files).describedAs("Should generate at least one file").isNotEmpty()
         assertThat(response.error).describedAs("Should not have errors").isNull()
-
         val generatedFile = response.files.first()
         assertThat(generatedFile.fileName).describedAs("Should generate Kotlin file").endsWith(".kt")
         assertThat(generatedFile.content).describedAs("Should contain Kotlin object declaration").contains("object")
@@ -49,26 +43,27 @@ class WebGenerationServiceTest {
 
     @Test
     fun `should generate Java API from BPMN file`() {
-        val base64Content = loadBpmnBase64("bpmn/c8-subscribe-newsletter.bpmn")
 
+        // given: a valid Zeebe BPMN file with Java output language
         val request = GenerateRequest(
             files = listOf(
                 GenerateRequest.BpmnFileData(
                     fileName = "c8-subscribe-newsletter.bpmn",
-                    content = base64Content
+                    content = loadBpmnBase64("bpmn/c8-subscribe-newsletter.bpmn"),
                 )
             ),
             config = GenerateRequest.GenerationConfig(
                 outputLanguage = OutputLanguage.JAVA,
-                processEngine = ProcessEngine.ZEEBE
+                processEngine = ProcessEngine.ZEEBE,
             )
         )
 
-        val response = service.generate(request)
+        // when: generating the API
+        val response = underTest.generate(request)
 
+        // then: a Java class file is generated
         assertThat(response.success).isTrue()
         assertThat(response.files).isNotEmpty()
-
         val generatedFile = response.files.first()
         assertThat(generatedFile.fileName).describedAs("Should generate Java file").endsWith(".java")
         assertThat(generatedFile.content).describedAs("Should contain Java class declaration").contains("class")
@@ -76,21 +71,25 @@ class WebGenerationServiceTest {
 
     @Test
     fun `should handle invalid Base64 content gracefully`() {
+
+        // given: a request with invalid Base64 content
         val request = GenerateRequest(
             files = listOf(
                 GenerateRequest.BpmnFileData(
                     fileName = "invalid.bpmn",
-                    content = "not-valid-base64!!!"
+                    content = "not-valid-base64!!!",
                 )
             ),
             config = GenerateRequest.GenerationConfig(
                 outputLanguage = OutputLanguage.KOTLIN,
-                processEngine = ProcessEngine.ZEEBE
+                processEngine = ProcessEngine.ZEEBE,
             )
         )
 
-        val response = service.generate(request)
+        // when: generating the API
+        val response = underTest.generate(request)
 
+        // then: the response indicates failure with an error message
         assertThat(response.success).isFalse()
         assertThat(response.error).isNotNull()
         assertThat(response.files).isEmpty()
@@ -98,26 +97,32 @@ class WebGenerationServiceTest {
 
     @Test
     fun `should process up to 3 BPMN files successfully`() {
-        // Note: The 3-file limit is enforced at the route layer, not service layer
-        // This test verifies the service can handle 3 files without errors
-        val c8Base64 = loadBpmnBase64("bpmn/c8-subscribe-newsletter.bpmn")
 
+        // given: a request with 3 identical BPMN files
+        val c8Base64 = loadBpmnBase64("bpmn/c8-subscribe-newsletter.bpmn")
         val request = GenerateRequest(
             files = listOf(
-                GenerateRequest.BpmnFileData("c8-subscribe-newsletter.bpmn", c8Base64),
-                GenerateRequest.BpmnFileData("c8-newsletter-copy1.bpmn", c8Base64),
-                GenerateRequest.BpmnFileData("c8-newsletter-copy2.bpmn", c8Base64)
+                GenerateRequest.BpmnFileData(fileName = "c8-subscribe-newsletter.bpmn", content = c8Base64),
+                GenerateRequest.BpmnFileData(fileName = "c8-newsletter-copy1.bpmn", content = c8Base64),
+                GenerateRequest.BpmnFileData(fileName = "c8-newsletter-copy2.bpmn", content = c8Base64),
             ),
             config = GenerateRequest.GenerationConfig(
                 outputLanguage = OutputLanguage.KOTLIN,
-                processEngine = ProcessEngine.ZEEBE
+                processEngine = ProcessEngine.ZEEBE,
             )
         )
 
-        val response = service.generate(request)
+        // when: generating the API for all files
+        val response = underTest.generate(request)
 
+        // then: generation succeeds and produces at least one file
         assertThat(response.error).isNull()
         assertThat(response.success).describedAs("Should successfully process 3 files").isTrue()
         assertThat(response.files).describedAs("Should generate at least one API file").isNotEmpty()
+    }
+
+    private fun loadBpmnBase64(resourcePath: String): String {
+        val bytes = javaClass.classLoader.getResourceAsStream(resourcePath)!!.readBytes()
+        return Base64.getEncoder().encodeToString(bytes)
     }
 }


### PR DESCRIPTION
Closes #253

## Summary

- Added `.agent/skills/create-unit-test/SKILL.md` documenting the canonical unit test pattern
- Applied the pattern consistently across **all 46 test files** in every module — full refactor for true unit tests, style-only pass for integration and smoke tests

## Changes

**Pattern applied everywhere:**
- `private val underTest` for subject under test
- `// given:` / `// when:` / `// then:` comments where sections are multi-line
- Named parameters throughout
- AssertJ `assertThat(...)` — replaced all bare `assert()` calls
- `confirmVerified(...)` after verify blocks
- `mockk<T>(relaxed = true)` consistently

**Full refactor (unit tests):** all 11 rule tests, CollisionDetectionServiceTest, BpmnValidationServiceTest, BpmnModelApiTest, CodeGenerationAdapterTest, ExtractBpmnAdapterTest, FlowNodeSorterTest, and more

**Style pass (integration/smoke):** extractor tests, builder tests, Gradle/Maven/MCP smoke tests, web service test

## Test plan

- [x] `./gradlew :bpmn-to-code-core:test` — green
- [x] `./gradlew :bpmn-to-code-testing:test` — green
- [x] `./gradlew :bpmn-to-code-web:test` — green
- [x] `./gradlew :bpmn-to-code-mcp:test` — green
- [x] Gradle and Maven test sources compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)