### PR TITLE
chore: enforce architecture via Konsist

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
     jacoco
+    `java-test-fixtures`
 }
 
 group = "io.github.emaarco"
@@ -19,8 +20,11 @@ dependencies {
     api(libs.slf4jApi)
     api(libs.kotlinLogging)
     testImplementation(libs.bundles.testing)
+    testImplementation(libs.konsist)
     testImplementation(kotlin("compiler-embeddable"))
     testRuntimeOnly(libs.junitPlatformLauncher)
+    testFixturesApi(libs.konsist)
+    testFixturesApi(libs.junit)
 }
 
 sourceSets {

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/architecture/HexagonalArchitectureTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/architecture/HexagonalArchitectureTest.kt
@@ -1,0 +1,118 @@
+package io.github.emaarco.bpmn.architecture
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
+import com.lemonappdev.konsist.api.architecture.Layer
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class HexagonalArchitectureTest {
+
+    private val rootPackage = "io.github.emaarco.bpmn"
+
+    @Test
+    fun `hexagonal architecture layers are respected`() {
+        Konsist
+            .scopeFromProject()
+            .assertArchitecture {
+                val domainLayer = Layer("Domain", "$rootPackage.domain..")
+                val inPortsLayer = Layer("In-Ports", "$rootPackage.application.port.inbound..")
+                val outPortsLayer = Layer("Out-Ports", "$rootPackage.application.port.outbound..")
+                val inAdaptersLayer = Layer("In-Adapters", "$rootPackage.adapter.inbound..")
+                val outAdaptersLayer = Layer("Out-Adapters", "$rootPackage.adapter.outbound..")
+                val applicationLayer = Layer("Application", "$rootPackage.application.service..")
+
+                domainLayer.dependsOnNothing()
+                inPortsLayer.dependsOn(domainLayer)
+                outPortsLayer.dependsOn(domainLayer)
+                outAdaptersLayer.dependsOn(domainLayer, outPortsLayer)
+                // Services import concrete out-adapter classes as constructor default values (no DI framework).
+                // The constructor parameter TYPES must still be out-port interfaces — enforced separately below.
+                applicationLayer.dependsOn(domainLayer, inPortsLayer, outPortsLayer, outAdaptersLayer)
+                // In-adapters act as composition root: they instantiate services (which wire their own adapters).
+                inAdaptersLayer.dependsOn(domainLayer, inPortsLayer, applicationLayer)
+            }
+    }
+
+    @Nested
+    inner class PortTests {
+
+        @Test
+        fun `all ports are interfaces`() {
+            Konsist
+                .scopeFromPackage("$rootPackage.application.port..")
+                .classesAndInterfacesAndObjects(includeNested = false, includeLocal = false)
+                .assertTrue { it is KoInterfaceDeclaration }
+        }
+    }
+
+    @Nested
+    inner class ServiceTests {
+
+        @Test
+        fun `services are named with Service suffix`() {
+            Konsist
+                .scopeFromPackage("$rootPackage.application.service..")
+                .classesAndInterfacesAndObjects(includeNested = false, includeLocal = false)
+                .filter { it.path.contains("/src/main/") }
+                .assertTrue { it.hasNameEndingWith("Service") }
+        }
+
+        @Test
+        fun `each service imports exactly one inbound port`() {
+            Konsist
+                .scopeFromPackage("$rootPackage.application.service..")
+                .files
+                .filter { it.path.contains("/src/main/") }
+                .assertTrue { file ->
+                    val inboundPortImports = file.imports
+                        .filter { it.name.contains(".application.port.inbound.") }
+                    inboundPortImports.size == 1
+                }
+        }
+
+        @Test
+        fun `service constructor parameters are typed as out-port interfaces, not concrete adapter implementations`() {
+            // Services may import concrete out-adapter classes as constructor default values (no DI framework),
+            // but the constructor parameter TYPES must use out-port interfaces, not the concrete adapter classes.
+            Konsist
+                .scopeFromPackage("$rootPackage.application.service..")
+                .files
+                .filter { it.path.contains("/src/main/") }
+                .assertTrue { file ->
+                    val outAdapterImportNames = file.imports
+                        .filter { it.name.startsWith("$rootPackage.adapter.outbound.") }
+                        .map { it.name.substringAfterLast(".") }
+                    val constructorParamTypeNames = file.classes()
+                        .flatMap { it.primaryConstructor?.parameters ?: emptyList() }
+                        .map { it.type.name }
+                    outAdapterImportNames.none { it in constructorParamTypeNames }
+                }
+        }
+    }
+
+    @Nested
+    inner class InAdapterTests {
+
+        @Test
+        fun `in-adapter constructor parameters are typed as inbound port interfaces, not concrete service implementations`() {
+            // In-adapters may import concrete service classes as constructor default values (no DI framework),
+            // but the constructor parameter TYPES must use inbound port interfaces, not the concrete service classes.
+            Konsist
+                .scopeFromPackage("$rootPackage.adapter.inbound..")
+                .files
+                .filter { it.path.contains("/src/main/") }
+                .assertTrue { file ->
+                    val serviceImportNames = file.imports
+                        .filter { it.name.startsWith("$rootPackage.application.service.") }
+                        .map { it.name.substringAfterLast(".") }
+                    val constructorParamTypeNames = file.classes()
+                        .flatMap { it.primaryConstructor?.parameters ?: emptyList() }
+                        .map { it.type.name }
+                    serviceImportNames.none { it in constructorParamTypeNames }
+                }
+        }
+    }
+}

--- a/bpmn-to-code-core/src/testFixtures/kotlin/io/github/emaarco/bpmn/architecture/ExternalModuleImportTest.kt
+++ b/bpmn-to-code-core/src/testFixtures/kotlin/io/github/emaarco/bpmn/architecture/ExternalModuleImportTest.kt
@@ -1,0 +1,37 @@
+package io.github.emaarco.bpmn.architecture
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Enforces that plugin wrapper modules only import from:
+ * - `io.github.emaarco.bpmn.domain.*` — domain objects
+ * - `io.github.emaarco.bpmn.adapter.inbound.*` — inbound adapters (the public API surface)
+ *
+ * Extend this class in each plugin module (Gradle, Maven, Web, MCP) and pass the module
+ * directory name as [modulePath]. The test will then be scoped to that module's source files.
+ *
+ * Note: `bpmn-to-code-testing` is excluded — it is a BPMN parsing utility library that
+ * legitimately uses the BPMN extraction out-adapter directly to implement its validation logic.
+ */
+abstract class ExternalModuleImportTest(private val modulePath: String) {
+
+    private val forbiddenImportPrefixes = listOf(
+        "io.github.emaarco.bpmn.application.",      // services and ports
+        "io.github.emaarco.bpmn.adapter.outbound.", // out-adapters
+    )
+
+    @Test
+    fun `module only imports domain objects or inbound adapters from core`() {
+        Konsist
+            .scopeFromProject()
+            .files
+            .filter { file -> file.path.contains(modulePath) }
+            .assertTrue { file ->
+                file.imports.none { import ->
+                    forbiddenImportPrefixes.any { import.name.startsWith(it) }
+                }
+            }
+    }
+}

--- a/bpmn-to-code-gradle/build.gradle.kts
+++ b/bpmn-to-code-gradle/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     compileOnly(project(":bpmn-to-code-core"))
     testImplementation(gradleTestKit())
     testImplementation(libs.bundles.testing)
+    testImplementation(testFixtures(project(":bpmn-to-code-core")))
     testRuntimeOnly(libs.junitPlatformLauncher)
 }
 

--- a/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
+++ b/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
@@ -1,0 +1,3 @@
+package io.github.emaarco.bpmn.architecture
+
+class ModuleArchitectureTest : ExternalModuleImportTest("bpmn-to-code-gradle")

--- a/bpmn-to-code-maven/build.gradle.kts
+++ b/bpmn-to-code-maven/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.mavenPluginAnnotations)
     testImplementation(project(":bpmn-to-code-core"))
     testImplementation(libs.bundles.testing)
+    testImplementation(testFixtures(project(":bpmn-to-code-core")))
     testRuntimeOnly(libs.junitPlatformLauncher)
 }
 

--- a/bpmn-to-code-maven/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
+++ b/bpmn-to-code-maven/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
@@ -1,0 +1,3 @@
+package io.github.emaarco.bpmn.architecture
+
+class ModuleArchitectureTest : ExternalModuleImportTest("bpmn-to-code-maven")

--- a/bpmn-to-code-mcp/build.gradle.kts
+++ b/bpmn-to-code-mcp/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.ktorServerNetty)
 
     testImplementation(libs.bundles.testing)
+    testImplementation(testFixtures(project(":bpmn-to-code-core")))
     testRuntimeOnly(libs.junitPlatformLauncher)
 }
 

--- a/bpmn-to-code-mcp/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
+++ b/bpmn-to-code-mcp/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
@@ -1,0 +1,3 @@
+package io.github.emaarco.bpmn.architecture
+
+class ModuleArchitectureTest : ExternalModuleImportTest("bpmn-to-code-mcp")

--- a/bpmn-to-code-web/build.gradle.kts
+++ b/bpmn-to-code-web/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     // Testing
     testImplementation(libs.bundles.testing)
     testImplementation(libs.ktorServerTestHost)
+    testImplementation(testFixtures(project(":bpmn-to-code-core")))
     testRuntimeOnly(libs.junitPlatformLauncher)
 }
 

--- a/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
+++ b/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/architecture/ModuleArchitectureTest.kt
@@ -1,0 +1,3 @@
+package io.github.emaarco.bpmn.architecture
+
+class ModuleArchitectureTest : ExternalModuleImportTest("bpmn-to-code-web")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ mcpKotlinSdk = "0.11.1"
 shadow = "9.4.1"
 slf4j = "2.0.17"
 kotlinLogging = "8.0.01"
+konsist = "0.17.3"
 
 [libraries]
 # Plugin dependencies
@@ -45,6 +46,7 @@ kotlinLogging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "
 mcpKotlinSdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcpKotlinSdk" }
 
 # Testing dependencies
+konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jUnit" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertJ" }
 junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatformLauncher" }


### PR DESCRIPTION
## Summary

- Enforces per-class line coverage ≥ 75% in `bpmn-to-code-core` via JaCoCo, wired into CI
- Moves pure validation DTOs to `domain/validation/model/` for clean exclusion grouping
- Adds Konsist architecture tests to enforce hexagonal layer boundaries:
  - Layer dependency rules (relaxed for no-DI composition root pattern)
  - In-adapters must type constructor params as inbound port interfaces, not concrete services
  - Services must type constructor params as outbound port interfaces, not concrete adapters
  - Plugin modules (Gradle, Maven, Web, MCP) may only import from `domain.*` or `adapter.inbound.*`
- Adds Lefthook for local pre-push coverage enforcement (mirrors CI check)
- Adds `docs/development/contributing.md` with one-time developer setup instructions

## Test plan

- [ ] `./gradlew :bpmn-to-code-core:test` — all tests including architecture tests pass
- [ ] `./gradlew :bpmn-to-code-core:jacocoTestCoverageVerification` — coverage ≥ 75% per class
- [ ] `./gradlew build` — full multi-module build passes
- [ ] `lefthook install && git push` — pre-push hook triggers on `.kt`/`.kts` changes