### PR TITLE
feat: enforce per-class test coverage (≥ 75%) via JaCoCo

### DIFF
--- a/.agent/AGENT.md
+++ b/.agent/AGENT.md
@@ -34,6 +34,13 @@ The core follows hexagonal architecture with clear separation of concerns:
 
 ## Common Commands
 
+### One-time setup
+Install [Lefthook](https://github.com/evilmartians/lefthook) and register the git hooks (runs coverage check before push):
+```bash
+brew install lefthook  # or see docs/development/contributing.md for other platforms
+lefthook install
+```
+
 ### Build and Test
 ```bash
 # Build entire project

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -63,3 +63,7 @@ jobs:
       # Step 4: Run Gradle build
       - name: Run Gradle Build
         run: ./gradlew build --warning-mode all
+
+      # Step 5: Enforce per-class test coverage (≥ 80%)
+      - name: Check Coverage
+        run: ./gradlew :bpmn-to-code-core:jacocoTestCoverageVerification

--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
+    jacoco
 }
 
 group = "io.github.emaarco"
@@ -29,4 +30,43 @@ sourceSets {
 
 tasks.named<Test>("test") {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+private val coverageExclusions = listOf(
+    "**/domain/shared/**",
+    "**/domain/validation/model/**",
+    "**/adapter/outbound/engine/constants/**",
+    "**/adapter/outbound/engine/extractor/*ImplementationKind*",
+    "**/adapter/outbound/json/model/**",
+    "**/application/port/**",
+    "**/*\$DefaultImpls*",
+    "**/*\$Companion*",
+)
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.named("test"))
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.map { fileTree(it) { exclude(coverageExclusions) } })
+    )
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = "CLASS"
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.75".toBigDecimal()
+            }
+        }
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.map { fileTree(it) { exclude(coverageExclusions) } })
+    )
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiFilesystemPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiFilesystemPlugin.kt
@@ -4,7 +4,7 @@ import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessApiFromFil
 import io.github.emaarco.bpmn.application.service.GenerateProcessApiService
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 class CreateProcessApiFilesystemPlugin(
     private val useCase: GenerateProcessApiFromFilesystemUseCase = GenerateProcessApiService(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiInMemoryPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiInMemoryPlugin.kt
@@ -5,7 +5,7 @@ import io.github.emaarco.bpmn.application.service.GenerateProcessApiInMemoryServ
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 class CreateProcessApiInMemoryPlugin(
     private val useCase: GenerateProcessApiInMemoryUseCase = GenerateProcessApiInMemoryService(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPlugin.kt
@@ -3,7 +3,7 @@ package io.github.emaarco.bpmn.adapter.inbound
 import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonFromFilesystemUseCase
 import io.github.emaarco.bpmn.application.service.GenerateProcessJsonService
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 class CreateProcessJsonFilesystemPlugin(
     private val useCase: GenerateProcessJsonFromFilesystemUseCase = GenerateProcessJsonService(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPlugin.kt
@@ -4,7 +4,7 @@ import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonInMemo
 import io.github.emaarco.bpmn.application.service.GenerateProcessJsonInMemoryService
 import io.github.emaarco.bpmn.domain.GeneratedJsonFile
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 class CreateProcessJsonInMemoryPlugin(
     private val useCase: GenerateProcessJsonInMemoryUseCase = GenerateProcessJsonInMemoryService(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/ValidateBpmnFilesystemPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/ValidateBpmnFilesystemPlugin.kt
@@ -3,7 +3,7 @@ package io.github.emaarco.bpmn.adapter.inbound
 import io.github.emaarco.bpmn.application.port.inbound.ValidateBpmnFromFilesystemUseCase
 import io.github.emaarco.bpmn.application.service.ValidateBpmnService
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 import io.github.emaarco.bpmn.domain.validation.ValidationResult
 
 class ValidateBpmnFilesystemPlugin(

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessApiFromFilesystemUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessApiFromFilesystemUseCase.kt
@@ -2,7 +2,7 @@ package io.github.emaarco.bpmn.application.port.inbound
 
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 interface GenerateProcessApiFromFilesystemUseCase {
     fun generateProcessApi(command: Command)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessApiInMemoryUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessApiInMemoryUseCase.kt
@@ -3,7 +3,7 @@ package io.github.emaarco.bpmn.application.port.inbound
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 interface GenerateProcessApiInMemoryUseCase {
     fun generateProcessApi(command: Command): List<GeneratedApiFile>

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonFromFilesystemUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonFromFilesystemUseCase.kt
@@ -1,7 +1,7 @@
 package io.github.emaarco.bpmn.application.port.inbound
 
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 interface GenerateProcessJsonFromFilesystemUseCase {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonInMemoryUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessJsonInMemoryUseCase.kt
@@ -2,7 +2,7 @@ package io.github.emaarco.bpmn.application.port.inbound
 
 import io.github.emaarco.bpmn.domain.GeneratedJsonFile
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 interface GenerateProcessJsonInMemoryUseCase {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/ValidateBpmnFromFilesystemUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/ValidateBpmnFromFilesystemUseCase.kt
@@ -1,7 +1,7 @@
 package io.github.emaarco.bpmn.application.port.inbound
 
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 import io.github.emaarco.bpmn.domain.validation.ValidationResult
 
 interface ValidateBpmnFromFilesystemUseCase {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryService.kt
@@ -11,7 +11,7 @@ import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.ProcessModel
 import io.github.emaarco.bpmn.domain.service.BpmnValidationService
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 
 class GenerateProcessApiInMemoryService(
     private val codeGenerator: GenerateApiCodePort = CodeGenerationAdapter(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiService.kt
@@ -14,7 +14,7 @@ import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.ProcessModel
 import io.github.emaarco.bpmn.domain.service.BpmnValidationService
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 
 class GenerateProcessApiService(
     private val codeGenerator: GenerateApiCodePort = CodeGenerationAdapter(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryService.kt
@@ -9,7 +9,7 @@ import io.github.emaarco.bpmn.domain.BpmnResource
 import io.github.emaarco.bpmn.domain.GeneratedJsonFile
 import io.github.emaarco.bpmn.domain.service.BpmnValidationService
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 
 class GenerateProcessJsonInMemoryService(
     private val jsonGenerator: GenerateJsonPort = BpmnJsonGenerationAdapter(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonService.kt
@@ -11,7 +11,7 @@ import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
 import io.github.emaarco.bpmn.application.port.outbound.SaveProcessJsonPort
 import io.github.emaarco.bpmn.domain.service.BpmnValidationService
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 
 class GenerateProcessJsonService(
     private val jsonGenerator: GenerateJsonPort = BpmnJsonGenerationAdapter(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnService.kt
@@ -7,8 +7,8 @@ import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
 import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
 import io.github.emaarco.bpmn.domain.service.BpmnValidationService
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 import io.github.emaarco.bpmn.domain.validation.ValidationResult
 
 class ValidateBpmnService(

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationService.kt
@@ -3,11 +3,11 @@ package io.github.emaarco.bpmn.domain.service
 import io.github.emaarco.bpmn.domain.ProcessModel
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationException
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import io.github.emaarco.bpmn.domain.validation.rules.CollisionDetectionRule
 import io.github.emaarco.bpmn.domain.validation.rules.EmptyProcessRule
 import io.github.emaarco.bpmn.domain.validation.rules.InvalidIdentifierRule

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/CollisionDetectionService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/CollisionDetectionService.kt
@@ -2,7 +2,7 @@ package io.github.emaarco.bpmn.domain.service
 
 import io.github.emaarco.bpmn.domain.ProcessModel
 import io.github.emaarco.bpmn.domain.shared.VariableMapping
-import io.github.emaarco.bpmn.domain.validation.CollisionDetail
+import io.github.emaarco.bpmn.domain.validation.model.CollisionDetail
 
 /**
  * Domain service responsible for detecting name collisions in BPMN models.

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/BpmnValidationException.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/BpmnValidationException.kt
@@ -1,5 +1,8 @@
 package io.github.emaarco.bpmn.domain.validation
 
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
+
 class BpmnValidationException(
     val violations: List<ValidationViolation>,
 ) : RuntimeException(buildMessage(violations)) {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/BpmnValidationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/BpmnValidationRule.kt
@@ -1,5 +1,10 @@
 package io.github.emaarco.bpmn.domain.validation
 
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
+
 interface BpmnValidationRule {
     val id: String
     val severity: Severity

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/Severity.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/Severity.kt
@@ -1,3 +1,0 @@
-package io.github.emaarco.bpmn.domain.validation
-
-enum class Severity { ERROR, WARN }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/ValidationPhase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/ValidationPhase.kt
@@ -1,3 +1,0 @@
-package io.github.emaarco.bpmn.domain.validation
-
-enum class ValidationPhase { PRE_MERGE, POST_MERGE }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/ValidationResult.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/ValidationResult.kt
@@ -1,5 +1,8 @@
 package io.github.emaarco.bpmn.domain.validation
 
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
+
 data class ValidationResult(
     val violations: List<ValidationViolation>,
 ) {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/CollisionDetail.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/CollisionDetail.kt
@@ -1,4 +1,4 @@
-package io.github.emaarco.bpmn.domain.validation
+package io.github.emaarco.bpmn.domain.validation.model
 
 /**
  * Represents a single variable name collision within a BPMN model.

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/Severity.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/Severity.kt
@@ -1,0 +1,3 @@
+package io.github.emaarco.bpmn.domain.validation.model
+
+enum class Severity { ERROR, WARN }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationConfig.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationConfig.kt
@@ -1,4 +1,4 @@
-package io.github.emaarco.bpmn.domain.validation
+package io.github.emaarco.bpmn.domain.validation.model
 
 data class ValidationConfig(
     val failOnWarning: Boolean = false,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationContext.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationContext.kt
@@ -1,4 +1,4 @@
-package io.github.emaarco.bpmn.domain.validation
+package io.github.emaarco.bpmn.domain.validation.model
 
 import io.github.emaarco.bpmn.domain.ProcessModel
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationPhase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationPhase.kt
@@ -1,0 +1,3 @@
+package io.github.emaarco.bpmn.domain.validation.model
+
+enum class ValidationPhase { PRE_MERGE, POST_MERGE }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationViolation.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/model/ValidationViolation.kt
@@ -1,4 +1,4 @@
-package io.github.emaarco.bpmn.domain.validation
+package io.github.emaarco.bpmn.domain.validation.model
 
 data class ValidationViolation(
     val ruleId: String,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/CollisionDetectionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/CollisionDetectionRule.kt
@@ -2,10 +2,10 @@ package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.service.CollisionDetectionService
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class CollisionDetectionRule(
     private val collisionDetectionService: CollisionDetectionService = CollisionDetectionService(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EmptyProcessRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EmptyProcessRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class EmptyProcessRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRule.kt
@@ -2,9 +2,9 @@ package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.shared.VariableMapping
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 /**
  * Checks that BPMN element IDs produce valid SCREAMING_SNAKE_CASE identifiers for the generated API.

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingCalledElementRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingCalledElementRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class MissingCalledElementRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingElementIdRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingElementIdRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 /**
  * Checks that every BPMN element has an 'id' attribute set.

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingErrorDefinitionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingErrorDefinitionRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class MissingErrorDefinitionRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingMessageNameRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingMessageNameRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class MissingMessageNameRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingProcessIdRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingProcessIdRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class MissingProcessIdRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingServiceTaskImplementationRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingServiceTaskImplementationRule.kt
@@ -2,9 +2,9 @@ package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class MissingServiceTaskImplementationRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingSignalNameRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingSignalNameRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class MissingSignalNameRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingTimerDefinitionRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingTimerDefinitionRule.kt
@@ -1,9 +1,9 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 
 class MissingTimerDefinitionRule : BpmnValidationRule {
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPluginTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonFilesystemPluginTest.kt
@@ -1,0 +1,39 @@
+package io.github.emaarco.bpmn.adapter.inbound
+
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonFromFilesystemUseCase
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class CreateProcessJsonFilesystemPluginTest {
+
+    private val useCase = mockk<GenerateProcessJsonFromFilesystemUseCase>(relaxed = true)
+    private val underTest = CreateProcessJsonFilesystemPlugin(useCase)
+
+    @Test
+    fun `execute delegates to use case with correct command`() {
+
+        // when: execute is called with all parameters
+        underTest.execute(
+            baseDir = "/path/to/bpmn",
+            filePattern = "*.bpmn",
+            outputFolderPath = "/output/folder",
+            engine = ProcessEngine.ZEEBE,
+        )
+
+        // then: use case is called with correct command mapping
+        verify {
+            useCase.generateProcessJson(
+                GenerateProcessJsonFromFilesystemUseCase.Command(
+                    baseDir = "/path/to/bpmn",
+                    filePattern = "*.bpmn",
+                    outputFolderPath = "/output/folder",
+                    engine = ProcessEngine.ZEEBE,
+                )
+            )
+        }
+        confirmVerified(useCase)
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPluginTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessJsonInMemoryPluginTest.kt
@@ -1,0 +1,51 @@
+package io.github.emaarco.bpmn.adapter.inbound
+
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonInMemoryUseCase
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CreateProcessJsonInMemoryPluginTest {
+
+    private val useCase = mockk<GenerateProcessJsonInMemoryUseCase>(relaxed = true)
+    private val underTest = CreateProcessJsonInMemoryPlugin(useCase)
+
+    @Test
+    fun `execute delegates to use case and returns generated files`() {
+
+        // given: multiple BpmnInput objects
+        val firstInput = CreateProcessJsonInMemoryPlugin.BpmnInput(bpmnXml = "<bpmn>first</bpmn>", processName = "first.bpmn")
+        val secondInput = CreateProcessJsonInMemoryPlugin.BpmnInput(bpmnXml = "<bpmn>second</bpmn>", processName = "second.bpmn")
+        val expectedFiles = listOf(
+            GeneratedJsonFile(fileName = "first.json", content = "{}"),
+            GeneratedJsonFile(fileName = "second.json", content = "{}"),
+        )
+        every { useCase.generateProcessJson(any()) } returns expectedFiles
+
+        // when: execute is called with multiple inputs
+        val result = underTest.execute(
+            bpmnContents = listOf(firstInput, secondInput),
+            engine = ProcessEngine.ZEEBE,
+        )
+
+        // then: use case is called with correct command mapping and returns generated files
+        verify {
+            useCase.generateProcessJson(
+                GenerateProcessJsonInMemoryUseCase.Command(
+                    engine = ProcessEngine.ZEEBE,
+                    bpmnContents = listOf(
+                        GenerateProcessJsonInMemoryUseCase.BpmnInput(bpmnXml = "<bpmn>first</bpmn>", processName = "first.bpmn"),
+                        GenerateProcessJsonInMemoryUseCase.BpmnInput(bpmnXml = "<bpmn>second</bpmn>", processName = "second.bpmn"),
+                    ),
+                )
+            )
+        }
+        assertThat(result).isEqualTo(expectedFiles)
+        confirmVerified(useCase)
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/ValidateBpmnFilesystemPluginTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/ValidateBpmnFilesystemPluginTest.kt
@@ -2,7 +2,7 @@ package io.github.emaarco.bpmn.adapter.inbound
 
 import io.github.emaarco.bpmn.application.port.inbound.ValidateBpmnFromFilesystemUseCase
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 import io.github.emaarco.bpmn.domain.validation.ValidationResult
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -40,6 +40,35 @@ class ValidateBpmnFilesystemPluginTest {
                     filePattern = "*.bpmn",
                     engine = ProcessEngine.ZEEBE,
                     validationConfig = config,
+                )
+            )
+        }
+        assertThat(result).isEqualTo(expectedResult)
+        confirmVerified(useCase)
+    }
+
+    @Test
+    fun `execute uses default validation config when not provided`() {
+
+        // given: an expected validation result
+        val expectedResult = ValidationResult(emptyList())
+        every { useCase.validateBpmn(any()) } returns expectedResult
+
+        // when: execute is called without explicit validationConfig
+        val result = underTest.execute(
+            baseDir = "/path/to/bpmn",
+            filePattern = "*.bpmn",
+            engine = ProcessEngine.CAMUNDA_7,
+        )
+
+        // then: use case is called with a default validation config
+        verify {
+            useCase.validateBpmn(
+                ValidateBpmnFromFilesystemUseCase.Command(
+                    baseDir = "/path/to/bpmn",
+                    filePattern = "*.bpmn",
+                    engine = ProcessEngine.CAMUNDA_7,
+                    validationConfig = ValidationConfig(),
                 )
             )
         }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
@@ -53,4 +53,18 @@ class ExtractBpmnAdapterTest {
         assertThatThrownBy { underTest.extract(bpmnFile = bpmnResource, engine = ProcessEngine.CAMUNDA_7) }
             .isInstanceOf(IllegalStateException::class.java)
     }
+
+    @Test
+    fun `extract wraps extractor exception in RuntimeException`() {
+
+        // given: an extractor that throws during parsing
+        val tempFile = File.createTempFile("invalid", ".bpmn").apply { deleteOnExit() }
+        val bpmnResource = BpmnResource(fileName = "invalid.bpmn", content = tempFile.inputStream())
+        every { extractor.extract(any()) } throws IllegalArgumentException("invalid BPMN content")
+
+        // when / then: the exception is wrapped in a RuntimeException with file name in the message
+        assertThatThrownBy { underTest.extract(bpmnFile = bpmnResource, engine = ProcessEngine.ZEEBE) }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("invalid.bpmn")
+    }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessJsonFileSaverTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessJsonFileSaverTest.kt
@@ -1,0 +1,47 @@
+package io.github.emaarco.bpmn.adapter.outbound.filesystem
+
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ProcessJsonFileSaverTest {
+
+    private val underTest = ProcessJsonFileSaver()
+
+    @Test
+    fun `writeFiles writes multiple files to output folder`(@TempDir tempDir: File) {
+
+        // given: multiple generated JSON files
+        val firstFile = GeneratedJsonFile(fileName = "order.json", content = """{"process":"order"}""")
+        val secondFile = GeneratedJsonFile(fileName = "payment.json", content = """{"process":"payment"}""")
+
+        // when: writeFiles is called
+        underTest.writeFiles(listOf(firstFile, secondFile), tempDir.absolutePath)
+
+        // then: both files are written with correct content
+        val orderFile = File(tempDir, "order.json")
+        val paymentFile = File(tempDir, "payment.json")
+
+        assertThat(orderFile.exists()).isTrue()
+        assertThat(paymentFile.exists()).isTrue()
+        assertThat(orderFile.readText()).isEqualTo("""{"process":"order"}""")
+        assertThat(paymentFile.readText()).isEqualTo("""{"process":"payment"}""")
+    }
+
+    @Test
+    fun `writeFiles creates output folder if it does not exist`(@TempDir tempDir: File) {
+
+        // given: a non-existent output subfolder
+        val newFolder = File(tempDir, "generated/json")
+        val file = GeneratedJsonFile(fileName = "order.json", content = "{}")
+
+        // when: writeFiles is called with the new folder path
+        underTest.writeFiles(listOf(file), newFolder.absolutePath)
+
+        // then: the folder is created and the file is written
+        assertThat(newFolder.exists()).isTrue()
+        assertThat(File(newFolder, "order.json").exists()).isTrue()
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryServiceTest.kt
@@ -1,0 +1,54 @@
+package io.github.emaarco.bpmn.application.service
+
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonInMemoryUseCase
+import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.emaarco.bpmn.application.port.outbound.GenerateJsonPort
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.testBpmnModel
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GenerateProcessJsonInMemoryServiceTest {
+
+    private val jsonGenerator = mockk<GenerateJsonPort>(relaxed = true)
+    private val bpmnExtractor = mockk<ExtractBpmnPort>(relaxed = true)
+
+    private val underTest = GenerateProcessJsonInMemoryService(
+        jsonGenerator = jsonGenerator,
+        bpmnExtractor = bpmnExtractor,
+    )
+
+    @Test
+    fun `generateProcessJson generates JSON files from BPMN content`() {
+
+        // given: BPMN content and a mock extractor
+        val bpmnInput = GenerateProcessJsonInMemoryUseCase.BpmnInput(
+            bpmnXml = "<bpmn>test</bpmn>",
+            processName = "test.bpmn",
+        )
+        val expectedJsonFile = GeneratedJsonFile(fileName = "order.json", content = "{}")
+        every { bpmnExtractor.extract(any(), any()) } returns dummyModel
+        every { jsonGenerator.generateJson(any()) } returns expectedJsonFile
+        val command = GenerateProcessJsonInMemoryUseCase.Command(
+            bpmnContents = listOf(bpmnInput),
+            engine = ProcessEngine.ZEEBE,
+        )
+
+        // when: generateProcessJson is called
+        val result = underTest.generateProcessJson(command)
+
+        // then: BPMN is extracted, JSON is generated and returned
+        verify { bpmnExtractor.extract(match { it.fileName == "test.bpmn" }, eq(ProcessEngine.ZEEBE)) }
+        verify { jsonGenerator.generateJson(any()) }
+        assertThat(result).hasSize(1)
+        assertThat(result[0]).isEqualTo(expectedJsonFile)
+        confirmVerified(jsonGenerator, bpmnExtractor)
+    }
+
+    private val dummyModel = testBpmnModel()
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonServiceTest.kt
@@ -1,0 +1,59 @@
+package io.github.emaarco.bpmn.application.service
+
+import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessJsonFromFilesystemUseCase
+import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.emaarco.bpmn.application.port.outbound.GenerateJsonPort
+import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
+import io.github.emaarco.bpmn.application.port.outbound.SaveProcessJsonPort
+import io.github.emaarco.bpmn.domain.BpmnResource
+import io.github.emaarco.bpmn.domain.GeneratedJsonFile
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.testBpmnModel
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class GenerateProcessJsonServiceTest {
+
+    private val jsonGenerator = mockk<GenerateJsonPort>(relaxed = true)
+    private val bpmnFileLoader = mockk<LoadBpmnFilesPort>(relaxed = true)
+    private val bpmnExtractor = mockk<ExtractBpmnPort>(relaxed = true)
+    private val fileSaver = mockk<SaveProcessJsonPort>(relaxed = true)
+
+    private val underTest = GenerateProcessJsonService(
+        jsonGenerator = jsonGenerator,
+        bpmnFileLoader = bpmnFileLoader,
+        bpmnExtractor = bpmnExtractor,
+        fileSaver = fileSaver,
+    )
+
+    @Test
+    fun `generateProcessJson generates JSON and writes to disk`() {
+
+        // given: a dummy BPMN resource and a command
+        val dummyResource = BpmnResource(fileName = "dummy.bpmn", content = "<bpmn></bpmn>".byteInputStream())
+        val expectedJsonFile = GeneratedJsonFile(fileName = "order.json", content = "{}")
+        every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(dummyResource)
+        every { bpmnExtractor.extract(any(), any()) } returns dummyModel
+        every { jsonGenerator.generateJson(any()) } returns expectedJsonFile
+        val command = GenerateProcessJsonFromFilesystemUseCase.Command(
+            baseDir = "baseDir",
+            filePattern = "*.bpmn",
+            engine = ProcessEngine.ZEEBE,
+            outputFolderPath = "outputFolder",
+        )
+
+        // when: generateProcessJson is invoked
+        underTest.generateProcessJson(command)
+
+        // then: JSON is generated and written to disk
+        verify { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") }
+        verify { jsonGenerator.generateJson(any()) }
+        verify { fileSaver.writeFiles(listOf(expectedJsonFile), "outputFolder") }
+        confirmVerified(jsonGenerator, bpmnFileLoader, fileSaver)
+    }
+
+    private val dummyModel = testBpmnModel()
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnServiceTest.kt
@@ -1,0 +1,73 @@
+package io.github.emaarco.bpmn.application.service
+
+import io.github.emaarco.bpmn.application.port.inbound.ValidateBpmnFromFilesystemUseCase
+import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
+import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
+import io.github.emaarco.bpmn.domain.BpmnResource
+import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
+import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
+import io.github.emaarco.bpmn.domain.testBpmnModel
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ValidateBpmnServiceTest {
+
+    private val bpmnFileLoader = mockk<LoadBpmnFilesPort>()
+    private val bpmnExtractor = mockk<ExtractBpmnPort>()
+
+    private val underTest = ValidateBpmnService(
+        bpmnFileLoader = bpmnFileLoader,
+        bpmnService = bpmnExtractor,
+    )
+
+    private val command = ValidateBpmnFromFilesystemUseCase.Command(
+        baseDir = "baseDir",
+        filePattern = "*.bpmn",
+        engine = ProcessEngine.ZEEBE,
+    )
+
+    private val dummyResource = BpmnResource(fileName = "dummy.bpmn", content = "<bpmn></bpmn>".byteInputStream())
+
+    @Test
+    fun `valid model returns empty result`() {
+
+        // given: a valid model
+        every { bpmnFileLoader.loadFrom(any(), any()) } returns listOf(dummyResource)
+        every { bpmnExtractor.extract(any(), any()) } returns testBpmnModel()
+
+        // when: validateBpmn is called
+        val result = underTest.validateBpmn(command)
+
+        // then: result has no violations
+        assertThat(result.isValid).isTrue()
+        assertThat(result.violations).isEmpty()
+    }
+
+    @Test
+    fun `pre-merge error stops execution and returns early`() {
+
+        // given: a model with a service task missing implementation (pre-merge ERROR)
+        val invalidModel = testBpmnModel(
+            flowNodes = listOf(
+                FlowNodeDefinition(
+                    id = "task1",
+                    properties = FlowNodeProperties.ServiceTask(ServiceTaskDefinition(id = "task1")),
+                )
+            )
+        )
+        every { bpmnFileLoader.loadFrom(any(), any()) } returns listOf(dummyResource)
+        every { bpmnExtractor.extract(any(), any()) } returns invalidModel
+
+        // when: validateBpmn is called
+        val result = underTest.validateBpmn(command)
+
+        // then: result contains only pre-merge errors, no post-merge violations added
+        assertThat(result.hasErrors).isTrue()
+        assertThat(result.errors).anyMatch { it.severity == Severity.ERROR }
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationServiceTest.kt
@@ -6,9 +6,9 @@ import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
 import io.github.emaarco.bpmn.domain.testBpmnModel
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationException
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/ValidationResultTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/ValidationResultTest.kt
@@ -1,5 +1,7 @@
 package io.github.emaarco.bpmn.domain.validation
 
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/CollisionDetectionRuleTest.kt
@@ -3,9 +3,9 @@ package io.github.emaarco.bpmn.domain.validation.rules
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EmptyProcessRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EmptyProcessRuleTest.kt
@@ -3,8 +3,8 @@ package io.github.emaarco.bpmn.domain.validation.rules
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
@@ -5,8 +5,8 @@ import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingCalledElementRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingCalledElementRuleTest.kt
@@ -5,8 +5,8 @@ import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingElementIdRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingElementIdRuleTest.kt
@@ -3,8 +3,8 @@ package io.github.emaarco.bpmn.domain.validation.rules
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingErrorDefinitionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingErrorDefinitionRuleTest.kt
@@ -3,8 +3,8 @@ package io.github.emaarco.bpmn.domain.validation.rules
 import io.github.emaarco.bpmn.domain.shared.ErrorDefinition
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingMessageNameRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingMessageNameRuleTest.kt
@@ -3,8 +3,8 @@ package io.github.emaarco.bpmn.domain.validation.rules
 import io.github.emaarco.bpmn.domain.shared.MessageDefinition
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingProcessIdRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingProcessIdRuleTest.kt
@@ -2,8 +2,8 @@ package io.github.emaarco.bpmn.domain.validation.rules
 
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingServiceTaskImplementationRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingServiceTaskImplementationRuleTest.kt
@@ -6,8 +6,8 @@ import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL_VALUE_KEY
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingSignalNameRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingSignalNameRuleTest.kt
@@ -3,8 +3,8 @@ package io.github.emaarco.bpmn.domain.validation.rules
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.shared.SignalDefinition
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingTimerDefinitionRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/MissingTimerDefinitionRuleTest.kt
@@ -5,8 +5,8 @@ import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.testBpmnModel
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
@@ -2,8 +2,8 @@ package io.github.emaarco.bpmn.adapter
 
 import io.github.emaarco.bpmn.adapter.inbound.ValidateBpmnFilesystemPlugin
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Incubating

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
@@ -2,7 +2,7 @@ package io.github.emaarco.bpmn.adapter;
 
 import io.github.emaarco.bpmn.adapter.inbound.CreateProcessJsonFilesystemPlugin;
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine;
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig;
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
@@ -3,7 +3,7 @@ package io.github.emaarco.bpmn.adapter;
 import io.github.emaarco.bpmn.adapter.inbound.CreateProcessApiFilesystemPlugin;
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage;
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine;
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig;
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
@@ -2,9 +2,9 @@ package io.github.emaarco.bpmn.adapter;
 
 import io.github.emaarco.bpmn.adapter.inbound.ValidateBpmnFilesystemPlugin;
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine;
-import io.github.emaarco.bpmn.domain.validation.ValidationConfig;
+import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig;
 import io.github.emaarco.bpmn.domain.validation.ValidationResult;
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation;
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidationAssert.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidationAssert.kt
@@ -1,8 +1,8 @@
 package io.github.emaarco.bpmn.testing
 
-import io.github.emaarco.bpmn.domain.validation.Severity
+import io.github.emaarco.bpmn.domain.validation.model.Severity
 import io.github.emaarco.bpmn.domain.validation.ValidationResult
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.AbstractAssert
 
 /**

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
@@ -6,11 +6,11 @@ import io.github.emaarco.bpmn.domain.BpmnResource
 import io.github.emaarco.bpmn.domain.service.ModelMergerService
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 import io.github.emaarco.bpmn.domain.validation.ValidationResult
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import java.nio.file.Path
 
 /**

--- a/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnProcessArchitectureTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnProcessArchitectureTest.kt
@@ -2,10 +2,10 @@ package io.github.emaarco.bpmn.testing
 
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
-import io.github.emaarco.bpmn.domain.validation.Severity
-import io.github.emaarco.bpmn.domain.validation.ValidationContext
-import io.github.emaarco.bpmn.domain.validation.ValidationPhase
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnValidationAssertTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/BpmnValidationAssertTest.kt
@@ -1,8 +1,8 @@
 package io.github.emaarco.bpmn.testing
 
-import io.github.emaarco.bpmn.domain.validation.Severity
+import io.github.emaarco.bpmn.domain.validation.model.Severity
 import io.github.emaarco.bpmn.domain.validation.ValidationResult
-import io.github.emaarco.bpmn.domain.validation.ValidationViolation
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,37 @@
+# Contributing
+
+## Prerequisites
+
+- Java 21 (see `.java-version`)
+- [Lefthook](https://github.com/evilmartians/lefthook) for local git hooks
+
+## One-time setup
+
+Install Lefthook and register the git hooks:
+
+```bash
+# macOS
+brew install lefthook
+
+# Other platforms: https://github.com/evilmartians/lefthook#installation
+```
+
+```bash
+lefthook install
+```
+
+This installs a `pre-push` hook that runs `:bpmn-to-code-core:jacocoTestCoverageVerification` — the same check enforced in CI.
+
+## Common Commands
+
+```bash
+./gradlew build                                               # full build
+./gradlew :bpmn-to-code-core:test                            # run core tests only
+./gradlew :bpmn-to-code-core:jacocoTestCoverageVerification  # check coverage manually
+```
+
+## Skipping hooks
+
+```bash
+git push --no-verify  # bypasses lefthook; CI still enforces
+```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,5 @@
+pre-push:
+  commands:
+    coverage:
+      glob: "*.{kt,kts}"
+      run: ./gradlew :bpmn-to-code-core:jacocoTestCoverageVerification


### PR DESCRIPTION
## Summary

- Moves pure validation DTOs/enums to `domain.validation.model` subpackage so they can be excluded from coverage with a single glob pattern instead of 6 individual patterns
- Adds JaCoCo to `bpmn-to-code-core` with a per-class LINE coverage rule at ≥ 75%
- Wires `jacocoTestCoverageVerification` into CI (`build-backend.yml`) as a PR gate

## Coverage exclusions

| Pattern | Reason |
|---|---|
| `**/domain/shared/**` | Pure DTOs |
| `**/domain/validation/model/**` | Pure DTOs/enums (moved here) |
| `**/adapter/outbound/engine/constants/**` | Constants objects |
| `**/adapter/outbound/engine/extractor/*ImplementationKind*` | Typed enum constants |
| `**/adapter/outbound/json/model/**` | JSON model DTOs |
| `**/application/port/**` | Interfaces — no bytecode |
| `**/*$DefaultImpls*` | Kotlin compiler artifact |
| `**/*$Companion*` | Kotlin companion object initializers |

## New tests

Added 6 missing test files for the JSON generation pipeline and validation service to establish the coverage baseline:
- `CreateProcessJsonFilesystemPluginTest`
- `CreateProcessJsonInMemoryPluginTest`
- `GenerateProcessJsonServiceTest`
- `GenerateProcessJsonInMemoryServiceTest`
- `ValidateBpmnServiceTest`
- `ProcessJsonFileSaverTest`

Closes #56 (partial — coverage gate only)