### PR TITLE
feat: AI-powered BPMN style guide skills

### DIFF
--- a/bpmn-to-code-skills/README.md
+++ b/bpmn-to-code-skills/README.md
@@ -19,6 +19,10 @@ Claude Code plugin with AI skills for setting up and using the [bpmn-to-code](ht
 | `setup-bpmn-to-code-gradle` | Set up the Gradle plugin in an existing project. Detects project structure, BPMN files, and output language. |
 | `setup-bpmn-to-code-maven` | Set up the Maven plugin in an existing project. Adds plugin configuration to `pom.xml`. |
 | `migrate-to-bpmn-to-code-apis` | Replace hardcoded BPMN strings with references to the generated Process API. |
+| `build-bpmn-styleguide` | Interactively create a `BPMN_STYLE_GUIDE.md` with team conventions for naming, IDs, and layout. |
+| `validate-bpmn-style` | Check BPMN files against a `BPMN_STYLE_GUIDE.md` and report violations with explanations. |
+| `generate-rules-to-enforce-bpmn-styleguide` | Generate Kotlin `BpmnValidationRule` implementations for all automatable style guide rules. |
+| `generate-rule-to-enforce-bpmn-styleguide` | Generate a Kotlin `BpmnValidationRule` for a single rule — useful while drafting or iterating. |
 
 ## Usage
 
@@ -28,6 +32,18 @@ Once installed, skills are available as slash commands:
 /bpmn-to-code:setup-bpmn-to-code-gradle
 /bpmn-to-code:setup-bpmn-to-code-maven
 /bpmn-to-code:migrate-to-bpmn-to-code-apis
+/bpmn-to-code:build-bpmn-styleguide
+/bpmn-to-code:validate-bpmn-style
+/bpmn-to-code:generate-rules-to-enforce-bpmn-styleguide
+/bpmn-to-code:generate-rule-to-enforce-bpmn-styleguide
 ```
 
 Or describe what you need and Claude will invoke the appropriate skill automatically.
+
+## Included Subagents
+
+| Subagent | Description |
+|----------|-------------|
+| `bpmn-styleguide-validator` | Wraps `/validate-bpmn-style` so the orchestrator can keep XML parsing and rule-by-rule judgement out of its main context, or fan out validation in parallel across many BPMN files (one subagent per file). |
+
+Invoke with `@bpmn-to-code:bpmn-styleguide-validator` or let Claude delegate automatically.

--- a/bpmn-to-code-skills/agents/bpmn-styleguide-validator.md
+++ b/bpmn-to-code-skills/agents/bpmn-styleguide-validator.md
@@ -1,0 +1,51 @@
+---
+name: bpmn-styleguide-validator
+description: "Validate one or more BPMN files against the project's BPMN_STYLE_GUIDE.md using the /validate-bpmn-style skill. Returns a structured violation report per file. Delegate to this subagent when you want to keep XML parsing and rule-by-rule judgement out of the main conversation, or when you want to fan out validation across many BPMN files in parallel — spawn multiple instances, one per file, to cut latency. Use proactively whenever the user asks to check BPMN style, lint BPMN files, or verify BPMN conventions across a project."
+tools: Read, Glob, Grep
+model: sonnet
+color: blue
+---
+
+You are the **BPMN Style Guide Validator**. You wrap the `/validate-bpmn-style` skill so the orchestrator can keep its main context small.
+
+## Your Job
+
+Given one or more BPMN file paths, run the `/validate-bpmn-style` skill against each and return a focused report. You never modify files.
+
+## How You're Invoked
+
+The orchestrator will pass you either:
+
+1. **A single BPMN file path** — the common case when the orchestrator is fanning out: the parent spawns N of you in parallel (one per BPMN file) and aggregates the results.
+2. **A set of BPMN file paths** (or no paths at all) — you process them sequentially in your own context. Use this when fan-out isn't worth the overhead (e.g. a project with only a handful of files).
+
+Either way, invoke the `/validate-bpmn-style` skill once per file. The skill handles parsing `BPMN_STYLE_GUIDE.md`, reading the BPMN XML, and routing each rule by its `validation` field (`deterministic`, `llm`, `hybrid`).
+
+## What You Return
+
+A compact report, structured per file:
+
+- File path (relative to the project root)
+- Violation count by severity (errors / warnings / info)
+- Ordered table of violations: severity · element ID · rule slug · half (`deterministic` / `llm` / `semantic` / none) · issue · suggested fix
+- One-line quote of each distinct rule's prose so the orchestrator (or the user) can see the convention without re-opening the style guide
+
+If a file has no violations, return a single line: `<file> — no violations`.
+
+If `BPMN_STYLE_GUIDE.md` is missing, return `"No BPMN_STYLE_GUIDE.md found. Run /build-bpmn-styleguide to create one."` and stop.
+
+## What You Don't Do
+
+- Don't modify BPMN files or source code. You're read-only.
+- Don't fix violations — reporting only. Suggested fixes go in the report.
+- Don't attempt to validate across files (cross-file consistency is out of scope for this skill).
+- Don't spawn further subagents. If the orchestrator wants fan-out, it spawns multiple instances of you.
+
+## Orchestration Notes (for the parent)
+
+To validate a large project quickly, the orchestrator can:
+
+- **Fan-out**: glob BPMN files once in the main context, then spawn one `bpmn-styleguide-validator` per file in parallel. Each subagent runs on its own file; the orchestrator aggregates the reports.
+- **Single-shot**: spawn one `bpmn-styleguide-validator` with the full file set when the project is small enough that parallelism isn't worth it.
+
+Override the model for specific runs if you want to trade capability for speed (e.g. `haiku` for fast first-pass scans, `sonnet` for deep review).

--- a/bpmn-to-code-skills/skills/build-bpmn-styleguide/SKILL.md
+++ b/bpmn-to-code-skills/skills/build-bpmn-styleguide/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: build-bpmn-styleguide
+description: "Interactively author a BPMN_STYLE_GUIDE.md for your project — a handbook that explains how the team models BPMN processes (naming, allowed elements, IDs, topics, engine-specific special cases). The output is a document humans can read; embedded YAML annotations let downstream skills enforce the rules. Use when the user asks to 'create a BPMN style guide', 'set up BPMN conventions', or 'define BPMN naming rules'."
+allowed-tools: Read, Write, Glob, Grep, AskUserQuestion
+---
+
+# Skill: build-bpmn-styleguide
+
+Interactively author `BPMN_STYLE_GUIDE.md` — a **human-readable handbook** that documents how the team models BPMN processes. The document teaches developers what good models look like; embedded YAML annotations make the same document machine-parseable so `/validate-bpmn-style` and `/generate-rules-to-enforce-bpmn-styleguide` can enforce the rules.
+
+## IMPORTANT
+
+- This skill describes **BPMN conventions only** — NOT code patterns (workers, adapters, frameworks are out of scope).
+- The output is **prose first, YAML second**. A reader should be able to skim the document and know how to model; tooling reads the YAML annotations to enforce the rules.
+- The skill knows nothing about downstream enforcement details (which built-in rules exist in `bpmn-to-code-testing`, which CI runs what). Consumers decide.
+- Never modify existing BPMN files or source code.
+- If `BPMN_STYLE_GUIDE.md` already exists, ask whether to overwrite, extend, or abort.
+- Use `AskUserQuestion` for every user decision. Default to `[RECOMMENDED]` answers; let the user accept in one keystroke.
+- Always load `resources/example-bpmn-style-guide.md` before emitting. It is the canonical shape to copy.
+
+## Reference Material
+
+Load these files as needed during the wizard. They're part of the skill, not the project.
+
+- `resources/example-bpmn-style-guide.md` — canonical output shape. Emit files that match its structure.
+- `resources/engines/camunda-7.md` — C7 supported elements, service-task kinds, async triple, variables, timers, transaction-boundary best practices.
+- `resources/engines/operaton.md` — Operaton deltas vs. C7 (namespace).
+- `resources/engines/cib-7.md` — CIB-7 deltas vs. C7 (none; uses C7 namespace).
+- `resources/engines/zeebe.md` — Zeebe support matrix, job-worker model, correlation keys, FEEL timer expressions.
+
+## Output Format
+
+The emitted file is Markdown that reads like documentation. Each rule block has:
+
+1. **Prose**: the convention, the rationale, examples of good and bad.
+2. **A YAML annotation** immediately after the prose:
+
+   ```markdown
+   <!-- rule:<kebab-case-slug> -->
+   ```yaml
+   category: business-modeling | technical-configuration
+   severity: error | warning | info
+   applies-to: [<BpmnElementType...>]
+   validation: deterministic | llm | hybrid
+   pattern: "<regex>"           # required when validation includes deterministic
+   engine: [CAMUNDA_7, ...]      # optional; defaults to the file's top-level Engine:
+   ```
+   ```
+
+The `<!-- rule:slug -->` HTML comment is invisible when the Markdown is rendered but survives in source — tools find rules by this anchor. Any YAML block not preceded by such a comment is ignored.
+
+### The `validation` field
+
+- `deterministic` — fully checkable by regex or a structural check on the domain model. `/generate-rules-to-enforce-bpmn-styleguide` picks it up; `/validate-bpmn-style` runs the regex.
+- `llm` — requires semantic judgement (naming quality, layout, notation choices). Only `/validate-bpmn-style` enforces it.
+- `hybrid` — has both. The regex catches the shape; the AI linter also checks the semantic half using the rule's prose as the brief. Code generation emits only the deterministic half.
+
+## Instructions
+
+### Step 1 — Scan Existing Conventions and Load Engine Metadata
+
+1. Glob for `**/*.bpmn` (exclude `build/`, `target/`, `node_modules/`).
+2. Read up to three sample files. Detect:
+   - Element ID patterns (e.g. `serviceTask_Xxx`, `Activity_Xxx`).
+   - Process ID format (kebab-case, camelCase, etc.).
+   - Whether elements have display names.
+   - Message / signal / error naming patterns.
+   - Engine from XML namespaces: `xmlns:camunda` → CAMUNDA_7 / CIB-7; `xmlns:zeebe` → ZEEBE; `xmlns:operaton` → OPERATON.
+3. Load the matching `resources/engines/<engine>.md`. This tells you which elements, implementation kinds, and attributes the engine supports — don't propose rules for features the engine lacks (e.g. `asyncBefore` on Zeebe; `JAVA_DELEGATE` on Zeebe).
+4. If no BPMN files are found, ask the user which engine to target.
+
+### Step 2 — Phase 1: Context (one question)
+
+`AskUserQuestion` for:
+- Confirm the detected engine (or choose one; treat CIB-7 as CAMUNDA_7 for the `Engine:` header but mention the distinction in prose).
+- Language: English or German.
+- Any team context worth capturing in the introduction (optional).
+
+Write the document header: title, `Engine: …`, `Language: …`, and an intro paragraph that previews the three sections.
+
+### Step 3 — Phase 2: Business Modeling (🎨)
+
+Elicit the mental model. These rules are mostly `validation: llm`.
+
+Ask about (grouped into one or two `AskUserQuestion` calls):
+
+- **Naming conventions** — tasks (verb + noun, present tense), events (noun + past/passive), gateways (short question), pools/lanes (speaking names). Show detected patterns as defaults.
+- **Allowed elements** — which BPMN elements does the team use, and when to reach for each? This is the single most important section for a newcomer. Write it as a bulleted list like the example (`User Task` for human work, `Message Catch Event` for external input, etc.).
+- **Layout** — left-to-right, spacing, crossing avoidance. Default `[RECOMMENDED]` is to include these as `severity: info` rules.
+
+For each rule, emit prose + `<!-- rule:slug -->` + YAML.
+
+### Step 4 — Phase 3: Technical Configuration (🔧)
+
+Mostly `validation: deterministic` or `hybrid`.
+
+Ask about (one `AskUserQuestion` is usually enough, since most teams have a fixed opinion):
+
+- **Element ID format** — default `type_DescriptionInCamelCase`.
+- **Process ID format** — default kebab-case, no `process_` prefix, no version suffix.
+- **Message ID schema** — default `<serviceName>.<myState>`. Offer `hybrid` if the team wants the semantic half ("serviceName matches bounded context") enforced too.
+- **Service task topic schema** — default `<serviceName>.<elementIdWithoutPrefix>`. Same `hybrid` offer.
+- **Gateway outgoing flow labels** — default required.
+- **Implementation-kind consistency** (C7 / Operaton / CIB-7 only) — offer the four kinds; most teams pick `EXTERNAL_TASK`. Skip for Zeebe.
+- **Process variables minimization** — include as `llm` info-level guidance.
+
+Emit each rule with prose (schema + good/bad examples) + YAML annotation.
+
+### Step 5 — Phase 4: Special Cases (⚠️)
+
+Engine-specific patterns. Don't just *offer* — analyze the user's models first, then ask them to choose.
+
+#### For CAMUNDA_7 / OPERATON / CIB-7 — async continuations
+
+1. **Load the best-practice default.** Read the "Transaction Boundaries — Async Continuation Best Practices" section in `resources/engines/camunda-7.md`. That table (external service tasks: no async; start / user / boundary / intermediate-catch: `asyncAfter=true`) is the default. Non-external service-task kinds (`JAVA_DELEGATE`, `DELEGATE_EXPRESSION`, `EXPRESSION`) have no default — don't emit a rule for them.
+2. **Analyze existing BPMN files.** For every BPMN file found in Step 1, tally each element type in the default table and count how many elements match / violate the default. Present a short "current state" summary.
+3. **Ask the user what to do** via `AskUserQuestion`. Four options:
+   - **Adopt best-practice default** — emit the rule exactly as in the engine reference.
+   - **Use detected conventions** — emit the rule with the team's current patterns baked in (e.g. if the team uses `asyncBefore` on service tasks, encode that).
+   - **Customize** — walk through each element type and confirm the default or specify the team's preference.
+   - **Skip** — don't include the rule.
+4. **Emit** a single `<!-- rule:async-continuations -->` block in the Special Cases section with `validation: deterministic` (per-element attribute check). Use the example file's Special Cases section as the prose template.
+
+#### For ZEEBE — message correlation keys
+
+Default: every `<bpmn:message>` has a `<zeebe:subscription correlationKey="…">`. Analyze existing messages, then ask via `AskUserQuestion`: adopt default / use detected (maybe the team has a relaxed rule) / skip.
+
+#### No applicable special cases
+
+If the user declines everything, omit the `## ⚠️ Special Cases` section entirely.
+
+### Step 6 — Phase 5: Review & Generate
+
+1. Assemble the full document, following the example shape:
+   - Title + `Engine:` + `Language:` header
+   - Introductory paragraph
+   - `## 🎨 Business Modeling` with the emitted rule blocks
+   - `## 🔧 Technical Configuration` with its rule blocks
+   - `## ⚠️ Special Cases` (if any)
+   - `## Validation Reference` (the field schema table — copy from the example verbatim)
+2. Show a preview. `AskUserQuestion` asks for confirmation or adjustments.
+3. On approval, write `BPMN_STYLE_GUIDE.md` to the project root.
+4. Suggest next steps:
+   - `/validate-bpmn-style` to lint BPMN files against the guide.
+   - `/generate-rules-to-enforce-bpmn-styleguide` to generate deterministic rules for the testing module.
+
+## Authoring Tips
+
+- Favour narrative over enumeration. A modeler reading the guide should understand *why*, not just *what*.
+- Include good/bad examples under every rule where it helps — lifted straight from the user's domain if you have enough context.
+- When a rule is `validation: llm`, the prose IS the rule (there's no regex). Make the prose concrete enough that `/validate-bpmn-style` has a clear brief.
+- When a rule is `validation: hybrid`, the prose should make the two halves explicit ("The shape is enforced by regex; the semantics are checked by the AI linter — it verifies that…").

--- a/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/camunda-7.md
+++ b/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/camunda-7.md
@@ -1,0 +1,144 @@
+# Camunda 7 (C7) — Supported BPMN Elements and Configuration
+
+This file documents the subset of BPMN that Camunda 7 supports and the engine-specific configuration attributes a style guide can target. Use it to decide which questions to ask the user and which conventions to encode in `BPMN_STYLE_GUIDE.md`.
+
+XML namespace: `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`
+
+## Supported Elements
+
+| Element | Supported | Notes |
+|---|---|---|
+| Service Task | yes | Four implementation kinds — see below |
+| User Task | yes | Supports assignee/candidateUsers/candidateGroups extensions |
+| Receive Task | yes | Correlates to a message definition |
+| Send Task | yes | Implementation configuration like service task |
+| Script Task | yes | Inline script or external resource |
+| Manual Task | yes | No automation |
+| Business Rule Task | yes | DMN integration via `camunda:decisionRef` |
+| Task (generic) | yes | No automation |
+| Start Event | yes | None / Message / Signal / Timer / Error |
+| End Event | yes | None / Message / Signal / Terminate / Error / Escalation / Compensation |
+| Intermediate Catch Event | yes | Message / Signal / Timer / Conditional / Link |
+| Intermediate Throw Event | yes | None / Message / Signal / Compensation / Escalation / Link |
+| Boundary Event | yes | Interrupting + non-interrupting; Message / Signal / Timer / Error / Escalation / Compensation / Conditional |
+| Exclusive Gateway | yes | `default` attribute for default flow |
+| Parallel Gateway | yes | — |
+| Inclusive Gateway | yes | `default` attribute for default flow |
+| Event-Based Gateway | yes | Only connects to intermediate catch events |
+| Complex Gateway | yes (rare) | — |
+| Sub-Process | yes | Embedded + Event Sub-Process + Transaction |
+| Event Sub-Process | yes | `triggeredByEvent="true"` |
+| Call Activity | yes | `calledElement` attribute |
+| Transaction | yes | — |
+| Escalation | yes | Supported as event definition |
+
+## Service Task Implementation Kinds
+
+Exactly one of the following attributes is set on `<bpmn:serviceTask>`. The `implementationValue` is the attribute's value; the `implementationKind` is the enum name below.
+
+| Kind | Attribute | Typical value shape |
+|---|---|---|
+| `EXTERNAL_TASK` | `camunda:type="external" camunda:topic="..."` | dot.separated.topic, e.g. `newsletter.sendConfirmationMail` |
+| `JAVA_DELEGATE` | `camunda:class="..."` | Fully qualified class name |
+| `DELEGATE_EXPRESSION` | `camunda:delegateExpression="${bean}"` | EL expression (usually a Spring bean name) |
+| `EXPRESSION` | `camunda:expression="${...}"` | EL expression |
+
+Source: `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ImplementationKind.kt`
+
+Style guide implications:
+- Teams typically pick one kind project-wide (e.g., external tasks for worker-based projects, delegate expressions for monolithic Spring deployments). A rule can enforce that choice.
+- External-task topics benefit from a schema rule (e.g., `<serviceName>.<elementIdWithoutPrefix>`).
+
+## Transaction Boundaries — Async Continuation Best Practices
+
+Camunda 7 and its forks run as an **embedded engine**: the process runtime shares the JVM and the database transaction with the surrounding service. Without explicit transaction boundaries, a failure in a late task can roll back earlier tasks whose business effects were already persisted. Async continuations (`asyncBefore`, `asyncAfter`, `exclusive`) define those boundaries.
+
+The best-practice default shipped with this skill follows the rules below. `build-bpmn-styleguide` Phase 4 compares what the user's models actually do against this default and lets them adopt, override, or skip.
+
+| Element | Default convention | Rationale |
+|---|---|---|
+| Service Task (`type=external`) | **never** `asyncBefore` / `asyncAfter`. | External-task workers poll from the engine — the handover is already a transaction boundary. Adding async on top creates a redundant job and confuses error handling. For other service-task kinds (`JAVA_DELEGATE`, `DELEGATE_EXPRESSION`, `EXPRESSION`) the skill does not propose a default — pick one consciously per your deployment model. |
+| Start Event | `asyncAfter=true` | Keeps the process-start commit separate from the first task. A failure in the first task doesn't roll back the process instance. |
+| User Task | `asyncAfter=true` | A user task is a wait state. Post-completion logic belongs in its own transaction so a failure doesn't make the user redo the task. |
+| Boundary Event (message / timer / signal / error) | `asyncAfter=true` | The boundary event commits the moment it fires; subsequent logic runs in a fresh transaction. |
+| Intermediate Catch Event (message / timer / signal) | `asyncAfter=true` | Same reasoning as boundary events — the catch is the wait state. |
+
+**Sources and further reading:**
+- Camunda 7 docs: [Transactions in Processes](https://docs.camunda.org/manual/latest/user-guide/process-engine/transactions-in-processes/)
+- The `asyncBefore` / `asyncAfter` / `exclusive` attributes are documented in the next section of this file.
+
+### What Phase 4 of `build-bpmn-styleguide` should do
+
+1. Parse each BPMN file the user already has. For each element type in the table above, count how many elements match / violate the default.
+2. Present the findings via `AskUserQuestion`. Offer four choices:
+   - **Adopt the default** — emit the `async-continuations` rule exactly as in the table.
+   - **Use detected conventions** — emit the rule with the team's current patterns baked in.
+   - **Customize** — walk through each element type and confirm each default.
+   - **Skip** — omit the rule entirely.
+3. Whichever option wins, emit one `<!-- rule:async-continuations -->` block in the Special Cases section with `validation: deterministic` — the rule is a per-element attribute check.
+
+## Async / Execution Attributes (async triple)
+
+Available on any activity / event:
+
+| Attribute | Default | Purpose |
+|---|---|---|
+| `camunda:asyncBefore="true"` | `false` | Transaction boundary before the activity |
+| `camunda:asyncAfter="true"` | `false` | Transaction boundary after the activity |
+| `camunda:exclusive="false"` | `true` | Allow concurrent execution of the same process instance |
+
+Style guide implications:
+- Some teams require explicit `asyncBefore` on message/signal start events of event sub-processes.
+- Others require `exclusive="true"` (the default) as a reminder.
+
+## Variables
+
+Captured by the extractor:
+- `camunda:inputParameter` / `camunda:outputParameter` on activities
+- `camunda:in` / `camunda:out` on call activities
+- `camunda:elementVariable` + `camunda:collection` on multi-instance activities
+- `camunda:properties` with a property named `additionalVariables` (whitespace-separated list) for variables touched outside the BPMN XML
+
+## Messages, Signals, Errors, Escalations
+
+- Messages and signals are top-level definitions referenced by event definitions (`messageRef`, `signalRef`).
+- Errors have both `name` and `errorCode`. A style rule can enforce an error-code pattern.
+- Escalations have `name` and `escalationCode`. Supported on end events, throw events, boundary events.
+
+## Timers
+
+Inside `<bpmn:timerEventDefinition>`, exactly one of:
+- `<bpmn:timeDate>ISO-8601</bpmn:timeDate>`
+- `<bpmn:timeDuration>ISO-8601</bpmn:timeDuration>` (e.g. `PT5M`, `PT1D`)
+- `<bpmn:timeCycle>R5/PT1H</bpmn:timeCycle>` or a cron expression
+
+Expressions may be used (`${expr}`), resolved at runtime.
+
+## Example XML snippets
+
+```xml
+<bpmn:serviceTask id="serviceTask_SendEmail"
+                  name="Send email"
+                  camunda:type="external"
+                  camunda:topic="newsletter.sendEmail"
+                  camunda:asyncBefore="true">
+  <bpmn:extensionElements>
+    <camunda:inputOutput>
+      <camunda:inputParameter name="recipient">${email}</camunda:inputParameter>
+    </camunda:inputOutput>
+  </bpmn:extensionElements>
+</bpmn:serviceTask>
+
+<bpmn:userTask id="userTask_Approve"
+               name="Approve order"
+               camunda:assignee="${approver}" />
+
+<bpmn:callActivity id="callActivity_VerifyPayment"
+                   calledElement="payment-verification" />
+
+<bpmn:intermediateCatchEvent id="event_WaitForConfirmation">
+  <bpmn:timerEventDefinition>
+    <bpmn:timeDuration>PT5M</bpmn:timeDuration>
+  </bpmn:timerEventDefinition>
+</bpmn:intermediateCatchEvent>
+```

--- a/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/cib-7.md
+++ b/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/cib-7.md
@@ -1,0 +1,29 @@
+# CIB-7 — Supported BPMN Elements and Configuration
+
+CIB-7 is a community-maintained fork of Camunda 7 (continuation of C7 after Camunda Services ended C7 support). Element support, service-task implementation kinds, the async triple, variables, messages/signals/errors/escalations, and timers are **identical** to Camunda 7.
+
+**Read `camunda-7.md` first for the full list.** This file only records deltas.
+
+## Differences vs. Camunda 7
+
+### XML namespace
+
+CIB-7 keeps the Camunda namespace for backwards compatibility:
+
+- `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"` with prefix `camunda:`
+
+Existing C7 BPMN files open and run unchanged on CIB-7.
+
+### Implementation kinds
+
+Same four as C7: `EXTERNAL_TASK`, `JAVA_DELEGATE`, `DELEGATE_EXPRESSION`, `EXPRESSION`.
+
+bpmn-to-code treats CIB-7 as `CAMUNDA_7` in `ProcessEngine`. When a user says "CIB-7", select the `CAMUNDA_7` engine in this skill.
+
+## Transaction Boundaries
+
+Same conventions as Camunda 7 — see the "Transaction Boundaries — Async Continuation Best Practices" section in `camunda-7.md`. CIB-7 keeps the `camunda:` prefix, so the XML examples there apply verbatim.
+
+## Style Guide Implications
+
+Same as C7. Generate C7-style guides unchanged for CIB-7 projects; there is nothing to configure differently.

--- a/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/operaton.md
+++ b/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/operaton.md
@@ -1,0 +1,38 @@
+# Operaton — Supported BPMN Elements and Configuration
+
+Operaton is a fork of Camunda 7. Element support, service-task implementation kinds, the async triple, variables, messages/signals/errors/escalations, and timers are **identical** to Camunda 7.
+
+**Read `camunda-7.md` first for the full list.** This file only records deltas.
+
+## Differences vs. Camunda 7
+
+### XML namespace
+
+- C7: `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"` with prefix `camunda:`
+- Operaton: `xmlns:operaton="http://operaton.org/schema/1.0/bpmn"` with prefix `operaton:`
+
+All engine-specific attributes use the `operaton:` prefix (e.g. `operaton:type`, `operaton:topic`, `operaton:delegateExpression`, `operaton:asyncBefore`).
+
+### Implementation kinds
+
+Same four as C7: `EXTERNAL_TASK`, `JAVA_DELEGATE`, `DELEGATE_EXPRESSION`, `EXPRESSION`.
+
+Source: `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonImplementationKind.kt`
+
+### Example XML snippet
+
+```xml
+<bpmn:serviceTask id="serviceTask_SendEmail"
+                  name="Send email"
+                  operaton:type="external"
+                  operaton:topic="newsletter.sendEmail"
+                  operaton:asyncBefore="true" />
+```
+
+## Transaction Boundaries
+
+Same conventions as Camunda 7 — see the "Transaction Boundaries — Async Continuation Best Practices" section in `camunda-7.md`. The attribute prefix is `operaton:` instead of `camunda:`, but the rules are identical.
+
+## Style Guide Implications
+
+Patterns and rule shapes used for Camunda 7 apply unchanged — only the attribute prefix differs. When generating a style guide for Operaton, reuse C7 conventions and swap `camunda:` → `operaton:` in any example XML.

--- a/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/zeebe.md
+++ b/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/engines/zeebe.md
@@ -1,0 +1,135 @@
+# Zeebe (Camunda 8) — Supported BPMN Elements and Configuration
+
+Zeebe is Camunda's cloud-native engine. Its BPMN subset and configuration model differ significantly from Camunda 7.
+
+XML namespace: `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"`
+
+## Supported Elements
+
+| Element | Supported | Notes |
+|---|---|---|
+| Service Task | yes | Job-worker only — see below |
+| User Task | yes | Tasklist integration |
+| Receive Task | yes | Message correlation required |
+| Send Task | yes | Like service task |
+| Script Task | yes (8.2+) | FEEL or user-defined job type |
+| Manual Task | yes | No automation |
+| Business Rule Task | yes | DMN decision reference |
+| Task (generic) | yes | No automation |
+| Start Event | yes | None / Message / Signal / Timer |
+| End Event | yes | None / Message / Signal / Terminate / Error |
+| Intermediate Catch Event | yes | Message / Signal / Timer / Link |
+| Intermediate Throw Event | yes | None / Message / Signal / Escalation / Link |
+| Boundary Event | yes | Interrupting + non-interrupting; Message / Signal / Timer / Error / Escalation |
+| Exclusive Gateway | yes | `default` attribute |
+| Parallel Gateway | yes | — |
+| Inclusive Gateway | yes (8.1+) | `default` attribute |
+| Event-Based Gateway | yes | — |
+| Complex Gateway | **no** | — |
+| Sub-Process | yes | Embedded + Event Sub-Process |
+| Event Sub-Process | yes | `triggeredByEvent="true"` |
+| Call Activity | yes | Uses `zeebe:calledElement processId` extension, not BPMN `calledElement` attribute |
+| Transaction | **no** | — |
+| Escalation | yes (8.2+) | Throwing/catching on events; limited vs. C7 |
+
+## Service Task Implementation — Job Workers Only
+
+Zeebe has exactly one implementation kind:
+
+| Kind | Extension element | Value shape |
+|---|---|---|
+| `JOB_WORKER` | `<zeebe:taskDefinition type="..." />` | Dot-separated job type, e.g. `newsletter.sendConfirmationMail` |
+
+Example:
+
+```xml
+<bpmn:serviceTask id="serviceTask_SendEmail" name="Send email">
+  <bpmn:extensionElements>
+    <zeebe:taskDefinition type="newsletter.sendEmail" retries="3" />
+  </bpmn:extensionElements>
+</bpmn:serviceTask>
+```
+
+Source: `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeImplementationKind.kt`
+
+Style guide implications:
+- Only the job-type schema rule applies. No DELEGATE_EXPRESSION, JAVA_DELEGATE, or EXPRESSION alternatives exist.
+- The `type` attribute value can reference a process variable via `=variableName` (FEEL expression). Rule patterns should account for this.
+
+## Async / Execution
+
+Zeebe is asynchronous by default. There is **no `asyncBefore`, `asyncAfter`, or `exclusive` attribute**. Do not ask the user about async conventions for Zeebe.
+
+## Variables
+
+Variables are scoped per activity and mapped via:
+
+- `<zeebe:ioMapping>` with `<zeebe:input source="..." target="..."/>` and `<zeebe:output source="..." target="..."/>`
+- `<zeebe:loopCharacteristics>` for multi-instance, with `inputElement`, `inputCollection`, `outputElement`, `outputCollection`
+
+No `camunda:properties` / `additionalVariables` mechanism.
+
+## Messages
+
+Zeebe messages **require a correlation key**:
+
+```xml
+<bpmn:message id="Message_OrderConfirmed" name="orderConfirmed">
+  <bpmn:extensionElements>
+    <zeebe:subscription correlationKey="=orderId" />
+  </bpmn:extensionElements>
+</bpmn:message>
+```
+
+The correlation key is a FEEL expression (note the `=` prefix). Style guide rules can enforce presence and naming of the correlation key expression.
+
+## Signals
+
+Global broadcast, no correlation. Same BPMN definition shape as C7.
+
+## Errors
+
+Error definitions use `name` + `errorCode`, like C7. Thrown via end events or by job workers.
+
+## Escalations
+
+Supported from Zeebe 8.2+. Fewer event-type combinations than C7. Check `shared/bpmn/c8-send-newsletter.bpmn` for a working example.
+
+## Timers
+
+Inside `<bpmn:timerEventDefinition>`, Zeebe expects FEEL expressions:
+
+- `<bpmn:timeDate>=orderDate</bpmn:timeDate>` (FEEL expression → `=` prefix) or literal ISO-8601 (`2024-01-01T00:00:00Z`)
+- `<bpmn:timeDuration>PT1H</bpmn:timeDuration>` (ISO-8601) or `=durationExpression`
+- `<bpmn:timeCycle>R5/PT1H</bpmn:timeCycle>` or cron
+
+Style guide implication: rule patterns on timer values need to tolerate both literal ISO-8601 and `=…` FEEL expressions.
+
+## Call Activity
+
+Uses a Zeebe extension, not the BPMN `calledElement` attribute:
+
+```xml
+<bpmn:callActivity id="callActivity_Payment">
+  <bpmn:extensionElements>
+    <zeebe:calledElement processId="payment-verification" />
+  </bpmn:extensionElements>
+</bpmn:callActivity>
+```
+
+## Example XML snippet
+
+```xml
+<bpmn:serviceTask id="serviceTask_SendEmail" name="Send email">
+  <bpmn:extensionElements>
+    <zeebe:taskDefinition type="newsletter.sendEmail" />
+    <zeebe:ioMapping>
+      <zeebe:input source="=recipient" target="to" />
+    </zeebe:ioMapping>
+  </bpmn:extensionElements>
+</bpmn:serviceTask>
+
+<bpmn:startEvent id="startEvent_OrderPlaced">
+  <bpmn:messageEventDefinition messageRef="Message_OrderPlaced" />
+</bpmn:startEvent>
+```

--- a/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/example-bpmn-style-guide.md
+++ b/bpmn-to-code-skills/skills/build-bpmn-styleguide/resources/example-bpmn-style-guide.md
@@ -1,0 +1,275 @@
+# BPMN Style Guide
+
+Engine: CAMUNDA_7
+Language: en
+
+This guide captures how our team models BPMN processes: the naming conventions we follow, the BPMN elements we use (and when to reach for each), the technical configuration we require, and the engine-specific special cases we've learned to handle. Read it end-to-end when you start modelling a new process; skim it for a refresher when reviewing one.
+
+The guide is divided into three parts:
+
+1. **🎨 Business Modeling** — how a model should read to a human.
+2. **🔧 Technical Configuration** — IDs, topics, engine-level settings.
+3. **⚠️ Special Cases** — patterns the engine forces on us.
+
+Each rule block is annotated with a machine-readable YAML stanza so tooling can enforce it automatically. The annotations live inside HTML comments (`<!-- rule:slug -->`) and fenced code blocks — they are invisible when the guide is rendered but survive in source. Two companion skills consume them:
+
+- `/validate-bpmn-style` — lints live BPMN files against this guide (advisory, not a CI gate).
+- `/generate-rules-to-enforce-bpmn-styleguide` — generates Kotlin `BpmnValidationRule` implementations for the deterministic rules, usable with `bpmn-to-code-testing`.
+
+---
+
+## 🎨 Business Modeling
+
+Readable diagrams start here. These rules are about naming, layout, and choosing the right BPMN element for the job. Most of them require human judgement and are enforced by `/validate-bpmn-style`; a handful also have a deterministic shape.
+
+### Naming — Tasks
+
+Describe **what has to be done**. One noun + one verb is usually enough. Keep it in the present tense; the task is an action, not a state.
+
+- good: `Send confirmation mail`, `Validate address`, `Check inventory`
+- bad: `Email`, `Confirmation sent`, `Do stuff`, `Check`
+
+<!-- rule:task-naming -->
+```yaml
+category: business-modeling
+severity: warning
+applies-to: [SERVICE_TASK, USER_TASK, SEND_TASK, RECEIVE_TASK, SCRIPT_TASK, MANUAL_TASK, BUSINESS_RULE_TASK, TASK]
+validation: llm
+```
+
+### Naming — Events
+
+Describe **what has happened**. Use a noun + a passive/past-tense verb. The event captures a state change; the name reflects that state.
+
+- good: `Order received`, `Payment authorized`, `Registration aborted`
+- bad: `Receive order`, `Authorize payment`, `Abort registration`
+
+<!-- rule:event-naming -->
+```yaml
+category: business-modeling
+severity: warning
+applies-to: [START_EVENT, END_EVENT, INTERMEDIATE_CATCH_EVENT, INTERMEDIATE_THROW_EVENT, BOUNDARY_EVENT]
+validation: llm
+```
+
+### Naming — Gateways
+
+Phrase the decision as a **short question**. One noun + one verb when you can.
+
+- good: `Customer known?`, `Inventory sufficient?`
+- bad: `Check customer`, `Gateway_0a1b2c3`
+
+<!-- rule:gateway-naming -->
+```yaml
+category: business-modeling
+severity: warning
+applies-to: [EXCLUSIVE_GATEWAY, INCLUSIVE_GATEWAY]
+validation: llm
+```
+
+### Naming — Pools and Lanes
+
+Use speaking names for the actor or system that owns the work: `Customer system`, `User`, `Fulfilment service`. Avoid generic labels like `Lane 1`.
+
+<!-- rule:pool-lane-naming -->
+```yaml
+category: business-modeling
+severity: info
+applies-to: [all-flow-nodes]
+validation: llm
+```
+
+### Allowed Elements
+
+We don't restrict BPMN — any element is allowed. These are the defaults we reach for; deviate only when you have a reason.
+
+- **User Task** — a specific person needs to act on the task (e.g. enter a best-before date for a scanned article).
+- **Message Catch Event** — we wait for an external input, typically a Kafka message.
+- **Receive Task** — like a message catch event, but we need to react *while* waiting (e.g. the order can be cancelled during the confirmation wait).
+- **Send Task vs. Service Task + outgoing message** — use a send task when the whole purpose of the task is to emit a message.
+- **Business Rule Task** — only when the logic is genuinely a DMN decision table. Don't overload it with integration logic.
+- **Script Task** — avoid in production flows. Use a service task instead so the behaviour is testable.
+- **Call Activity** — when the sub-process stands on its own and has a lifecycle (owned BPMN file, its own process ID, reusable).
+
+<!-- rule:allowed-notation-choices -->
+```yaml
+category: business-modeling
+severity: info
+applies-to: [all-flow-nodes]
+validation: deterministic
+```
+*Deterministic: set-membership check against `FlowNodeDefinition.elementType`. An element whose type is not on the allowed list is a violation. The list above is the source of truth.*
+
+### Layout
+
+- **Reading direction**: left to right. The start event sits on the left, end events on the right.
+- **Spacing**: leave enough room between elements that labels don't collide.
+- **No crossings**: if sequence flows would cross, break the flow with an intermediate event, a sub-process, or a layout change. Crossings are a smell that the process is hiding complexity.
+
+<!-- rule:layout-left-to-right -->
+```yaml
+category: business-modeling
+severity: info
+applies-to: [process]
+validation: llm
+```
+
+---
+
+## 🔧 Technical Configuration
+
+These rules govern how automation-relevant elements are identified and configured.
+They're mostly deterministic and can be enforced by either the LLM via `/validate-bpmn-style` or by the generated `BpmnValidationRule`s in your test suite.
+
+### Element IDs
+
+Every element that matters for automation has an ID in the format `type_DescriptionInCamelCase`. The `type_` prefix mirrors the BPMN element type; the description is PascalCase.
+
+| Element | Example |
+|---|---|
+| Start Event | `startEvent_OrderReceived` |
+| Intermediate Event | `event_ShipmentDelayed` |
+| End Event | `endEvent_OrderCompleted` |
+| Service Task | `serviceTask_SendConfirmationMail` |
+| User Task | `userTask_ApproveOrder` |
+| Receive Task | `receiveTask_AwaitPayment` |
+| Gateway | `gateway_CustomerKnown` |
+| Sub-Process | `subProcess_Confirmation` |
+| Call Activity | `callActivity_AbortRegistration` |
+| Timer Event | `timer_After3Days` |
+
+The auto-generated IDs from the Camunda Modeler (`Activity_0x7f3a`, `Gateway_1abc`) are rejected — rename them before you commit.
+
+<!-- rule:element-id-format -->
+```yaml
+category: technical-configuration
+severity: error
+applies-to: [all-flow-nodes]
+validation: deterministic
+pattern: "^(startEvent|endEvent|event|serviceTask|userTask|receiveTask|sendTask|scriptTask|manualTask|businessRuleTask|gateway|subProcess|callActivity|task|timer|boundaryEvent)_[A-Z][a-zA-Z0-9]*$"
+```
+
+### Process IDs
+
+Process IDs are kebab-case, no `process_` prefix, no version suffix. The name has a domain meaning (the business capability), not a technical one.
+
+- good: `newsletter-subscription`, `order-fulfillment`, `invoice-processing`
+- bad: `process_NewsletterSubscription`, `newsletterSubscriptionV2`, `PROC_01`
+
+<!-- rule:process-id-format -->
+```yaml
+category: technical-configuration
+severity: error
+applies-to: [process]
+validation: deterministic
+pattern: "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+```
+
+### Message IDs
+
+Messages are identified service-wide by `<serviceName>.<myState>` in camelCase. The service name is the bounded context; the state is what's being communicated.
+
+- good: `order.orderCreated`, `newsletter.subscriptionConfirmed`
+- bad: `Message_ConfirmSubscription`, `newsletter_subscription_confirmed`
+
+<!-- rule:message-id-schema -->
+```yaml
+category: technical-configuration
+severity: error
+applies-to: [messages]
+validation: hybrid
+pattern: "^[a-z][a-zA-Z0-9]*\\.[a-z][a-zA-Z0-9]*$"
+```
+*Hybrid: the regex catches the shape. `/validate-bpmn-style` additionally checks that `<serviceName>` matches the bounded context of the process.*
+
+### Service Task Topics (Type IDs)
+
+A Camunda 7 topic (or Zeebe job type) is the identifier the worker subscribes to. We use `<serviceName>.<elementIdWithoutPrefix>` in camelCase — same `<serviceName>` as the messages, so topics and messages line up.
+
+- good: `order.validateAddress`, `newsletter.sendConfirmationMail`
+- bad: `SendConfirmationMail`, `newsletter_send_confirmation_mail`
+
+<!-- rule:service-task-topic -->
+```yaml
+category: technical-configuration
+severity: error
+applies-to: [SERVICE_TASK]
+validation: hybrid
+pattern: "^[a-z][a-zA-Z0-9]*\\.[a-z][a-zA-Z0-9]*$"
+```
+*Hybrid: regex catches the shape; the AI linter additionally checks that `<elementIdWithoutPrefix>` actually matches the element ID (minus `serviceTask_` prefix, lowercased).*
+
+### Gateway Flow Labels
+
+Outgoing sequence flows from exclusive or inclusive gateways are labelled. Labels should answer the question asked at the gateway (`yes` / `no` or a short descriptor).
+
+<!-- rule:gateway-flow-labels -->
+```yaml
+category: technical-configuration
+severity: error
+applies-to: [sequence-flows]
+validation: deterministic
+```
+
+### Process Variables
+
+Keep process variables minimal. The engine is not a database — pass only the data needed for orchestration decisions. A flag `isPremiumCustomer` is fine; the whole customer object as JSON is too much. When in doubt, load from the domain service inside the worker.
+
+<!-- rule:minimize-process-variables -->
+```yaml
+category: technical-configuration
+severity: info
+applies-to: [process]
+validation: llm
+```
+
+---
+
+## ⚠️ Special Cases
+
+Patterns the engine forces on us. Skim once; revisit when they bite.
+
+### Transaction Boundaries (Async Continuations, C7 / Operaton / CIB-7)
+
+CIB-7 is an **embedded engine** — the process runtime shares the JVM and the database transaction with the service. Without explicit transaction boundaries, a failure in a late task can roll back earlier tasks whose business effects have already been persisted. The conventions below keep engine state and business state aligned.
+
+TL;DR:
+
+| Element | Convention |
+|---|---|
+| Service Task (`type=external`) | **never** `asyncBefore` / `asyncAfter`. The external-task worker already acts as a transaction boundary. Other implementation kinds (`JAVA_DELEGATE`, `DELEGATE_EXPRESSION`, `EXPRESSION`) are not covered by this default — decide per deployment model. |
+| Start Event | `asyncAfter=true`. |
+| User Task | `asyncAfter=true`. |
+| Boundary Event (all types) | `asyncAfter=true`. |
+| Intermediate Catch Event (all types) | `asyncAfter=true`. |
+
+<!-- rule:async-continuations -->
+```yaml
+category: technical-configuration
+severity: error
+applies-to: [SERVICE_TASK, USER_TASK, START_EVENT, BOUNDARY_EVENT, INTERMEDIATE_CATCH_EVENT]
+engine: [CAMUNDA_7, OPERATON]
+validation: deterministic
+```
+*Deterministic: per-element attribute check — external service tasks must have neither `asyncBefore` nor `asyncAfter`; start / user / boundary / intermediate-catch events must have `asyncAfter=true`.*
+
+### Message Correlation (Zeebe)
+
+If this style guide targets Zeebe, every message definition must carry a `zeebe:subscription` element with a FEEL `correlationKey` expression. This isn't optional — Zeebe can't correlate messages without it.
+
+*(Not applicable to this C7 example, but included here so a Zeebe-targeted guide has a template.)*
+
+---
+
+## Validation Reference
+
+| Field | Values | Meaning |
+|---|---|---|
+| `category` | `business-modeling` \| `technical-configuration` | Which section of this handbook the rule belongs to |
+| `severity` | `error` \| `warning` \| `info` | Reporting level |
+| `applies-to` | BPMN element types or meta-categories (`all-flow-nodes`, `sequence-flows`, `process`, `messages`, `signals`, `errors`, `escalations`) | What the rule checks |
+| `validation` | `deterministic` \| `llm` \| `hybrid` | How the rule gets enforced |
+| `pattern` | regex | Deterministic check (required when `validation` includes a deterministic half) |
+| `engine` | subset of `[CAMUNDA_7, OPERATON, CIB_7, ZEEBE]` | Optional engine scope; defaults to the top-level `Engine:` |
+
+`validation: hybrid` means both halves exist. `/generate-rules-to-enforce-bpmn-styleguide` generates Kotlin for the deterministic half; `/validate-bpmn-style` runs both halves and quotes the rule's prose in the violation message.

--- a/bpmn-to-code-skills/skills/generate-rule-to-enforce-bpmn-styleguide/SKILL.md
+++ b/bpmn-to-code-skills/skills/generate-rule-to-enforce-bpmn-styleguide/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: generate-rule-to-enforce-bpmn-styleguide
+argument-hint: "[rule-slug]"
+description: "Generate a Kotlin BpmnValidationRule implementation for ONE rule from BPMN_STYLE_GUIDE.md. Use when drafting / iterating on a single rule, or when the user asks to 'generate a rule for <slug>', 'create the element-id-format rule', or 'add just this one rule to the test module'. For all rules at once, use generate-rules-to-enforce-bpmn-styleguide."
+allowed-tools: Read, Write, Glob, Grep, Bash(./gradlew *)
+---
+
+# Skill: generate-rule-to-enforce-bpmn-styleguide
+
+Generate a single Kotlin `BpmnValidationRule` implementation for one entry in `BPMN_STYLE_GUIDE.md`. Same template, conventions and output directory as the bulk variant — use this when you're drafting a rule or iterating on one without regenerating the full file.
+
+## IMPORTANT
+
+- Everything the bulk variant (`generate-rules-to-enforce-bpmn-styleguide`) says also applies here.
+- The rule must include a deterministic half (`validation: deterministic` or `validation: hybrid`). If the user asks for an `llm`-only rule, explain that it belongs to `/validate-bpmn-style` only and stop.
+- For `hybrid` rules, generate the deterministic half and note in a comment that the semantic half stays for `/validate-bpmn-style`.
+- Don't touch the aggregator (`BpmnStyleGuideRules.kt`) owned by the bulk variant. This skill writes its own per-rule file; the user can run the bulk skill later to regenerate the aggregator.
+- Use `requireNotNull()` instead of `!!`.
+- Use `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRule.kt` as the structural template.
+
+## Domain Model
+
+For rule bodies, read the actual domain classes under `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/` — don't trust static summaries.
+
+## Instructions
+
+### Step 0 — Verify `bpmn-to-code-testing` Setup
+
+Same check as the bulk variant — generated rules need the dependency.
+
+1. Glob for build files at repo root and one level below: `build.gradle`, `build.gradle.kts`, `pom.xml`, `*/build.gradle*`, `*/pom.xml`.
+2. Grep each for `bpmn-to-code-testing`.
+3. Missing → abort with the Gradle + Maven snippets (see the bulk skill). Tell the user to add it and re-run.
+4. Multiple module matches → ask which one hosts the rule.
+
+### Step 1 — Resolve the Rule Slug
+
+1. Locate `BPMN_STYLE_GUIDE.md` (current dir, then git root). Missing → suggest `/build-bpmn-styleguide`.
+2. Parse the file to enumerate rules:
+   - Find every `<!-- rule:<slug> -->` anchor.
+   - For each, capture the slug + the next ``` ```yaml``` fenced block + the preceding prose.
+3. If `$ARGUMENTS` is a rule slug, look it up.
+4. If no argument, list all slugs and ask which one to generate.
+5. If the slug doesn't exist, report and stop.
+
+### Step 2 — Classify and Confirm
+
+Decide based on the rule's `validation`:
+
+- `deterministic` → proceed.
+- `hybrid` → proceed (deterministic half); inform the user the semantic half stays for `/validate-bpmn-style`.
+- `llm` → stop. Explain that the rule is enforced only by `/validate-bpmn-style` and there's nothing to generate.
+
+Before generating, show the user:
+- Which domain-model property the rule inspects (from the rule's `applies-to` + the YAML schema).
+- The regex (or check) that will be applied.
+- The classification (deterministic / hybrid).
+
+Ask for confirmation.
+
+### Step 3 — Generate the Rule
+
+One Kotlin file, one class. Class name is PascalCase of the slug (e.g. `element-id-format` → `ElementIdFormatRule`).
+
+**File header:**
+
+```kotlin
+// Generated from BPMN_STYLE_GUIDE.md by /generate-rule-to-enforce-bpmn-styleguide.
+// Re-run the skill after editing the rule in the style guide.
+```
+
+**Class for a `deterministic` rule** (follow `InvalidIdentifierRule.kt` for shape):
+
+```kotlin
+/**
+ * element-id-format (deterministic)
+ * Category: technical-configuration
+ */
+class ElementIdFormatRule : BpmnValidationRule {
+    override val id = "element-id-format"
+    override val severity = Severity.ERROR
+
+    override fun validate(context: ValidationContext): List<ValidationViolation> {
+        val pattern = Regex("^(serviceTask|userTask|...)_[A-Z][a-zA-Z0-9]*$")
+        return context.model.flowNodes
+            .filter { node ->
+                val nodeId = requireNotNull(node.id) { "FlowNode missing id" }
+                !pattern.matches(nodeId)
+            }
+            .map { node ->
+                ValidationViolation(
+                    ruleId = id,
+                    severity = severity,
+                    elementId = node.id,
+                    processId = context.model.processId,
+                    message = "Element ID '${node.id}' does not match format type_DescriptionInCamelCase",
+                )
+            }
+    }
+}
+```
+
+**Class for a `hybrid` rule** — same shape, but the doc comment calls out the split:
+
+```kotlin
+/**
+ * service-task-topic (hybrid — deterministic half only)
+ * Category: technical-configuration
+ *
+ * This rule covers the deterministic shape check. The semantic half
+ * is enforced by /validate-bpmn-style using the rule's prose as the brief.
+ */
+class ServiceTaskTopicRule : BpmnValidationRule { /* ... */ }
+```
+
+### Step 4 — Scan for an Existing Version of This Rule
+
+Before asking where to write, see whether the project already has a rule for this slug:
+
+1. Glob `**/src/test/kotlin/**/architecture/bpmn/**/*.kt`, plus a broader `**/src/test/kotlin/**/*Rule.kt` to catch alternative layouts.
+2. Grep the matches for the slug as the `override val id = "<slug>"` literal, and for the expected class name.
+3. If found:
+   - Show the user the existing implementation.
+   - Ask whether to **replace** it (overwrite the file), **skip** generation (keep the existing file as-is), or **write alongside** under a different class name (user resolves the duplicate manually).
+4. If nothing matches, proceed directly to Step 5.
+
+### Step 5 — Ask Output Location
+
+Default to `src/test/kotlin/<package>/architecture/bpmn/<ClassName>.kt` in the module from Step 0 — same directory as the bulk skill uses. If Step 4 found an existing file, suggest that location by default. Confirm or let the user override.
+
+### Step 6 — Write and Verify
+
+1. Create `architecture/bpmn/` if needed.
+2. Write the file.
+3. Run `./gradlew compileKotlin` (or the module's test-compile task).
+4. Fix and retry if it fails.
+5. Show how to plug the rule in:
+
+   ```kotlin
+   BpmnValidator
+       .fromClasspath("bpmn/")
+       .engine(ProcessEngine.CAMUNDA_7)
+       .withRules(BpmnRules.all() + listOf(ElementIdFormatRule()))
+       .validate()
+       .assertNoErrors()
+   ```
+
+6. Mention the bulk skill for when the user is ready to generate the full aggregator (`BpmnStyleGuideRules.kt`). If this is a `hybrid` rule, remind them that `/validate-bpmn-style` still needs to run for the semantic half.

--- a/bpmn-to-code-skills/skills/generate-rules-to-enforce-bpmn-styleguide/SKILL.md
+++ b/bpmn-to-code-skills/skills/generate-rules-to-enforce-bpmn-styleguide/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: generate-rules-to-enforce-bpmn-styleguide
+description: "Generate Kotlin BpmnValidationRule implementations for every deterministic (or hybrid) rule in BPMN_STYLE_GUIDE.md, so they can be enforced at test time by the bpmn-to-code-testing module. llm-only rules stay in the style guide for /validate-bpmn-style. Use when the user asks to 'generate validation rules from the style guide', 'enforce BPMN conventions in CI', or 'automate style checks in tests'. For a single rule, use generate-rule-to-enforce-bpmn-styleguide."
+allowed-tools: Read, Write, Glob, Grep, Bash(./gradlew *)
+---
+
+# Skill: generate-rules-to-enforce-bpmn-styleguide
+
+Generate Kotlin `BpmnValidationRule` implementations for the deterministic rules in `BPMN_STYLE_GUIDE.md`. The output is a single file that plugs into `bpmn-to-code-testing`'s `BpmnValidator`.
+
+## IMPORTANT
+
+- Only generate rules where `validation` includes a deterministic half (`deterministic` or `hybrid`). Pure-LLM rules stay in the style guide for `/validate-bpmn-style`.
+- For `hybrid` rules, generate the deterministic half only. Mention in a comment on the generated class that the full rule also has a semantic half enforced by `/validate-bpmn-style`.
+- Never modify existing source files — only create new files.
+- Always present the classification table to the user before generating anything.
+- Use `requireNotNull()` instead of `!!` (project convention).
+- Use `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRule.kt` as the structural template.
+- After generating, verify compilation with `./gradlew compileKotlin` (or the user's module-specific task).
+
+## Domain Model
+
+For rule bodies, read the actual domain classes under `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/` — don't trust static summaries, the model evolves. `ProcessModel` is the entry point.
+
+## Instructions
+
+### Step 0 — Verify `bpmn-to-code-testing` Setup
+
+Generated rules depend on `io.github.emaarco:bpmn-to-code-testing`. If it's not on the user's classpath, the code won't compile — abort before writing anything.
+
+1. Glob for build files at repo root and one level below: `build.gradle`, `build.gradle.kts`, `pom.xml`, `*/build.gradle*`, `*/pom.xml`.
+2. Grep each for `bpmn-to-code-testing`.
+3. No match → abort and show how to add it:
+
+   ```kotlin
+   // build.gradle.kts
+   dependencies {
+       testImplementation("io.github.emaarco:bpmn-to-code-testing:<latest>")
+   }
+   ```
+
+   ```xml
+   <!-- pom.xml -->
+   <dependency>
+     <groupId>io.github.emaarco</groupId>
+     <artifactId>bpmn-to-code-testing</artifactId>
+     <version><latest></version>
+     <scope>test</scope>
+   </dependency>
+   ```
+
+   Tell the user to add it and re-run.
+4. Multiple module matches → ask which one hosts the rules.
+
+### Step 1 — Read and Parse the Style Guide
+
+1. Locate `BPMN_STYLE_GUIDE.md` (current dir, then git root). Missing → suggest `/build-bpmn-styleguide`.
+2. Parse the file:
+   - Find every `<!-- rule:<slug> -->` anchor.
+   - For each, take the next ``` ```yaml``` fenced block as the rule metadata.
+   - Extract `category`, `severity`, `applies-to`, `validation`, `pattern`, `engine` (optional).
+   - Ignore YAML blocks without a preceding anchor.
+
+### Step 2 — Classify Rules
+
+For each rule, decide whether to generate Kotlin for it:
+
+| `validation` | Generate? | Note |
+|---|---|---|
+| `deterministic` | Yes | Full rule goes into Kotlin. |
+| `hybrid` | Partial | Generate the deterministic half; document that the semantic half stays for `/validate-bpmn-style`. |
+| `llm` | No | Skip. Rule stays in the style guide. |
+
+Present the classification as a table and pause for user confirmation:
+
+```
+| Rule                | Category                 | Validation    | Generate? | Reason |
+|---------------------|--------------------------|---------------|-----------|--------|
+| element-id-format   | technical-configuration  | deterministic | Yes       | Regex on FlowNodeDefinition.id |
+| service-task-topic  | technical-configuration  | hybrid        | Partial   | Regex half generated; semantic half stays in style guide |
+| task-naming         | business-modeling        | llm           | No        | Semantic only — use /validate-bpmn-style |
+| gateway-flow-labels | technical-configuration  | deterministic | Yes       | Presence check on SequenceFlowDefinition.flowName |
+```
+
+### Step 3 — Generate the File
+
+Produce a single Kotlin file: one class per generated rule + an aggregator.
+
+**File header:**
+
+```kotlin
+// Generated from BPMN_STYLE_GUIDE.md by /generate-rules-to-enforce-bpmn-styleguide.
+// Re-run the skill after editing the style guide to keep this file in sync.
+```
+
+**Per-rule class** (template — follow `InvalidIdentifierRule.kt` for shape):
+
+```kotlin
+/**
+ * element-id-format (deterministic)
+ * Category: technical-configuration
+ */
+class ElementIdFormatRule : BpmnValidationRule {
+    override val id = "element-id-format"
+    override val severity = Severity.ERROR
+
+    override fun validate(context: ValidationContext): List<ValidationViolation> {
+        val pattern = Regex("^(serviceTask|userTask|...)_[A-Z][a-zA-Z0-9]*$")
+        return context.model.flowNodes
+            .filter { node ->
+                val nodeId = requireNotNull(node.id) { "FlowNode missing id" }
+                !pattern.matches(nodeId)
+            }
+            .map { node ->
+                ValidationViolation(
+                    ruleId = id,
+                    severity = severity,
+                    elementId = node.id,
+                    processId = context.model.processId,
+                    message = "Element ID '${node.id}' does not match format type_DescriptionInCamelCase",
+                )
+            }
+    }
+}
+```
+
+**For `hybrid` rules**, the class comment calls out the semantic half:
+
+```kotlin
+/**
+ * service-task-topic (hybrid — deterministic half only)
+ * Category: technical-configuration
+ *
+ * This rule covers the deterministic shape check. The semantic half
+ * ('<elementIdWithoutPrefix>' actually matches the element ID minus
+ * 'serviceTask_') is enforced by /validate-bpmn-style.
+ */
+class ServiceTaskTopicRule : BpmnValidationRule { /* ... */ }
+```
+
+**Aggregator:**
+
+```kotlin
+object BpmnStyleGuideRules {
+    @JvmField val ELEMENT_ID_FORMAT = ElementIdFormatRule()
+    @JvmField val SERVICE_TASK_TOPIC = ServiceTaskTopicRule()
+    // …
+
+    @JvmStatic
+    fun all(): List<BpmnValidationRule> = listOf(
+        ELEMENT_ID_FORMAT,
+        SERVICE_TASK_TOPIC,
+        // …
+    )
+}
+```
+
+### Step 4 — Scan for Existing Rules
+
+Before asking for an output location, see what the project already has:
+
+1. Glob `**/src/test/kotlin/**/architecture/bpmn/**/*.kt`, plus a broader `**/src/test/kotlin/**/*Rule.kt` to catch alternative layouts.
+2. Grep the matches for `: BpmnValidationRule` (class declarations) and for each slug from the style guide (as the `override val id = "<slug>"` literal).
+3. Use what you find:
+   - If a `BpmnStyleGuideRules.kt` file already exists at the expected path, read it. Show the user the rules that are already implemented and ask whether to **overwrite**, **merge** (add the new rules and keep existing ones that aren't in the style guide), or **abort**.
+   - If rules with the same `id` exist in different files or under different class names, list them and ask the user how to resolve: **replace**, **skip** (don't regenerate this rule), or **write alongside** (let the user deduplicate manually).
+   - If nothing matches, proceed directly to Step 5.
+
+### Step 5 — Ask Output Location
+
+Default to `src/test/kotlin/<package>/architecture/bpmn/BpmnStyleGuideRules.kt` inside the module that holds `bpmn-to-code-testing` (from Step 0). `<package>` should match the project's test package convention. If Step 4 found an existing aggregator or rule files, suggest the same location. Confirm or let the user override.
+
+### Step 6 — Write and Verify
+
+1. Create `architecture/bpmn/` if it doesn't exist.
+2. Write the file.
+3. Run `./gradlew compileKotlin` (or the module's test-compile task).
+4. If compilation fails, fix and retry.
+5. Show how to integrate:
+
+   ```kotlin
+   BpmnValidator
+       .fromClasspath("bpmn/")
+       .engine(ProcessEngine.CAMUNDA_7)
+       .withRules(BpmnRules.all() + BpmnStyleGuideRules.all())
+       .validate()
+       .assertNoErrors()
+   ```
+
+6. Remind the user that LLM-only rules and the semantic half of hybrid rules still need `/validate-bpmn-style` — the test suite alone won't cover them.

--- a/bpmn-to-code-skills/skills/validate-bpmn-style/SKILL.md
+++ b/bpmn-to-code-skills/skills/validate-bpmn-style/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: validate-bpmn-style
+argument-hint: "[path/to/file.bpmn]"
+description: "Check BPMN files against a team-defined BPMN_STYLE_GUIDE.md and report violations with explanations and suggested fixes. Routes each rule through the right check: deterministic (regex), llm (semantic judgement), or hybrid (both). Use when the user asks to 'check BPMN style', 'validate BPMN conventions', 'review BPMN naming', or 'lint BPMN files'."
+allowed-tools: Read, Glob, Grep
+---
+
+# Skill: validate-bpmn-style
+
+Check BPMN files against a project's `BPMN_STYLE_GUIDE.md` and report violations. The style guide is a handbook — prose explains each rule, YAML annotations inside the prose define how to enforce it. Route each rule by its `validation` field: `deterministic` (regex), `llm` (semantic judgement), or `hybrid` (regex + semantics).
+
+## IMPORTANT
+
+- Read-only. Never modify BPMN files or any other files.
+- Advisory only — never a CI gate. Present results as recommendations.
+- If `BPMN_STYLE_GUIDE.md` is missing, abort and suggest `/build-bpmn-styleguide`.
+- Process files one at a time to manage context.
+- **Always read the BPMN XML directly.** The JSON export is ignored — BPMN XML is the source of truth, covers every engine consistently, and carries everything needed (including the `name` attribute for display names and DI data for layout rules).
+- When reporting a violation, quote the rule's prose so the user understands *why* — that's the value this skill adds over a regex linter.
+
+## Instructions
+
+### Step 1 — Locate and Parse the Style Guide
+
+1. Look for `BPMN_STYLE_GUIDE.md` in the current directory first, then the git root.
+2. If missing: `"No BPMN_STYLE_GUIDE.md found. Run /build-bpmn-styleguide to create one."`
+3. Parse the file:
+   - Find every anchor matching `<!-- rule:<slug> -->` in the Markdown source.
+   - For each anchor, take the next ``` ```yaml ... ``` ``` fenced block as the rule's YAML metadata.
+   - Take the surrounding prose (from the nearest preceding `###` or `##` heading down to the anchor) as the rule's brief — you'll reference this in violation messages.
+   - Ignore YAML blocks that aren't preceded by a rule anchor.
+4. Parse the top-level `Engine:` header (and any rule-level `engine:` overrides) to filter rules per file.
+
+### Step 2 — Select Input
+
+1. If `$ARGUMENTS` is a `.bpmn` file path, use only that file.
+2. Otherwise, glob for `**/*.bpmn` (exclude `build/`, `target/`, `node_modules/`).
+3. Read each BPMN file's XML directly.
+
+### Step 3 — Route Each Rule by `validation`
+
+For each input + each rule (filtered by engine):
+
+**`validation: deterministic`**
+
+Apply the `pattern` regex (or structural check — e.g. set-membership for `allowed-notation-choices`) to the relevant XML path — see the mapping table below. A miss is a violation.
+
+**`validation: llm`**
+
+No regex. Use the rule's prose as the brief. Inspect the element(s) identified by `applies-to` and judge whether they satisfy the convention. Examples:
+- `task-naming` → look at task-type elements' `name` attribute; judge verb+noun, present-tense.
+- `layout-left-to-right` → use the `<bpmndi:BPMNShape>` coordinates to check flow direction.
+
+**`validation: hybrid`**
+
+Run the regex first. If it fails, report a deterministic violation and stop for that rule/element.
+If the regex passes, *additionally* run the LLM judgement on the semantic half described in the prose. Example for `service-task-topic` (hybrid):
+- Regex: topic matches `^[a-z][a-zA-Z0-9]*\.[a-z][a-zA-Z0-9]*$` → pass.
+- Semantic: is `<elementIdWithoutPrefix>` actually the element's ID minus `serviceTask_`? → LLM check.
+
+Report the two halves separately when they disagree.
+
+### XML Path Mapping
+
+| Rule target | BPMN XML path |
+|---|---|
+| Process ID | `<bpmn:process id>` |
+| Flow node ID | `<bpmn:serviceTask id>`, `<bpmn:userTask id>`, … |
+| Flow node display name | `<bpmn:* name>` on the flow-node element |
+| Service task implementation (Camunda 7 / Operaton) | `camunda:topic` / `operaton:topic` / `camunda:class` / `camunda:delegateExpression` / `camunda:expression` (and `operaton:` equivalents) |
+| Service task implementation (Zeebe) | `<zeebe:taskDefinition type="…">` inside the serviceTask's `<bpmn:extensionElements>` |
+| Sequence flow label | `<bpmn:sequenceFlow name>` |
+| Message name | `<bpmn:message name>` |
+| Signal name | `<bpmn:signal name>` |
+| Error name / code | `<bpmn:error name errorCode>` |
+| Escalation name / code | `<bpmn:escalation name escalationCode>` |
+| Async triple (Camunda 7 / Operaton / CIB-7) | `camunda:asyncBefore`, `camunda:asyncAfter`, `camunda:exclusive` (or `operaton:*`) on the flow-node element |
+| Zeebe correlation key | `<zeebe:subscription correlationKey="…">` inside the message's `<bpmn:extensionElements>` |
+| Layout coordinates | `<bpmndi:BPMNShape bpmnElement="…">` with `<dc:Bounds x="…" y="…" width="…" height="…">` |
+
+### Step 4 — Report Results
+
+Group by file, sort by severity (errors → warnings → info). For each violation, include a short quote of the rule's prose so the user understands the convention.
+
+```
+## Results
+
+### `path/to/process.bpmn`
+
+| Severity | Element | Rule | Half | Issue | Suggested Fix |
+|----------|---------|------|------|-------|---------------|
+| error   | `Activity_0x7f3a` | element-id-format   | deterministic | ID does not match `type_CamelCase` format | Rename to `serviceTask_SendEmail` |
+| warning | `Activity_0x7f3a` | task-naming         | llm           | Name "do stuff" isn't a clear verb+noun    | "Send confirmation mail" |
+| error   | `serviceTask_X`    | service-task-topic | semantic      | Topic `billing.x` doesn't match the element ID `X` | Use `billing.x` |
+
+> **element-id-format**: Every element that matters for automation has an ID in the format `type_DescriptionInCamelCase`.
+
+> **task-naming**: Describe what has to be done. One noun + one verb is usually enough.
+
+### `path/to/other-process.bpmn`
+
+No violations found.
+
+---
+
+**Summary**: 2 files checked, 2 errors, 1 warning.
+```
+
+### Step 5 — Provide Context
+
+Beyond the table, add a short note for each distinct rule that was violated explaining *why* the convention matters (readability, maintainability, tooling compatibility). The goal is teaching, not shaming — this is the advantage AI-powered checking has over a regex linter.
+
+## Orchestration
+
+For fan-out validation across a large project, invoke the `bpmn-styleguide-validator` subagent once per BPMN file in parallel. Each subagent runs this skill on a single file; the orchestrator aggregates the reports. See `bpmn-to-code-skills/agents/bpmn-styleguide-validator.md`.


### PR DESCRIPTION
## Summary
- Add `displayName` field to `FlowNodeDefinition` to extract the BPMN `name` attribute from flow nodes
- Create three new user-facing skills in `bpmn-to-code-skills`:
  - **`build-bpmn-styleguide`** — interactive wizard that creates a `BPMN_STYLE_GUIDE.md`
  - **`validate-bpmn-style`** — AI-powered checker that validates BPMN files against the style guide
  - **`generate-style-rules`** — generates Kotlin `BpmnValidationRule` implementations from automatable style guide rules

Closes #188

## Test plan
- [x] All existing tests pass (`./gradlew test`)
- [x] New test verifies `displayName` extraction from BPMN XML
- [ ] Invoke `/build-bpmn-styleguide` on a project with BPMN files
- [ ] Invoke `/validate-bpmn-style` against generated style guide
- [ ] Invoke `/generate-style-rules` and verify compilation of generated rules