### PR TITLE
test: validate syntax of generated Kotlin, Java, and JSON output

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     api(libs.slf4jApi)
     api(libs.kotlinLogging)
     testImplementation(libs.bundles.testing)
+    testImplementation(kotlin("compiler-embeddable"))
     testRuntimeOnly(libs.junitPlatformLauncher)
 }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilderTest.kt
@@ -20,26 +20,26 @@ import javax.tools.JavaFileObject
 import javax.tools.SimpleJavaFileObject
 import javax.tools.ToolProvider
 
-private fun assertJavaSyntaxValid(fileName: String, source: String) {
-    val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
-    val diagnostics = DiagnosticCollector<JavaFileObject>()
-    val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
-    val sourceObject = object : SimpleJavaFileObject(
-        URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
-    ) {
-        override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
-    }
-    val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
-    task.parse()
-    val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
-    assertThat(errors)
-        .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
-        .isEmpty()
-}
-
 class JavaProcessApiBuilderTest {
 
     private val underTest = JavaProcessApiBuilder()
+
+    private fun assertJavaSyntaxValid(fileName: String, source: String) {
+        val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
+        val diagnostics = DiagnosticCollector<JavaFileObject>()
+        val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
+        val sourceObject = object : SimpleJavaFileObject(
+            URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
+        ) {
+            override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
+        }
+        val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
+        task.parse()
+        val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
+        assertThat(errors)
+            .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
+            .isEmpty()
+    }
 
     @Test
     fun `buildApiFile generates correct process API file`() {

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilderTest.kt
@@ -9,9 +9,33 @@ import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.testBpmnModelApi
 import io.github.emaarco.bpmn.domain.testSendNewsletterBpmnModel
 import io.github.emaarco.bpmn.domain.testSubscribeNewsletterBpmnModel
+import com.sun.source.util.JavacTask
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.net.URI
+import javax.tools.Diagnostic
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaFileObject
+import javax.tools.SimpleJavaFileObject
+import javax.tools.ToolProvider
+
+private fun assertJavaSyntaxValid(fileName: String, source: String) {
+    val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
+    val diagnostics = DiagnosticCollector<JavaFileObject>()
+    val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
+    val sourceObject = object : SimpleJavaFileObject(
+        URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
+    ) {
+        override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
+    }
+    val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
+    task.parse()
+    val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
+    assertThat(errors)
+        .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
+        .isEmpty()
+}
 
 class JavaProcessApiBuilderTest {
 
@@ -42,6 +66,7 @@ class JavaProcessApiBuilderTest {
 
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/NewsletterSubscriptionProcessApiJava.txt")).toURI())
         assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertJavaSyntaxValid(result.fileName, result.content)
     }
 
     @Test
@@ -60,6 +85,7 @@ class JavaProcessApiBuilderTest {
 
         // then: expect the generated code contains valid Java
         assertThat(result.content).isNotEmpty()
+        assertJavaSyntaxValid(result.fileName, result.content)
     }
 
     @Test
@@ -86,5 +112,6 @@ class JavaProcessApiBuilderTest {
         // then: output contains Variants section instead of flat Flows/Relations
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/MultiVariantProcessApiJava.txt")).toURI())
         assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertJavaSyntaxValid(result.fileName, result.content)
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilderTest.kt
@@ -24,23 +24,6 @@ class JavaProcessApiBuilderTest {
 
     private val underTest = JavaProcessApiBuilder()
 
-    private fun assertJavaSyntaxValid(fileName: String, source: String) {
-        val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
-        val diagnostics = DiagnosticCollector<JavaFileObject>()
-        val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
-        val sourceObject = object : SimpleJavaFileObject(
-            URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
-        ) {
-            override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
-        }
-        val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
-        task.parse()
-        val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
-        assertThat(errors)
-            .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
-            .isEmpty()
-    }
-
     @Test
     fun `buildApiFile generates correct process API file`() {
 
@@ -113,5 +96,22 @@ class JavaProcessApiBuilderTest {
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/MultiVariantProcessApiJava.txt")).toURI())
         assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
         assertJavaSyntaxValid(result.fileName, result.content)
+    }
+
+    private fun assertJavaSyntaxValid(fileName: String, source: String) {
+        val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
+        val diagnostics = DiagnosticCollector<JavaFileObject>()
+        val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
+        val sourceObject = object : SimpleJavaFileObject(
+            URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
+        ) {
+            override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
+        }
+        val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
+        task.parse()
+        val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
+        assertThat(errors)
+            .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
+            .isEmpty()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaSharedTypesBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaSharedTypesBuilderTest.kt
@@ -12,26 +12,26 @@ import javax.tools.JavaFileObject
 import javax.tools.SimpleJavaFileObject
 import javax.tools.ToolProvider
 
-private fun assertJavaSyntaxValid(fileName: String, source: String) {
-    val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
-    val diagnostics = DiagnosticCollector<JavaFileObject>()
-    val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
-    val sourceObject = object : SimpleJavaFileObject(
-        URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
-    ) {
-        override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
-    }
-    val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
-    task.parse()
-    val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
-    assertThat(errors)
-        .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
-        .isEmpty()
-}
-
 class JavaSharedTypesBuilderTest {
 
     private val underTest = JavaSharedTypesBuilder()
+
+    private fun assertJavaSyntaxValid(fileName: String, source: String) {
+        val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
+        val diagnostics = DiagnosticCollector<JavaFileObject>()
+        val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
+        val sourceObject = object : SimpleJavaFileObject(
+            URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
+        ) {
+            override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
+        }
+        val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
+        task.parse()
+        val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
+        assertThat(errors)
+            .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
+            .isEmpty()
+    }
 
     @Test
     fun `buildTypeFiles generates all 5 shared type files`() {

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaSharedTypesBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaSharedTypesBuilderTest.kt
@@ -1,9 +1,33 @@
 package io.github.emaarco.bpmn.adapter.outbound.codegen.builder
 
+import com.sun.source.util.JavacTask
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.net.URI
+import javax.tools.Diagnostic
+import javax.tools.DiagnosticCollector
+import javax.tools.JavaFileObject
+import javax.tools.SimpleJavaFileObject
+import javax.tools.ToolProvider
+
+private fun assertJavaSyntaxValid(fileName: String, source: String) {
+    val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
+    val diagnostics = DiagnosticCollector<JavaFileObject>()
+    val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
+    val sourceObject = object : SimpleJavaFileObject(
+        URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
+    ) {
+        override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
+    }
+    val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
+    task.parse()
+    val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
+    assertThat(errors)
+        .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
+        .isEmpty()
+}
 
 class JavaSharedTypesBuilderTest {
 
@@ -29,6 +53,7 @@ class JavaSharedTypesBuilderTest {
                 "Missing fixture: /api/types/$fixtureName"
             }
             assertThat(typeFile.content).isEqualToIgnoringWhitespace(File(fixtureResource.toURI()).readText())
+            assertJavaSyntaxValid(typeFile.fileName, typeFile.content)
         }
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaSharedTypesBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaSharedTypesBuilderTest.kt
@@ -16,23 +16,6 @@ class JavaSharedTypesBuilderTest {
 
     private val underTest = JavaSharedTypesBuilder()
 
-    private fun assertJavaSyntaxValid(fileName: String, source: String) {
-        val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
-        val diagnostics = DiagnosticCollector<JavaFileObject>()
-        val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
-        val sourceObject = object : SimpleJavaFileObject(
-            URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
-        ) {
-            override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
-        }
-        val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
-        task.parse()
-        val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
-        assertThat(errors)
-            .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
-            .isEmpty()
-    }
-
     @Test
     fun `buildTypeFiles generates all 5 shared type files`() {
 
@@ -55,6 +38,23 @@ class JavaSharedTypesBuilderTest {
             assertThat(typeFile.content).isEqualToIgnoringWhitespace(File(fixtureResource.toURI()).readText())
             assertJavaSyntaxValid(typeFile.fileName, typeFile.content)
         }
+    }
+
+    private fun assertJavaSyntaxValid(fileName: String, source: String) {
+        val compiler = requireNotNull(ToolProvider.getSystemJavaCompiler())
+        val diagnostics = DiagnosticCollector<JavaFileObject>()
+        val fileManager = compiler.getStandardFileManager(diagnostics, null, null)
+        val sourceObject = object : SimpleJavaFileObject(
+            URI.create("string:///${fileName.replace('.', '/')}"), JavaFileObject.Kind.SOURCE
+        ) {
+            override fun getCharContent(ignoreEncodingErrors: Boolean): CharSequence = source
+        }
+        val task = compiler.getTask(null, fileManager, diagnostics, null, null, listOf(sourceObject)) as JavacTask
+        task.parse()
+        val errors = diagnostics.diagnostics.filter { it.kind == Diagnostic.Kind.ERROR }
+        assertThat(errors)
+            .withFailMessage { "Java syntax errors in generated output: ${errors.map { it.getMessage(null) }}" }
+            .isEmpty()
     }
 
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
@@ -24,26 +24,6 @@ import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.junit.jupiter.api.Test
 import java.io.File
 
-@OptIn(K1Deprecation::class)
-private val kotlinEnvironment by lazy {
-    val config = CompilerConfiguration()
-    config.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-    KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(), config, EnvironmentConfigFiles.JVM_CONFIG_FILES)
-}
-
-private fun assertKotlinSyntaxValid(source: String) {
-    val file = KtPsiFactory(kotlinEnvironment.project).createFile(source)
-    val errors = mutableListOf<String>()
-    file.accept(object : KtTreeVisitorVoid() {
-        override fun visitErrorElement(element: PsiErrorElement) {
-            errors.add(element.errorDescription)
-        }
-    })
-    assertThat(errors)
-        .withFailMessage { "Kotlin syntax errors in generated output: $errors" }
-        .isEmpty()
-}
-
 class KotlinProcessApiBuilderTest {
 
     private val underTest = KotlinProcessApiBuilder()
@@ -101,5 +81,29 @@ class KotlinProcessApiBuilderTest {
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/MultiVariantProcessApiKotlin.txt")).toURI())
         assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
         assertKotlinSyntaxValid(result.content)
+    }
+
+    companion object {
+
+        @OptIn(K1Deprecation::class)
+        private val kotlinEnvironment by lazy {
+            val config = CompilerConfiguration()
+            config.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+            KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(), config, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+        }
+
+        @OptIn(K1Deprecation::class)
+        private fun assertKotlinSyntaxValid(source: String) {
+            val file = KtPsiFactory(kotlinEnvironment.project).createFile(source)
+            val errors = mutableListOf<String>()
+            file.accept(object : KtTreeVisitorVoid() {
+                override fun visitErrorElement(element: PsiErrorElement) {
+                    errors.add(element.errorDescription)
+                }
+            })
+            assertThat(errors)
+                .withFailMessage { "Kotlin syntax errors in generated output: $errors" }
+                .isEmpty()
+        }
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
@@ -11,8 +11,38 @@ import io.github.emaarco.bpmn.domain.testSendNewsletterBpmnModel
 import io.github.emaarco.bpmn.domain.testSubscribeNewsletterBpmnModel
 
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.junit.jupiter.api.Test
 import java.io.File
+
+@OptIn(K1Deprecation::class)
+private val kotlinEnvironment by lazy {
+    val config = CompilerConfiguration()
+    config.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+    KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(), config, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+}
+
+private fun assertKotlinSyntaxValid(source: String) {
+    val file = KtPsiFactory(kotlinEnvironment.project).createFile(source)
+    val errors = mutableListOf<String>()
+    file.accept(object : KtTreeVisitorVoid() {
+        override fun visitErrorElement(element: PsiErrorElement) {
+            errors.add(element.errorDescription)
+        }
+    })
+    assertThat(errors)
+        .withFailMessage { "Kotlin syntax errors in generated output: $errors" }
+        .isEmpty()
+}
 
 class KotlinProcessApiBuilderTest {
 
@@ -43,6 +73,7 @@ class KotlinProcessApiBuilderTest {
 
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/NewsletterSubscriptionProcessApiKotlin.txt")).toURI())
         assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertKotlinSyntaxValid(result.content)
     }
 
     @Test
@@ -69,5 +100,6 @@ class KotlinProcessApiBuilderTest {
         // then: output contains Variants section instead of flat Flows/Relations
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/MultiVariantProcessApiKotlin.txt")).toURI())
         assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertKotlinSyntaxValid(result.content)
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilderTest.kt
@@ -2,8 +2,38 @@ package io.github.emaarco.bpmn.adapter.outbound.codegen.builder
 
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.K1Deprecation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.junit.jupiter.api.Test
 import java.io.File
+
+@OptIn(K1Deprecation::class)
+private val kotlinEnvironment by lazy {
+    val config = CompilerConfiguration()
+    config.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+    KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(), config, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+}
+
+private fun assertKotlinSyntaxValid(source: String) {
+    val file = KtPsiFactory(kotlinEnvironment.project).createFile(source)
+    val errors = mutableListOf<String>()
+    file.accept(object : KtTreeVisitorVoid() {
+        override fun visitErrorElement(element: PsiErrorElement) {
+            errors.add(element.errorDescription)
+        }
+    })
+    assertThat(errors)
+        .withFailMessage { "Kotlin syntax errors in generated output: $errors" }
+        .isEmpty()
+}
 
 class KotlinSharedTypesBuilderTest {
 
@@ -29,6 +59,7 @@ class KotlinSharedTypesBuilderTest {
                 "Missing fixture: /api/types/$fixtureName"
             }
             assertThat(typeFile.content).isEqualToIgnoringWhitespace(File(fixtureResource.toURI()).readText())
+            assertKotlinSyntaxValid(typeFile.content)
         }
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilderTest.kt
@@ -15,26 +15,6 @@ import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 import org.junit.jupiter.api.Test
 import java.io.File
 
-@OptIn(K1Deprecation::class)
-private val kotlinEnvironment by lazy {
-    val config = CompilerConfiguration()
-    config.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-    KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(), config, EnvironmentConfigFiles.JVM_CONFIG_FILES)
-}
-
-private fun assertKotlinSyntaxValid(source: String) {
-    val file = KtPsiFactory(kotlinEnvironment.project).createFile(source)
-    val errors = mutableListOf<String>()
-    file.accept(object : KtTreeVisitorVoid() {
-        override fun visitErrorElement(element: PsiErrorElement) {
-            errors.add(element.errorDescription)
-        }
-    })
-    assertThat(errors)
-        .withFailMessage { "Kotlin syntax errors in generated output: $errors" }
-        .isEmpty()
-}
-
 class KotlinSharedTypesBuilderTest {
 
     private val underTest = KotlinSharedTypesBuilder()
@@ -63,4 +43,27 @@ class KotlinSharedTypesBuilderTest {
         }
     }
 
+    companion object {
+
+        @OptIn(K1Deprecation::class)
+        private val kotlinEnvironment by lazy {
+            val config = CompilerConfiguration()
+            config.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+            KotlinCoreEnvironment.createForProduction(Disposer.newDisposable(), config, EnvironmentConfigFiles.JVM_CONFIG_FILES)
+        }
+
+        @OptIn(K1Deprecation::class)
+        private fun assertKotlinSyntaxValid(source: String) {
+            val file = KtPsiFactory(kotlinEnvironment.project).createFile(source)
+            val errors = mutableListOf<String>()
+            file.accept(object : KtTreeVisitorVoid() {
+                override fun visitErrorElement(element: PsiErrorElement) {
+                    errors.add(element.errorDescription)
+                }
+            })
+            assertThat(errors)
+                .withFailMessage { "Kotlin syntax errors in generated output: $errors" }
+                .isEmpty()
+        }
+    }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
@@ -10,14 +10,14 @@ import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.io.File
 
-private fun assertJsonSyntaxValid(source: String) {
-    runCatching { Json.parseToJsonElement(source) }
-        .onFailure { fail("JSON syntax error in generated output: ${it.message}") }
-}
-
 class BpmnJsonGeneratorTest {
 
     private val underTest = BpmnJsonGenerator()
+
+    private fun assertJsonSyntaxValid(source: String) {
+        runCatching { Json.parseToJsonElement(source) }
+            .onFailure { fail("JSON syntax error in generated output: ${it.message}") }
+    }
 
     @Test
     fun `generates correct JSON for single model`() {

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
@@ -4,9 +4,16 @@ import io.github.emaarco.bpmn.domain.MergedBpmnModel
 import io.github.emaarco.bpmn.domain.MergedBpmnModel.VariantData
 import io.github.emaarco.bpmn.domain.testSendNewsletterBpmnModel
 import io.github.emaarco.bpmn.domain.testSubscribeNewsletterBpmnModel
+import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import java.io.File
+
+private fun assertJsonSyntaxValid(source: String) {
+    runCatching { Json.parseToJsonElement(source) }
+        .onFailure { fail("JSON syntax error in generated output: ${it.message}") }
+}
 
 class BpmnJsonGeneratorTest {
 
@@ -24,6 +31,7 @@ class BpmnJsonGeneratorTest {
         // then: expect the generated JSON to match the expected snapshot
         val expectedFile = File(javaClass.getResource("/json/NewsletterSubscriptionProcess.json")!!.toURI())
         assertThat(result).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertJsonSyntaxValid(result)
     }
 
     @Test
@@ -49,6 +57,7 @@ class BpmnJsonGeneratorTest {
         // then: expect the generated JSON to match the expected snapshot
         val expectedFile = File(javaClass.getResource("/json/MultiVariantNewsletterProcess.json")!!.toURI())
         assertThat(result).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertJsonSyntaxValid(result)
     }
 
     @Test

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/json/BpmnJsonGeneratorTest.kt
@@ -14,11 +14,6 @@ class BpmnJsonGeneratorTest {
 
     private val underTest = BpmnJsonGenerator()
 
-    private fun assertJsonSyntaxValid(source: String) {
-        runCatching { Json.parseToJsonElement(source) }
-            .onFailure { fail("JSON syntax error in generated output: ${it.message}") }
-    }
-
     @Test
     fun `generates correct JSON for single model`() {
 
@@ -72,5 +67,10 @@ class BpmnJsonGeneratorTest {
 
         // then: filename is processId.json
         assertThat(result.fileName).isEqualTo("newsletterSubscription.json")
+    }
+
+    private fun assertJsonSyntaxValid(source: String) {
+        runCatching { Json.parseToJsonElement(source) }
+            .onFailure { fail("JSON syntax error in generated output: ${it.message}") }
     }
 }


### PR DESCRIPTION
Closes #257

## Summary

- Adds `kotlin-compiler-embeddable` as a test dependency for PSI-based Kotlin syntax checking
- Inlines `assertKotlinSyntaxValid` in `KotlinProcessApiBuilderTest` and `KotlinSharedTypesBuilderTest` — parses source via `KtPsiFactory` and fails on any `PsiErrorElement`
- Inlines `assertJavaSyntaxValid` in `JavaProcessApiBuilderTest` and `JavaSharedTypesBuilderTest` — uses `JavacTask.parse()` (parse-only, no type resolution) so missing symbols like `BpmnTimer` don't cause false failures
- Inlines `assertJsonSyntaxValid` in `BpmnJsonGeneratorTest` — uses `Json.parseToJsonElement()` from the existing `kotlinx-serialization-json` dependency

## Notes

`KotlinCoreEnvironment.createForProduction` is annotated as K1 API in Kotlin 2.3.20 — opted in via `@OptIn(K1Deprecation::class)` and updated the deprecated `CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY` to `CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY`.