### PR TITLE
fix: remove duplicate flat variables from generated Variables API

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
@@ -274,7 +274,6 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val variablesBuilder = TypeSpec.classBuilder("Variables").addModifiers(PUBLIC, STATIC, FINAL)
-            modelApi.model.variables.forEach { variable -> variablesBuilder.addField(createAttribute(variable)) }
             modelApi.model.flowNodes
                 .filter { it.variables.isNotEmpty() }
                 .sortedBy { it.getRawName() }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -269,7 +269,6 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val variablesBuilder = TypeSpec.objectBuilder("Variables")
-            modelApi.model.variables.forEach { variable -> variablesBuilder.addProperty(createAttribute(variable)) }
             modelApi.model.flowNodes
                 .filter { it.variables.isNotEmpty() }
                 .sortedBy { it.getRawName() }

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
@@ -76,10 +76,6 @@ public final class SendNewsletterProcessApi {
   }
 
   public static final class Variables {
-    public static final String AUTHOR = "author";
-
-    public static final String SUBSCRIBERS = "subscribers";
-
     public static final class ServiceTaskLoadSubscribers {
       public static final String AUTHOR = "author";
 

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -81,10 +81,6 @@ object SendNewsletterProcessApi {
   }
 
   object Variables {
-    const val AUTHOR: String = "author"
-
-    const val SUBSCRIBERS: String = "subscribers"
-
     object ServiceTaskLoadSubscribers {
       const val AUTHOR: String = "author"
 

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -88,10 +88,6 @@ public final class NewsletterSubscriptionProcessApi {
   }
 
   public static final class Variables {
-    public static final String SUBSCRIPTION_ID = "subscriptionId";
-
-    public static final String TEST_VARIABLE = "testVariable";
-
     public static final class ActivitySendConfirmationMail {
       public static final String SUBSCRIPTION_ID = "subscriptionId";
 

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -95,10 +95,6 @@ object NewsletterSubscriptionProcessApi {
   }
 
   object Variables {
-    const val SUBSCRIPTION_ID: String = "subscriptionId"
-
-    const val TEST_VARIABLE: String = "testVariable"
-
     object ActivitySendConfirmationMail {
       const val SUBSCRIPTION_ID: String = "subscriptionId"
 


### PR DESCRIPTION
The Variables object was emitting each variable twice: once at the root level and once inside a node-scoped sub-object. Since every variable already belongs to at least one flow node, the root-level flat list was pure duplication.