### PR TITLE
feat(web): reskin web generator UI to match docs landing aesthetic

### DIFF
--- a/bpmn-to-code-web/src/main/resources/static/css/styles.css
+++ b/bpmn-to-code-web/src/main/resources/static/css/styles.css
@@ -1,878 +1,948 @@
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
+/* bpmn-to-code webview — docs-landing-aligned glass aesthetic */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-    --primary-color: #2563eb;
-    --primary-hover: #1d4ed8;
-    --brand-accent: #3b82f6;
-    --brand-soft: rgba(37, 99, 235, 0.12);
-    --success-color: #10b981;
-    --error-color: #ef4444;
-    --border-color: #e5e7eb;
-    --text-primary: #111827;
-    --text-secondary: #6b7280;
-    --bg-gray: #f9fafb;
-    --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    --blue: #335DE4;
+    --navy: #1B1E3A;
+    --green: #0FA968;
+    --green-bright: #00C878;
+    --green-dark: #0A7244;
+    --purple: #6B46A3;
+    --orange: #CE6C00;
+    --red: #E36781;
+
+    --fg: #1B1E3A;
+    --fg-muted: #5A6178;
+    --fg-subtle: #8F93B0;
+
+    --card-glass: rgba(255, 255, 255, 0.55);
+    --grad-1: #CFD9F8;
+    --grad-2: #E8D9F5;
+    --grad-3: #D2F0E0;
+
+    --bg: #FCFDFF;
+    --bg-soft: #F7F8FB;
+    --border: #E4E7F0;
+    --border-soft: #EEF0F7;
 }
 
-body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+html, body {
+    min-height: 100vh;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
     line-height: 1.6;
-    color: var(--text-primary);
-    background: var(--bg-gray);
+}
+body {
+    display: flex;
+    flex-direction: column;
+}
+body > .container {
+    flex: 1 0 auto;
+}
+body > .site-footer {
+    flex-shrink: 0;
 }
 
-/* Navbar — matches docs site nav */
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background:
+        radial-gradient(ellipse 900px 700px at 8% 6%, var(--grad-1) 0%, transparent 62%),
+        radial-gradient(ellipse 800px 600px at 92% 10%, var(--grad-2) 0%, transparent 58%),
+        radial-gradient(ellipse 1000px 700px at 70% 85%, var(--grad-3) 0%, transparent 58%),
+        var(--bg);
+    z-index: -1;
+    pointer-events: none;
+}
+
+a { color: inherit; text-decoration: none; }
+button { border: 0; background: none; padding: 0; font: inherit; cursor: pointer; color: inherit; }
+
+/* NAV */
 .navbar {
-    background: white;
-    border-bottom: 1px solid var(--border-color);
     position: sticky;
     top: 0;
-    z-index: 100;
+    z-index: 10;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
 }
-
 .navbar-inner {
     max-width: 900px;
     margin: 0 auto;
-    padding: 0 1rem;
-    height: 56px;
+    padding: 0 32px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 14px;
+    height: 62px;
 }
-
 .navbar-brand {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    text-decoration: none;
-    color: var(--text-primary);
-    font-weight: 600;
-    font-size: 1rem;
+    gap: 8px;
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--fg);
+    letter-spacing: -0.01em;
 }
+.navbar-brand .mark { display: inline-flex; }
+.navbar-brand .mark img { display: block; border-radius: 4px; }
 
-.navbar-brand img {
-    border-radius: 4px;
+.navbar-links .version-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 9px;
+    border-radius: 6px;
+    background: #fff;
+    border: 1px solid var(--border);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--fg-muted);
+    text-decoration: none;
+    transition: color 0.15s, border-color 0.15s;
 }
+.navbar-links .version-badge::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--green-bright);
+    box-shadow: 0 0 8px var(--green-bright);
+    margin-right: 6px;
+    flex-shrink: 0;
+}
+.navbar-links .version-badge:hover { border-color: var(--green); color: var(--fg); }
 
 .navbar-links {
+    margin-left: auto;
     display: flex;
     align-items: center;
-    gap: 1.5rem;
-}
-
-.navbar-links a {
-    color: var(--text-secondary);
-    text-decoration: none;
-    font-size: 0.875rem;
+    gap: 22px;
+    font-size: 14px;
+    color: var(--fg);
     font-weight: 500;
-    transition: color 0.2s;
 }
+.navbar-links a { transition: color 0.15s; }
+.navbar-links a:hover { color: var(--blue); }
+.navbar-icon { display: inline-flex; color: var(--fg-muted); padding: 6px; }
+.navbar-icon:hover { color: var(--fg); }
 
-.navbar-links a:hover {
-    color: var(--primary-color);
-}
+/* Layout */
+.container { max-width: 900px; margin: 0 auto; padding: 0 32px; }
 
-.navbar-icon {
-    display: inline-flex;
-    align-items: center;
-    color: var(--text-secondary);
-}
-
-.navbar-icon:hover {
-    color: var(--text-primary);
-}
-
-/* Version Badge */
-.version-badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.15rem 0.5rem;
-    font-size: 0.7rem;
-    font-weight: 600;
-    color: var(--primary-color);
-    background: var(--brand-soft);
-    border: 1px solid var(--primary-color);
-    border-radius: 999px;
-    text-decoration: none;
-    transition: background 0.2s, color 0.2s;
-    margin-left: 0.25rem;
-}
-
-.version-badge:hover {
-    background: var(--primary-color);
-    color: white;
-}
-
-.container {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
-}
-
-/* Hero — matches docs site hero section */
-.hero {
-    text-align: center;
-    margin-bottom: 2rem;
-}
-
+/* Hero */
+.hero { text-align: center; padding: 68px 0 34px; }
 .hero-name {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-    background: linear-gradient(135deg, #2563eb, #3b82f6);
+    font-size: 62px;
+    font-weight: 900;
+    line-height: 1.02;
+    letter-spacing: -0.04em;
+    margin-bottom: 14px;
+    background: linear-gradient(90deg, var(--green-bright) 0%, var(--purple) 55%, var(--blue) 100%);
     -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
     background-clip: text;
+    color: transparent;
 }
-
 .hero-text {
-    font-size: 1.5rem;
+    font-size: 22px;
     font-weight: 700;
-    color: var(--text-primary);
-    line-height: 1.4;
-    margin-bottom: 1rem;
+    color: var(--fg);
+    line-height: 1.35;
+    margin-bottom: 14px;
+    letter-spacing: -0.015em;
 }
-
 .hero-description {
-    font-size: 1rem;
-    color: var(--text-secondary);
+    font-size: 16px;
+    color: var(--fg-muted);
     line-height: 1.6;
-    max-width: 600px;
-    margin: 0 auto 1.5rem;
+    max-width: 620px;
+    margin: 0 auto 24px;
 }
-
 .hero-features {
     display: flex;
-    gap: 0.75rem;
     justify-content: center;
+    gap: 8px;
     flex-wrap: wrap;
 }
-
 .feature-badge {
-    background: var(--brand-soft);
-    color: var(--primary-color);
-    padding: 0.375rem 0.875rem;
-    border-radius: 2rem;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    border: 1px solid #dbeafe;
+    padding: 5px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--fg-muted);
 }
 
-/* Preview Notice */
+/* Preview notice */
 .preview-notice {
+    margin: 0 0 24px;
+    padding: 12px 18px;
     display: flex;
     align-items: flex-start;
-    gap: 0.75rem;
-    background: #eff6ff;
-    border: 1px solid #bfdbfe;
-    border-radius: 0.5rem;
-    padding: 1rem 1.25rem;
-    margin-bottom: 2rem;
-    color: #1e40af;
-    font-size: 0.95rem;
-    line-height: 1.6;
+    gap: 12px;
+    background: rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    border-radius: 12px;
+    font-size: 13.5px;
+    color: var(--fg-muted);
+    line-height: 1.5;
 }
+.preview-notice-icon { color: var(--blue); flex-shrink: 0; margin-top: 1px; }
+.preview-notice-content strong { color: var(--fg); font-weight: 600; }
+.preview-notice-content a { color: var(--blue); font-weight: 600; }
 
-.preview-notice-icon {
-    flex-shrink: 0;
-    margin-top: 0.1rem;
+/* Tab switcher — soft green pill for active */
+.tab-switcher {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    background: rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    border-radius: 999px;
+    margin: 0 0 24px;
+    width: 100%;
 }
-
-.preview-notice-icon svg {
-    display: block;
-}
-
-.preview-notice-content {
+.tab-btn {
     flex: 1;
-}
-
-.preview-notice-content strong {
+    padding: 10px 20px;
+    border-radius: 999px;
+    font-size: 14px;
     font-weight: 600;
-    color: #1e3a8a;
-}
-
-.preview-notice-content a {
-    color: #2563eb;
-    text-decoration: underline;
-    font-weight: 500;
-}
-
-.preview-notice-content a:hover {
-    color: #1d4ed8;
-}
-
-/* Card */
-.card {
-    background: white;
-    border-radius: 0.5rem;
-    padding: 2rem;
-    margin-bottom: 2rem;
-    box-shadow: var(--shadow);
-    border: 1px solid var(--border-color);
-}
-
-.card h2 {
-    font-size: 1.5rem;
-    margin-bottom: 1.5rem;
-    color: var(--text-primary);
-}
-
-/* Upload Section */
-.upload-area {
-    border: 2px dashed var(--border-color);
-    border-radius: 0.5rem;
-    padding: 3rem 2rem;
+    color: var(--fg-muted);
     text-align: center;
-    transition: all 0.3s ease;
-    background: var(--bg-gray);
+    transition: all 0.2s;
+    font-family: inherit;
+}
+.tab-btn:hover { color: var(--fg); }
+.tab-btn-active {
+    background: rgba(15, 169, 104, 0.14);
+    color: var(--green-dark);
+    box-shadow: inset 0 0 0 1px rgba(15, 169, 104, 0.32), 0 2px 8px -3px rgba(15, 169, 104, 0.2);
 }
 
-.upload-area:hover,
-.upload-area.drag-over {
-    border-color: var(--primary-color);
-    background: #eff6ff;
+/* Cards */
+main { display: flex; flex-direction: column; gap: 20px; padding-bottom: 56px; }
+.card {
+    background: var(--card-glass);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    border-radius: 16px;
+    padding: 24px 26px;
+    box-shadow:
+        0 24px 48px -28px rgba(27, 30, 58, 0.18),
+        0 6px 14px -10px rgba(27, 30, 58, 0.06),
+        0 0 0 1px rgba(255, 255, 255, 0.55) inset;
+}
+.card h2 {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.012em;
+    margin-bottom: 16px;
+    color: var(--fg);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.card h2::before {
+    content: attr(data-step);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(51, 93, 228, 0.08);
+    color: var(--blue);
+    border: 1px solid rgba(51, 93, 228, 0.2);
+}
+.config-section h2::before {
+    background: rgba(107, 70, 163, 0.08);
+    color: var(--purple);
+    border-color: rgba(107, 70, 163, 0.2);
+}
+.results-section h2::before {
+    background: rgba(15, 169, 104, 0.1);
+    color: var(--green);
+    border-color: rgba(15, 169, 104, 0.25);
 }
 
-.upload-label {
-    cursor: pointer;
+/* Upload */
+.upload-area {
+    border: 2px dashed rgba(51, 93, 228, 0.28);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.35);
+    padding: 36px 24px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1rem;
-    color: var(--text-secondary);
+    gap: 10px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.2s;
 }
-
-.upload-label svg {
-    color: var(--primary-color);
+.upload-area:hover {
+    border-color: rgba(51, 93, 228, 0.5);
+    background: rgba(255, 255, 255, 0.5);
 }
-
-.upload-label span {
-    font-size: 1rem;
+.upload-area.drag-over {
+    border-color: var(--blue);
+    background: rgba(51, 93, 228, 0.08);
+    box-shadow: 0 0 0 4px rgba(51, 93, 228, 0.1);
 }
-
+.upload-label {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    width: 100%;
+}
+.upload-label svg { color: var(--blue); opacity: 0.8; }
+.upload-label > span:first-of-type { font-size: 15px; font-weight: 600; color: var(--fg); }
 .upload-hint {
-    font-size: 0.875rem !important;
-    color: var(--text-secondary);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11.5px;
+    color: var(--fg-subtle);
 }
 
-/* Sample Divider */
 .sample-divider {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin: 1.5rem 0;
-    color: var(--text-secondary);
-    font-size: 0.875rem;
+    gap: 12px;
+    margin: 18px 0;
+    color: var(--fg-subtle);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 11px;
 }
-
-.sample-divider::before,
-.sample-divider::after {
-    content: '';
+.sample-divider::before, .sample-divider::after {
+    content: "";
     flex: 1;
-    border-top: 1px solid var(--border-color);
-}
-
-/* File List */
-.file-list {
-    margin-top: 1rem;
-}
-
-.file-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.625rem 1rem;
-    background: var(--bg-gray);
-    border-radius: 0.375rem;
-    margin-bottom: 0.375rem;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    border: 1px solid transparent;
-}
-
-.file-item:hover {
-    background: #eff6ff;
-    border-color: #dbeafe;
-}
-
-.file-item-active {
-    background: #eff6ff;
-    border-color: var(--primary-color);
-}
-
-.file-item-info {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    min-width: 0;
-}
-
-.file-item-name {
-    font-weight: 500;
-    font-size: 0.875rem;
-    color: var(--text-primary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.file-item-size {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-    white-space: nowrap;
-}
-
-.file-item-remove {
-    background: none;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    font-size: 1.125rem;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    transition: all 0.15s;
-    line-height: 1;
-}
-
-.file-item-remove:hover {
-    color: var(--error-color);
-    background: rgba(239, 68, 68, 0.1);
-}
-
-/* BPMN Viewer */
-.bpmn-viewer-container {
-    margin-top: 1rem;
-}
-
-#bpmn-canvas {
-    height: 400px;
-    border: 1px solid var(--border-color);
-    border-radius: 0.375rem;
-    overflow: hidden;
-    background: white;
-}
-
-/* Form */
-.form-group {
-    margin-bottom: 1.5rem;
-}
-
-.form-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-}
-
-label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
-    color: var(--text-primary);
-}
-
-.required {
-    color: var(--error-color);
-}
-
-input[type="text"],
-select {
-    width: 100%;
-    padding: 0.625rem 0.75rem;
-    border: 1px solid var(--border-color);
-    border-radius: 0.375rem;
-    font-size: 1rem;
-    transition: border-color 0.2s;
-}
-
-input[type="text"]:focus,
-select:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-}
-
-small {
-    display: block;
-    margin-top: 0.375rem;
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-}
-
-.checkbox-label {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    font-weight: 400;
-}
-
-.checkbox-label input[type="checkbox"] {
-    margin-right: 0.5rem;
-    width: 1.125rem;
-    height: 1.125rem;
-    cursor: pointer;
+    height: 1px;
+    background: var(--border-soft);
 }
 
 /* Buttons */
 .btn {
-    padding: 0.75rem 1.5rem;
-    font-size: 1rem;
-    font-weight: 500;
-    border-radius: 0.375rem;
-    border: none;
-    cursor: pointer;
+    padding: 12px 22px;
+    border-radius: 999px;
+    font-size: 14.5px;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
     transition: all 0.2s;
+    font-family: inherit;
+    cursor: pointer;
+    border: 0;
+    text-decoration: none;
 }
-
 .btn-primary {
-    background: var(--primary-color);
-    color: white;
-    width: 100%;
+    background: rgba(255, 255, 255, 0.72);
+    color: var(--green-dark);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    box-shadow: inset 0 0 0 1.5px rgba(15, 169, 104, 0.5), 0 2px 8px -3px rgba(15, 169, 104, 0.15);
 }
-
 .btn-primary:hover:not(:disabled) {
-    background: var(--primary-hover);
+    background: rgba(15, 169, 104, 0.08);
+    transform: translateY(-1px);
+    box-shadow: inset 0 0 0 1.5px rgba(15, 169, 104, 0.7), 0 4px 14px -4px rgba(15, 169, 104, 0.28);
 }
-
+.btn-primary:active:not(:disabled) {
+    background: var(--green);
+    color: #fff;
+    transform: translateY(0);
+    box-shadow: inset 0 0 0 1.5px rgba(13, 138, 84, 0.4), 0 4px 14px -4px rgba(15, 169, 104, 0.45);
+}
 .btn-primary:disabled {
-    opacity: 0.5;
+    opacity: 0.55;
     cursor: not-allowed;
 }
-
 .btn-secondary {
-    background: white;
-    color: var(--primary-color);
-    border: 1px solid var(--primary-color);
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(15, 169, 104, 0.22);
+    color: var(--green-dark);
+}
+.btn-secondary:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(15, 169, 104, 0.42);
+    transform: translateY(-1px);
+}
+.btn-secondary:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+.sample-btn { width: 100%; }
+
+/* Form */
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+.form-row.form-row-single { grid-template-columns: 1fr; }
+.form-group label {
+    display: block;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--fg-subtle);
+    margin-bottom: 8px;
+}
+.form-group select {
     width: 100%;
+    padding: 12px 36px 12px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(27, 30, 58, 0.1);
+    background: rgba(255, 255, 255, 0.65);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--fg);
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none' stroke='%235A6178' stroke-width='2'%3E%3Cpath d='M1 1.5 L6 6.5 L11 1.5'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 14px center;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.form-group select:hover {
+    border-color: rgba(27, 30, 58, 0.2);
+    background-color: rgba(255, 255, 255, 0.85);
+}
+.form-group select:focus {
+    outline: 0;
+    border-color: var(--blue);
+    box-shadow: 0 0 0 3px rgba(51, 93, 228, 0.12);
+}
+.generate-btn { width: 100%; margin-top: 4px; }
+
+/* File list (uploaded BPMN files) */
+.file-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 14px;
+}
+.file-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.55);
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.file-item:hover {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(27, 30, 58, 0.16);
+}
+.file-item.file-item-active {
+    background: #fff;
+    border-color: rgba(51, 93, 228, 0.4);
+    box-shadow: 0 0 0 3px rgba(51, 93, 228, 0.1);
+}
+.file-item-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+}
+.file-item-name {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.file-item-size {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10.5px;
+    color: var(--fg-subtle);
+}
+.file-item-remove {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--fg-subtle);
+    font-size: 18px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.15s;
+}
+.file-item-remove:hover {
+    background: rgba(227, 103, 129, 0.12);
+    color: var(--red);
 }
 
-.btn-secondary:hover {
-    background: #eff6ff;
+/* BPMN viewer */
+.bpmn-viewer-container {
+    margin-top: 14px;
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.55);
+    overflow: hidden;
+}
+#bpmn-canvas {
+    width: 100%;
+    height: 360px;
 }
 
-/* Results */
+/* Generated file blocks (rendered by JS into #results-content) */
+#results-content {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin-top: 4px;
+}
 .code-file {
-    margin-bottom: 2rem;
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    border-radius: 12px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    box-shadow: 0 4px 14px -10px rgba(27, 30, 58, 0.14), 0 0 0 1px rgba(255, 255, 255, 0.4) inset;
 }
-
 .code-file-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 1rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 2px solid var(--border-color);
+    gap: 10px;
+    padding: 11px 14px;
+    background: rgba(255, 255, 255, 0.6);
+    border-bottom: 1px solid var(--border-soft);
 }
-
-.code-file-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: var(--text-primary);
+.code-file-icon {
+    width: 22px;
+    height: 22px;
+    border-radius: 5px;
+    font-size: 10.5px;
+    font-weight: 800;
+    color: #fff;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    letter-spacing: -0.02em;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.15);
 }
-
-.code-file-meta {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-}
-
-.code-file-actions {
+.code-file-icon.ci-kt { background: linear-gradient(135deg, #7F52FF 0%, #C411E0 55%, #E44857 100%); }
+.code-file-icon.ci-jv { background: linear-gradient(135deg, #E76F00 0%, #F29111 100%); }
+.code-file-icon.ci-json { background: linear-gradient(135deg, #CE6C00 0%, #F5A623 100%); }
+.code-file-title-group {
     display: flex;
-    gap: 0.5rem;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
 }
+.code-file-title {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.code-file-meta {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10.5px;
+    color: var(--fg-subtle);
+}
+.code-file-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+.btn-copy, .btn-download {
+    padding: 5px 11px;
+    border-radius: 999px;
+    background: rgba(15, 169, 104, 0.1);
+    color: var(--green-dark);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10.5px;
+    font-weight: 600;
+    border: 1px solid rgba(15, 169, 104, 0.2);
+    cursor: pointer;
+    transition: all 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+.btn-copy:hover, .btn-download:hover {
+    background: rgba(15, 169, 104, 0.18);
+    border-color: rgba(15, 169, 104, 0.38);
+}
+.btn-copy svg, .btn-download svg { width: 12px; height: 12px; }
 
 .code-preview {
-    position: relative;
-    background: #f6f8fa;
-    border-radius: 0.375rem;
-    overflow: hidden;
-    margin-bottom: 1rem;
-}
-
-.code-preview pre {
-    margin: 0;
-    padding: 1rem;
+    background: #fff;
+    padding: 14px 16px;
+    font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+    font-size: 12.5px;
+    line-height: 1.75;
+    color: #0F1129;
+    text-align: left;
     overflow-x: auto;
 }
+.code-preview pre { margin: 0; }
+.code-preview code { font-family: inherit; background: transparent; padding: 0; }
 
-.code-preview code {
-    font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
-    font-size: 0.875rem;
-    line-height: 1.5;
-}
-
-.btn-copy,
-.btn-download {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    color: white;
-    border: none;
-    border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.btn-copy {
-    background: var(--primary-color);
-}
-
-.btn-copy:hover {
-    background: var(--primary-hover);
-}
-
-.btn-download {
-    background: var(--success-color);
-}
-
-.btn-download:hover {
-    background: #059669;
-}
-
-/* Post-Generation CTA */
-.cta-section {
-    text-align: center;
-    background: linear-gradient(135deg, #eff6ff 0%, #f0fdf4 100%);
-}
-
-.cta-section h2 {
-    color: var(--text-primary);
-}
-
-.cta-section p {
-    color: var(--text-secondary);
-    margin-bottom: 1.5rem;
-    font-size: 1rem;
-}
-
-.cta-buttons {
+/* Results actions (Reset + Download .zip) */
+.results-actions {
     display: flex;
-    gap: 1rem;
-    justify-content: center;
-    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 22px;
+}
+.results-actions .btn {
+    padding: 8px 16px;
+    font-size: 13px;
 }
 
-.cta-buttons .btn {
-    width: auto;
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-}
-
-/* Loading */
+/* Loading spinner */
 .loading {
-    text-align: center;
-    padding: 3rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    padding: 36px 24px;
+    background: var(--card-glass);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(27, 30, 58, 0.08);
+    border-radius: 16px;
+    color: var(--fg-muted);
+    font-size: 14px;
 }
-
 .spinner {
-    border: 4px solid var(--border-color);
-    border-top: 4px solid var(--primary-color);
+    width: 28px;
+    height: 28px;
+    border: 2.5px solid rgba(15, 169, 104, 0.18);
+    border-top-color: var(--green);
     border-radius: 50%;
-    width: 48px;
-    height: 48px;
-    animation: spin 1s linear infinite;
-    margin: 0 auto 1rem;
+    animation: spin 0.9s linear infinite;
 }
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
+@keyframes spin { to { transform: rotate(360deg); } }
 
 /* Error */
 .error-message {
-    background: #fee2e2;
-    border: 1px solid #fca5a5;
-    color: #991b1b;
-    padding: 1rem;
-    border-radius: 0.375rem;
-    margin-bottom: 1rem;
-    white-space: pre-wrap;
-    font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace;
-    font-size: 0.875rem;
+    padding: 14px 18px;
+    background: rgba(227, 103, 129, 0.08);
+    border: 1px solid rgba(227, 103, 129, 0.3);
+    border-radius: 12px;
+    color: #B53E5C;
+    font-size: 13.5px;
+    line-height: 1.5;
+}
+
+/* CTA */
+.cta-section { text-align: center; }
+.cta-section h2 { justify-content: center; margin-bottom: 6px; }
+.cta-section h2::before { display: none; }
+.cta-section .cta-sub {
+    color: var(--fg-muted);
+    margin-bottom: 22px;
+    font-size: 15px;
+}
+
+/* Install grid (Gradle / Maven) */
+.install-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin-bottom: 22px;
+    text-align: left;
+}
+.install-card {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    padding: 14px 14px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.42);
+    border: 1px solid rgba(27, 30, 58, 0.06);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    transition: all 0.2s;
+    position: relative;
+    color: var(--fg);
+}
+.install-card:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.7);
+    border-color: rgba(27, 30, 58, 0.12);
+    box-shadow: 0 8px 20px -12px rgba(27, 30, 58, 0.18);
+}
+.install-card::after {
+    content: "→";
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    color: var(--fg-subtle);
+    transition: transform 0.2s, color 0.2s;
+}
+.install-card:hover::after {
+    transform: translateX(3px);
+    color: var(--green-dark);
+}
+.install-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 9.5px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    width: fit-content;
+}
+.install-tag svg { flex-shrink: 0; }
+.tag-gradle {
+    background: rgba(2, 48, 58, 0.08);
+    color: #02303A;
+    border: 1px solid rgba(2, 48, 58, 0.22);
+}
+.tag-maven {
+    background: rgba(199, 26, 54, 0.08);
+    color: #C71A36;
+    border: 1px solid rgba(199, 26, 54, 0.24);
+}
+.install-name {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--fg);
+    letter-spacing: -0.01em;
+}
+.install-sub {
+    font-size: 12px;
+    color: var(--fg-muted);
+    line-height: 1.45;
+    max-width: calc(100% - 24px);
+}
+
+/* Keep-exploring divider */
+.learn-divider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 4px 0 16px;
+    color: var(--fg-subtle);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+.learn-divider::before, .learn-divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border-soft);
+}
+
+/* Learn cards */
+.learn-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    text-align: left;
+}
+.learn-card {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    padding: 14px 14px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.42);
+    border: 1px solid rgba(27, 30, 58, 0.06);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    transition: all 0.2s;
+    position: relative;
+    color: var(--fg);
+}
+.learn-card:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.7);
+    border-color: rgba(27, 30, 58, 0.12);
+    box-shadow: 0 8px 20px -12px rgba(27, 30, 58, 0.18);
+}
+.learn-card::after {
+    content: "→";
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    color: var(--fg-subtle);
+    transition: transform 0.2s, color 0.2s;
+}
+.learn-card:hover::after {
+    transform: translateX(3px);
+    color: var(--green-dark);
+}
+.learn-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 6px;
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 9.5px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    width: fit-content;
+}
+.tag-validate {
+    background: rgba(107, 70, 163, 0.12);
+    color: var(--purple);
+    border: 1px solid rgba(107, 70, 163, 0.22);
+}
+.tag-ship {
+    background: rgba(15, 169, 104, 0.12);
+    color: var(--green-dark);
+    border: 1px solid rgba(15, 169, 104, 0.22);
+}
+.tag-reference {
+    background: rgba(51, 93, 228, 0.1);
+    color: var(--blue);
+    border: 1px solid rgba(51, 93, 228, 0.22);
+}
+.learn-name {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--fg);
+    letter-spacing: -0.01em;
+}
+.learn-sub {
+    font-size: 12px;
+    color: var(--fg-muted);
+    line-height: 1.45;
+    max-width: calc(100% - 24px);
 }
 
 /* Footer */
-footer {
-    margin-top: 4rem;
-    padding: 3rem 0 2rem;
-    border-top: 1px solid var(--border-color);
-    color: var(--text-secondary);
-    font-size: 0.875rem;
+.site-footer {
+    background: var(--bg-soft);
+    border-top: 1px solid var(--border);
+    margin-top: 40px;
 }
-
-.footer-links {
+.footer-inner {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 22px 32px;
     display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.25rem;
-    padding-right: 1rem;
-    padding-left: 1rem;
-    text-align: left;
-    flex-wrap: nowrap;
-}
-
-.footer-section {
-    flex: 1;
-    min-width: 180px;
-    padding-right: 1rem;
-}
-
-.footer-section h4 {
-    font-size: 1rem;
-    color: var(--text-primary);
-    margin-bottom: 0.75rem;
-    font-weight: 600;
-}
-
-.footer-section p {
-    line-height: 1.6;
-    margin-bottom: 0.5rem;
-}
-
-.footer-section a {
-    color: var(--primary-color);
-    text-decoration: none;
-}
-
-.footer-section a:hover {
-    text-decoration: underline;
-}
-
-.footer-bottom {
-    text-align: center;
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--border-color);
-    color: var(--text-secondary);
-    font-style: italic;
-}
-
-/* Social Links Row */
-.social-links-row {
-    display: flex;
-    justify-content: center;
     align-items: center;
-    gap: 2rem;
-    padding: 1rem;
+    justify-content: space-between;
+    gap: 20px;
     flex-wrap: wrap;
-    border-top: 1px solid var(--border-color);
-    color: var(--text-secondary);
 }
-
-.social-link-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    text-decoration: none;
-    transition: transform 0.2s ease;
-}
-
-.social-link-item:hover {
-    transform: translateY(-2px);
-}
-
-.social-link-item:hover .platform-name {
-    color: var(--primary-color);
-}
-
-.social-icon {
+.footer-brand { display: flex; align-items: center; gap: 10px; }
+.footer-brand .mark-sm {
+    width: 22px;
+    height: 22px;
+    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+}
+.footer-brand .mark-sm img { display: block; border-radius: 4px; }
+.footer-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 13px;
+    line-height: 1.5;
+}
+.footer-text .credit { color: var(--fg-muted); }
+.footer-text .credit a { color: var(--fg); font-weight: 600; }
+.footer-text .credit a:hover { color: var(--blue); }
+.footer-text .credit .heart { color: #E36781; }
+.footer-text .legal { font-size: 12px; color: var(--fg-subtle); }
+.footer-text .legal a {
+    color: var(--fg-subtle);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+.footer-text .legal a:hover { color: var(--fg-muted); }
+.footer-text .legal a + a::before {
+    content: " · ";
+    display: inline;
+    margin: 0 4px;
+    color: var(--fg-subtle);
+    text-decoration: none;
+}
+.footer-right { display: flex; align-items: center; gap: 18px; }
+.footer-right a {
+    color: var(--fg-muted);
+    font-size: 13px;
+    font-weight: 500;
+    transition: color 0.15s;
+}
+.footer-right a:hover { color: var(--blue); }
+.footer-right .icon-link {
     width: 32px;
     height: 32px;
-    color: var(--text-secondary);
-    background: var(--bg-gray);
-    border-radius: 50%;
-    transition: all 0.2s ease;
-    flex-shrink: 0;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    transition: all 0.15s;
 }
-
-.social-icon img {
-    width: 24px;
-    height: 24px;
-    object-fit: contain;
-}
-
-.social-icon:hover {
-    color: var(--primary-color);
-    background: #eff6ff;
-    transform: translateY(-2px);
-}
-
-.social-icon svg {
-    width: 18px;
-    height: 18px;
-}
-
-.platform-name {
-    color: var(--text-secondary);
-    font-size: 0.875rem;
-    transition: color 0.2s ease;
-}
-
-/* Tab Switcher */
-.tab-switcher {
-    display: flex;
-    background: white;
-    border: 1px solid var(--border-color);
-    border-radius: 0.5rem;
-    padding: 0.25rem;
-    margin-bottom: 2rem;
-    width: 100%;
-}
-
-.tab-btn {
-    flex: 1;
-    text-align: center;
-    padding: 0.5rem 1.25rem;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    color: var(--text-secondary);
-    background: transparent;
-    border: none;
-    border-radius: 0.375rem;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.tab-btn:hover {
-    color: var(--primary-color);
-    background: var(--bg-gray);
-}
-
-.tab-btn-active {
-    color: var(--primary-color);
-    background: var(--brand-soft);
-    font-weight: 600;
-}
-
-.form-row-single {
-    grid-template-columns: 1fr;
-}
+.footer-right .icon-link:hover { border-color: var(--blue); color: var(--blue); }
+.footer-right .icon-link svg { width: 15px; height: 15px; }
 
 /* Responsive */
-@media (max-width: 640px) {
-    .navbar-inner {
-        padding: 0 0.75rem;
-    }
-
-    .navbar-links a:not(.navbar-icon) {
-        display: none;
-    }
-
-    .container {
-        padding: 1.25rem 0.75rem;
-    }
-
-    .hero-name {
-        font-size: 1.75rem;
-    }
-
-    .hero-text {
-        font-size: 1.125rem;
-    }
-
-    .hero-description {
-        font-size: 0.875rem;
-        margin-bottom: 1rem;
-    }
-
-    .hero-features {
-        gap: 0.375rem;
-    }
-
-    .feature-badge {
-        font-size: 0.7rem;
-        padding: 0.25rem 0.5rem;
-    }
-
-    .preview-notice {
-        font-size: 0.8125rem;
-        padding: 0.75rem 1rem;
-        margin-bottom: 1.25rem;
-    }
-
-    .card {
-        padding: 1.25rem;
-        margin-bottom: 1.25rem;
-    }
-
-    .card h2 {
-        font-size: 1.25rem;
-        margin-bottom: 1rem;
-    }
-
-    .form-row {
-        grid-template-columns: 1fr;
-    }
-
-    .upload-area {
-        padding: 1.5rem 1rem;
-    }
-
-    .sample-divider {
-        margin: 1rem 0;
-    }
-
-    #bpmn-canvas {
-        height: 250px;
-    }
-
-    .code-file-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.75rem;
-    }
-
-    .code-file-actions {
-        width: 100%;
-    }
-
-    .btn-copy,
-    .btn-download {
-        flex: 1;
-        justify-content: center;
-    }
-
-    .cta-section {
-        padding: 1.5rem 1.25rem;
-    }
-
-    .cta-buttons {
-        flex-direction: column;
-    }
-
-    .cta-buttons .btn {
-        width: 100%;
-        justify-content: center;
-    }
-
-    footer {
-        margin-top: 2rem;
-        padding: 2rem 0 1.5rem;
-    }
-
-    .footer-links {
-        flex-direction: column;
-        gap: 1.25rem;
-        text-align: center;
-    }
-
-    .footer-section {
-        flex: none;
-        padding-right: 0;
-    }
-
-    .social-links-row {
-        gap: 1.25rem;
-        padding: 0.75rem;
-    }
-
+@media (max-width: 720px) {
+    .hero-name { font-size: 48px; }
+    .navbar-inner { padding: 0 20px; }
+    .container { padding: 0 20px; }
+    .form-row { grid-template-columns: 1fr; }
+    .install-grid { grid-template-columns: 1fr; }
+    .learn-grid { grid-template-columns: 1fr; }
+    .footer-inner { padding: 22px 20px; }
+    .card { padding: 22px 20px; }
 }

--- a/bpmn-to-code-web/src/main/resources/static/index.html
+++ b/bpmn-to-code-web/src/main/resources/static/index.html
@@ -5,30 +5,31 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <title>bpmn-to-code - Online Generator</title>
     <link href="/static/favicon/miragon.png" rel="icon" type="image/png">
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link href="/static/css/styles.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" rel="stylesheet">
 </head>
 <body>
+
 <!-- Navbar -->
 <nav class="navbar">
     <div class="navbar-inner">
         <a href="/" class="navbar-brand">
-            <img src="/static/favicon/miragon.png" alt="" width="24" height="24">
+            <span class="mark"><img src="/static/favicon/miragon.png" alt="" width="22" height="22"></span>
             <span>bpmn-to-code</span>
-            <a class="version-badge" id="version-badge" href="https://github.com/emaarco/bpmn-to-code/releases" target="_blank" style="display: none;"></a>
         </a>
         <div class="navbar-links">
-            <a href="https://emaarco.github.io/bpmn-to-code/" target="_blank">Documentation</a>
-            <a href="https://github.com/emaarco/bpmn-to-code" target="_blank" class="navbar-icon" aria-label="GitHub">
-                <svg fill="currentColor" height="20" viewBox="0 0 24 24" width="20">
-                    <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-                </svg>
+            <a href="https://emaarco.github.io/bpmn-to-code/" target="_blank" rel="noopener">Documentation</a>
+            <a href="https://github.com/emaarco/bpmn-to-code" target="_blank" rel="noopener" class="navbar-icon" aria-label="GitHub">
+                <svg fill="currentColor" height="19" width="19" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
             </a>
+            <a id="version-badge" class="version-badge" href="https://github.com/emaarco/bpmn-to-code/releases" target="_blank" rel="noopener" style="display: none;"></a>
         </div>
     </div>
 </nav>
 
 <div class="container">
+
     <!-- Hero -->
     <header class="hero">
         <h1 class="hero-name">bpmn-to-code</h1>
@@ -39,7 +40,7 @@
         </p>
         <div class="hero-features">
             <span class="feature-badge">Compile-Time Safety</span>
-            <span class="feature-badge">Zeebe / Camunda 7 / Operaton</span>
+            <span class="feature-badge">Zeebe / Camunda 7 / CIB7 / Operaton</span>
             <span class="feature-badge">Java &amp; Kotlin</span>
             <span class="feature-badge">JSON Export</span>
         </div>
@@ -47,45 +48,43 @@
 
     <!-- Preview Notice -->
     <div class="preview-notice">
-        <div class="preview-notice-icon">
-            <svg fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20">
-                <circle cx="12" cy="12" r="10"></circle>
-                <line x1="12" x2="12" y1="16" y2="12"></line>
-                <line x1="12" x2="12.01" y1="8" y2="8"></line>
-            </svg>
-        </div>
+        <svg class="preview-notice-icon" fill="none" height="18" width="18" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"></circle>
+            <line x1="12" x2="12" y1="16" y2="12"></line>
+            <line x1="12" x2="12.01" y1="8" y2="8"></line>
+        </svg>
         <div class="preview-notice-content">
             <strong>Early Version:</strong> This is an early version of the bpmn-to-code web generator.
             If you encounter any issues or have suggestions for improvement, please
-            <a href="https://github.com/emaarco/bpmn-to-code/issues" target="_blank">report them on GitHub</a>.
+            <a href="https://github.com/emaarco/bpmn-to-code/issues" target="_blank" rel="noopener">report them on GitHub</a>.
             Your feedback helps make this tool better!
         </div>
     </div>
 
     <!-- Tab Switcher -->
     <div class="tab-switcher">
-        <button class="tab-btn tab-btn-active" data-tab="code" id="tab-code">Code API</button>
-        <button class="tab-btn" data-tab="json" id="tab-json">JSON Export</button>
+        <button class="tab-btn tab-btn-active" data-tab="code" id="tab-code" type="button">Code API</button>
+        <button class="tab-btn" data-tab="json" id="tab-json" type="button">JSON Export</button>
     </div>
 
     <main>
         <!-- Step 1: Upload BPMN Files -->
         <section class="card upload-section" id="upload-section">
-            <h2>1. Upload BPMN Files</h2>
+            <h2 data-step="STEP 01">Upload BPMN Files</h2>
             <div class="upload-area" id="upload-area">
                 <input accept=".bpmn" hidden id="file-input" multiple type="file">
                 <label class="upload-label" for="file-input">
-                    <svg fill="none" height="48" stroke="currentColor" viewBox="0 0 24 24" width="48">
+                    <svg fill="none" height="40" width="40" stroke="currentColor" stroke-width="1.6" viewBox="0 0 24 24" aria-hidden="true">
                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                         <polyline points="17 8 12 3 7 8"></polyline>
                         <line x1="12" x2="12" y1="3" y2="15"></line>
                     </svg>
-                    <span>Click to select BPMN files or drag & drop</span>
+                    <span>Click to select BPMN files or drag &amp; drop</span>
                     <span class="upload-hint">.bpmn files only</span>
                 </label>
             </div>
             <div class="sample-divider"><span>or</span></div>
-            <button class="btn btn-secondary" id="try-sample-btn" type="button">
+            <button class="btn btn-secondary sample-btn" id="try-sample-btn" type="button">
                 Try with Newsletter Sample
             </button>
             <div class="file-list" id="file-list"></div>
@@ -96,7 +95,7 @@
 
         <!-- Step 2: Configure Generation -->
         <section class="card config-section" id="config-section" style="display: none;">
-            <h2 id="config-heading">2. Configure Generation</h2>
+            <h2 data-step="STEP 02" id="config-heading">Configure Generation</h2>
             <form id="config-form">
                 <div class="form-row" id="form-row">
                     <div class="form-group" id="language-group">
@@ -106,7 +105,6 @@
                             <option value="JAVA">Java</option>
                         </select>
                     </div>
-
                     <div class="form-group">
                         <label for="process-engine">Process Engine</label>
                         <select id="process-engine">
@@ -116,8 +114,7 @@
                         </select>
                     </div>
                 </div>
-
-                <button class="btn btn-primary" id="generate-btn" type="submit">
+                <button class="btn btn-primary generate-btn" id="generate-btn" type="submit">
                     Generate Process API
                 </button>
             </form>
@@ -125,23 +122,11 @@
 
         <!-- Step 3: Results -->
         <section class="card results-section" id="results-section" style="display: none;">
-            <h2 id="results-heading">3. Generated Code</h2>
+            <h2 data-step="STEP 03" id="results-heading">Generated Code</h2>
             <div id="results-content"></div>
-        </section>
-
-        <!-- Post-Generation CTA -->
-        <section class="card cta-section" id="cta-section" style="display: none;">
-            <h2>Ready for Production?</h2>
-            <p>Install the plugin to generate code automatically during your build.</p>
-            <div class="cta-buttons">
-                <a href="https://emaarco.github.io/bpmn-to-code/getting-started/gradle"
-                   class="btn btn-primary" target="_blank">
-                    Get Started with Gradle
-                </a>
-                <a href="https://emaarco.github.io/bpmn-to-code/getting-started/maven"
-                   class="btn btn-secondary" target="_blank">
-                    Get Started with Maven
-                </a>
+            <div class="results-actions">
+                <button class="btn btn-secondary" id="reset-btn" type="button">Reset</button>
+                <button class="btn btn-primary" id="download-all-btn" type="button">Download .zip</button>
             </div>
         </section>
 
@@ -153,101 +138,96 @@
 
         <!-- Error Display -->
         <div class="error-message" id="error-message" style="display: none;"></div>
+
+        <!-- CTA — install + keep exploring (always visible) -->
+        <section class="card cta-section" id="cta-section">
+            <h2>Ready for Production?</h2>
+            <p class="cta-sub">Wire bpmn-to-code into your build, then dig into what else it can do.</p>
+
+            <div class="install-grid">
+                <a href="https://emaarco.github.io/bpmn-to-code/getting-started/gradle" target="_blank" rel="noopener" class="install-card">
+                    <span class="install-tag tag-gradle">
+                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                            <rect x="3" y="5" width="15" height="2.4" rx="1.2" fill="currentColor"></rect>
+                            <rect x="5" y="10.8" width="15" height="2.4" rx="1.2" fill="currentColor" opacity=".78"></rect>
+                            <rect x="3" y="16.6" width="13" height="2.4" rx="1.2" fill="currentColor" opacity=".58"></rect>
+                        </svg>
+                        GRADLE
+                    </span>
+                    <div class="install-name">build.gradle.kts</div>
+                    <div class="install-sub">Apply the plugin and configure it to point at your .bpmn files.</div>
+                </a>
+                <a href="https://emaarco.github.io/bpmn-to-code/getting-started/maven" target="_blank" rel="noopener" class="install-card">
+                    <span class="install-tag tag-maven">
+                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M4 19V7l4 6 4-8 4 8 4-6v12"></path>
+                        </svg>
+                        MAVEN
+                    </span>
+                    <div class="install-name">pom.xml</div>
+                    <div class="install-sub">Add the plugin and configure it to point at your .bpmn files.</div>
+                </a>
+            </div>
+
+            <div class="learn-divider"><span>Keep exploring</span></div>
+
+            <div class="learn-grid">
+                <a href="https://emaarco.github.io/bpmn-to-code/testing/" target="_blank" rel="noopener" class="learn-card">
+                    <span class="learn-tag tag-validate">VALIDATE</span>
+                    <div class="learn-name">bpmn-to-code-testing</div>
+                    <div class="learn-sub">ArchUnit-style rules that enforce BPMN conventions across your repo.</div>
+                </a>
+                <a href="https://emaarco.github.io/bpmn-to-code/agent-skills/" target="_blank" rel="noopener" class="learn-card">
+                    <span class="learn-tag tag-ship">SHIP</span>
+                    <div class="learn-name">Agent skills</div>
+                    <div class="learn-sub">Scaffold Spring process services from BPMN with Claude Code.</div>
+                </a>
+                <a href="https://emaarco.github.io/bpmn-to-code/" target="_blank" rel="noopener" class="learn-card">
+                    <span class="learn-tag tag-reference">DOCS</span>
+                    <div class="learn-name">Full documentation</div>
+                    <div class="learn-sub">Guides, examples, compatibility matrix, and full API reference.</div>
+                </a>
+            </div>
+        </section>
+
     </main>
 
-    <footer>
-        <div class="footer-links">
-            <div class="footer-section">
-                <h4>Production Use</h4>
-                <p>
-                    Install the
-                    <a href="https://plugins.gradle.org/plugin/io.github.emaarco.bpmn-to-code-gradle" target="_blank">Gradle
-                        plugin</a>
-                    or
-                    <a href="https://central.sonatype.com/artifact/io.github.emaarco/bpmn-to-code-maven"
-                       target="_blank">Maven plugin</a>
-                    for automated code generation in your build pipeline
-                </p>
-            </div>
+</div><!-- /.container -->
 
-            <div class="footer-section">
-                <h4>Resources</h4>
-                <p>This project can be found on GitHub</p>
-                <p>
-                    <a href="https://emaarco.github.io/bpmn-to-code/" target="_blank">Documentation</a>
-                    <span> · </span>
-                    <a href="https://github.com/emaarco/bpmn-to-code" target="_blank">GitHub Repository</a>
-                    <span id="resources-separator"> · </span>
-                    <a href="https://github.com/emaarco/bpmn-to-code/issues" target="_blank">Report Issues</a>
-                </p>
-            </div>
-
-            <div class="footer-section">
-                <h4>About</h4>
-                <p>
-                    Created with ♥ by
-                    <a href="https://www.linkedin.com/in/schaeckm" target="_blank">Marco Schäck</a>
-                </p>
-                <p>
-                    <a href="#" id="imprint-link" target="_blank">Legal Notice</a>
-                    <span id="legal-separator"> · </span>
-                    <a href="#" id="privacy-link" target="_blank">Privacy Policy</a>
-                </p>
+<footer class="site-footer">
+    <div class="footer-inner">
+        <div class="footer-brand">
+            <span class="mark-sm"><img src="/static/favicon/miragon.png" alt="" width="20" height="20"></span>
+            <div class="footer-text">
+                <div class="credit">
+                    Created with <span class="heart">♥</span> by
+                    <a href="https://www.linkedin.com/in/schaeckm" target="_blank" rel="noopener">Marco Schäck</a>
+                </div>
+                <div class="legal">
+                    © 2026 · Open source under
+                    <a href="https://github.com/emaarco/bpmn-to-code?tab=MIT-1-ov-file#readme" target="_blank" rel="noopener">MIT Licence</a><a href="#" id="imprint-link" target="_blank" rel="noopener" style="display: none;">Legal Notice</a><a href="#" id="privacy-link" target="_blank" rel="noopener" style="display: none;">Privacy Policy</a>
+                </div>
             </div>
         </div>
-
-        <div class="social-links-row">
-            <a aria-label="GitHub" class="social-link-item" href="https://github.com/emaarco" target="_blank">
-                <span class="social-icon">
-                    <svg fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
-                        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
-                    </svg>
-                </span>
-                <span class="platform-name">GitHub</span>
+        <div class="footer-right">
+            <a href="https://medium.com/@emaarco" target="_blank" rel="noopener">Medium</a>
+            <a href="https://central.sonatype.com/artifact/io.github.emaarco/bpmn-to-code-maven" target="_blank" rel="noopener">Maven Central</a>
+            <a href="https://www.linkedin.com/in/schaeckm" target="_blank" rel="noopener" class="icon-link" aria-label="LinkedIn">
+                <svg fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452z"/></svg>
             </a>
-            <a aria-label="LinkedIn" class="social-link-item" href="https://www.linkedin.com/in/schaeckm"
-               target="_blank">
-                <span class="social-icon">
-                    <svg fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
-                        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                    </svg>
-                </span>
-                <span class="platform-name">LinkedIn</span>
-            </a>
-            <a aria-label="Medium" class="social-link-item" href="https://medium.com/@emaarco" target="_blank">
-                <span class="social-icon">
-                    <svg fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
-                        <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zM20.96 12c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z"/>
-                    </svg>
-                </span>
-                <span class="platform-name">Medium</span>
-            </a>
-            <a aria-label="Miragon" class="social-link-item" href="https://miragon.io" target="_blank">
-                <span class="social-icon">
-                    <img alt="Miragon" height="24" src="/static/favicon/miragon.png" width="24">
-                </span>
-                <span class="platform-name">Miragon</span>
+            <a href="https://github.com/emaarco/bpmn-to-code" target="_blank" rel="noopener" class="icon-link" aria-label="GitHub">
+                <svg fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
             </a>
         </div>
-
-        <div class="footer-bottom">
-            <span>Contributions welcome</span>
-            <span> · </span>
-            <span>Open source under
-                <a href="https://github.com/emaarco/bpmn-to-code?tab=MIT-1-ov-file#readme"
-                   target="_blank">MIT Licence
-                </a>
-            </span>
-        </div>
-
-    </footer>
-</div>
+    </div>
+</footer>
 
 <script src="https://unpkg.com/bpmn-js@18.6.3/dist/bpmn-navigated-viewer.production.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/kotlin.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/java.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/json.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 <script src="/static/js/main.js"></script>
 </body>
 </html>

--- a/bpmn-to-code-web/src/main/resources/static/js/main.js
+++ b/bpmn-to-code-web/src/main/resources/static/js/main.js
@@ -1,21 +1,19 @@
 const TAB_CONFIG = {
     code: {
-        configHeading: '2. Configure Generation',
+        configHeading: 'Configure Generation',
         generateLabel: 'Generate Process API',
-        resultsHeading: '3. Generated Code',
+        resultsHeading: 'Generated Code',
         loadingText: 'Generating code...',
         showLanguage: true,
-        showCta: true,
         apiEndpoint: '/api/generate',
         downloadMime: 'text/plain',
     },
     json: {
-        configHeading: '2. Select Process Engine',
+        configHeading: 'Select Process Engine',
         generateLabel: 'Generate JSON',
-        resultsHeading: '3. Generated JSON',
+        resultsHeading: 'Generated JSON',
         loadingText: 'Generating JSON...',
         showLanguage: false,
-        showCta: false,
         apiEndpoint: '/api/generate-json',
         downloadMime: 'application/json',
     }
@@ -60,7 +58,6 @@ function switchTab(tab) {
     document.getElementById('form-row').classList.toggle('form-row-single', !cfg.showLanguage);
 
     document.getElementById('results-section').style.display = 'none';
-    document.getElementById('cta-section').style.display = 'none';
     document.getElementById('error-message').style.display = 'none';
     document.getElementById('results-content').innerHTML = '';
     state.generatedFiles = [];
@@ -94,6 +91,9 @@ function setupEventListeners() {
 
     configForm.addEventListener('submit', handleGenerate);
     trySampleBtn.addEventListener('click', loadSample);
+
+    document.getElementById('download-all-btn').addEventListener('click', downloadAllAsZip);
+    document.getElementById('reset-btn').addEventListener('click', resetGeneration);
 }
 
 function handleFileSelect(e) {
@@ -136,7 +136,6 @@ function removeFile(fileName) {
         document.getElementById('config-section').style.display = 'none';
         document.getElementById('results-section').style.display = 'none';
         document.getElementById('bpmn-viewer-container').style.display = 'none';
-        document.getElementById('cta-section').style.display = 'none';
         state.currentBpmnXml = null;
         state.selectedFileIndex = 0;
         renderFileList();
@@ -236,7 +235,6 @@ async function handleGenerate(e) {
 
     resultsSection.style.display = 'none';
     errorMessage.style.display = 'none';
-    document.getElementById('cta-section').style.display = 'none';
     loading.style.display = 'block';
     generateBtn.disabled = true;
 
@@ -265,9 +263,6 @@ async function handleGenerate(e) {
             state.generatedFiles = result.files;
             renderResults(result.files);
             resultsSection.style.display = 'block';
-            if (cfg.showCta) {
-                document.getElementById('cta-section').style.display = 'block';
-            }
             resultsSection.scrollIntoView({ behavior: 'smooth' });
         } else {
             showError(result.error || 'Unknown error occurred');
@@ -287,23 +282,26 @@ function renderResults(files) {
         ? 'json'
         : (document.getElementById('output-language').value === 'JAVA' ? 'java' : 'kotlin');
 
-    document.getElementById('results-content').innerHTML = files.map((file, index) => `
+    document.getElementById('results-content').innerHTML = files.map((file, index) => {
+        const icon = fileIconFor(file.fileName);
+        return `
         <div class="code-file">
             <div class="code-file-header">
-                <div>
+                <span class="code-file-icon ${icon.cls}">${icon.label}</span>
+                <div class="code-file-title-group">
                     <div class="code-file-title">${escapeHtml(file.fileName)}</div>
                     <div class="code-file-meta">Process: ${escapeHtml(file.processId)}</div>
                 </div>
                 <div class="code-file-actions">
-                    <button class="btn-copy" onclick="copyToClipboard(${index})">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                    <button type="button" class="btn-copy" onclick="copyToClipboard(${index})">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                             <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
                         </svg>
                         Copy
                     </button>
-                    <button class="btn-download" onclick="downloadFile('${escapeHtml(file.fileName)}', ${index})">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                    <button type="button" class="btn-download" onclick="downloadFile('${escapeHtml(file.fileName)}', ${index})">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                             <polyline points="7 10 12 15 17 10"></polyline>
                             <line x1="12" y1="15" x2="12" y2="3"></line>
@@ -316,32 +314,40 @@ function renderResults(files) {
                 <pre><code class="language-${languageClass}">${escapeHtml(file.content)}</code></pre>
             </div>
         </div>
-    `).join('');
+        `;
+    }).join('');
 
-    document.querySelectorAll('pre code').forEach((block) => {
+    document.querySelectorAll('#results-content pre code').forEach((block) => {
         hljs.highlightElement(block);
     });
+}
+
+function fileIconFor(fileName) {
+    const name = (fileName || '').toLowerCase();
+    if (name.endsWith('.kt')) return { cls: 'ci-kt', label: 'Kt' };
+    if (name.endsWith('.java')) return { cls: 'ci-jv', label: 'Jv' };
+    if (name.endsWith('.json')) return { cls: 'ci-json', label: '{ }' };
+    return { cls: 'ci-kt', label: 'Kt' };
 }
 
 function copyToClipboard(index) {
     const file = state.generatedFiles[index];
 
     navigator.clipboard.writeText(file.content).then(() => {
-        const buttons = document.querySelectorAll('.btn-copy');
+        const buttons = document.querySelectorAll('#results-content .btn-copy');
         const button = buttons[index];
+        if (!button) return;
         const originalHTML = button.innerHTML;
 
         button.innerHTML = `
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <polyline points="20 6 9 17 4 12"></polyline>
             </svg>
             Copied!
         `;
-        button.style.background = '#10b981';
 
         setTimeout(() => {
             button.innerHTML = originalHTML;
-            button.style.background = '';
         }, 2000);
     }).catch(err => {
         console.error('Failed to copy:', err);
@@ -361,6 +367,53 @@ function downloadFile(fileName, index) {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+}
+
+async function downloadAllAsZip() {
+    if (!state.generatedFiles.length) return;
+    if (typeof JSZip === 'undefined') {
+        showError('Zip download is unavailable (failed to load JSZip).');
+        return;
+    }
+
+    const btn = document.getElementById('download-all-btn');
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Packaging...';
+
+    try {
+        const zip = new JSZip();
+        state.generatedFiles.forEach(file => {
+            zip.file(file.fileName, file.content);
+        });
+        const blob = await zip.generateAsync({ type: 'blob' });
+        const processId = state.generatedFiles[0].processId || 'bpmn-to-code';
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${processId}.zip`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    } catch (err) {
+        console.error('Failed to build zip:', err);
+        showError('Failed to build zip: ' + err.message);
+    } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
+    }
+}
+
+function resetGeneration() {
+    state.generatedFiles = [];
+    document.getElementById('results-content').innerHTML = '';
+    document.getElementById('results-section').style.display = 'none';
+    document.getElementById('error-message').style.display = 'none';
+    const config = document.getElementById('config-section');
+    if (config.style.display !== 'none') {
+        config.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
 }
 
 function showError(message) {
@@ -416,7 +469,6 @@ async function loadConfiguration() {
 function setupLegalLinks(legalLinks) {
     const imprintLink = document.getElementById('imprint-link');
     const privacyLink = document.getElementById('privacy-link');
-    const separator = document.getElementById('legal-separator');
 
     if (legalLinks.imprintUrl) {
         imprintLink.href = legalLinks.imprintUrl;
@@ -430,11 +482,5 @@ function setupLegalLinks(legalLinks) {
         privacyLink.style.display = 'inline';
     } else {
         privacyLink.style.display = 'none';
-    }
-
-    if (legalLinks.imprintUrl && legalLinks.privacyUrl) {
-        separator.style.display = 'inline';
-    } else {
-        separator.style.display = 'none';
     }
 }


### PR DESCRIPTION
## Summary

Reskins the `bpmn-to-code-web` static page to match the new docs landing aesthetic (commit #271). DOM contract and every behavior in `main.js` is preserved — this is visual only at the user-facing level, with a couple of minor JS adjustments to render the new per-file output and drop redundant legal-separator plumbing.

The design itself is the outcome of the `/design-shotgun` exploration on this branch (5 variants + multiple iterations before finalization). Branch history preserves the design journey; this commit lands the result.

**Design mockup tokens → live webview** — same Manrope + JetBrains Mono, same soft-radial gradient bg, same glass cards, same miragon paper-plane mark as the docs landing.

## What changed

- `bpmn-to-code-web/src/main/resources/static/index.html` — new structure (nav + hero wordmark + preview notice + tab switcher + 3 step cards + CTA with install/learn grid + miragon footer). Every JS-facing id (`#upload-area`, `#file-input`, `#file-list`, `#bpmn-canvas`, `#config-section`, `#config-form`, `#output-language`, `#process-engine`, `#generate-btn`, `#results-section`, `#results-content`, `#results-heading`, `#config-heading`, `#loading`, `#loading-text`, `#error-message`, `#cta-section`, `#try-sample-btn`, `#version-badge`, `#imprint-link`, `#privacy-link`, `#tab-code`, `#tab-json`) preserved.
- `bpmn-to-code-web/src/main/resources/static/css/styles.css` — full rewrite with new tokens, `.drag-over` state, `.form-row-single` collapse, `.code-file` block style, `.code-file-icon` variants per file extension, glass CTA cards, miragon-green outlined primary buttons, miragon footer with auto " · " separator between legal links.
- `bpmn-to-code-web/src/main/resources/static/js/main.js` — three targeted edits:
  - `TAB_CONFIG` — drop "2."/"3." prefixes (the step pill in CSS shows that now)
  - `renderResults()` — emit new file-block structure with icon + title-group + smaller pill action buttons
  - `copyToClipboard()` — scope the `.btn-copy` selector to `#results-content`; drop the inline background override (the new pill has its own hover/active style)
  - `setupLegalLinks()` — drop the `#legal-separator` span handling (CSS `a + a::before` now inserts " · " automatically when adjacent links are visible)
- `docs/design-mockups/web-view-20260421/` — removed now that the design is live in the webview.

## Intentional divergence from mockup

- Mockup's hero feature badge mentions **CIB7** as a supported engine. CIB7 is **kept in the marketing badge** but **NOT added to the Process Engine select** because `ProcessEngine.kt` currently only accepts `ZEEBE | CAMUNDA_7 | OPERATON`. If/when CIB7 is added to the backend enum, flip the mockup's select option on (one line of HTML).

## Test plan

- [ ] Start the web module locally (`./gradlew :bpmn-to-code-web:bootRun`) and open `http://localhost:<port>/`.
- [ ] Nav renders with miragon paper-plane mark + bpmn-to-code title + version badge (once `/api/config` responds).
- [ ] Hero wordmark shows green→purple→blue gradient at weight 900.
- [ ] Click "Code API" / "JSON Export" tabs — active pill turns soft-green, headings update, language select hides for JSON.
- [ ] Drag a `.bpmn` file onto the drop zone — border turns blue (`.drag-over`), file lands in the file-list card, BPMN viewer renders.
- [ ] Click "Try with Newsletter Sample" — loads `/samples/c8-newsletter.bpmn`, auto-selects Zeebe, viewer renders.
- [ ] Click Generate Process API — loading spinner shows, results render as stacked `.code-file` blocks, each with its vendor-colored Kt/Jv/JSON icon, filename, process id, Copy + Download pills. Syntax highlighting works for Kotlin/Java/JSON.
- [ ] Click Copy on a file — button text flips to "Copied!", restores after 2s.
- [ ] Click Download on a file — browser downloads the file with correct name + MIME.
- [ ] Flip to JSON tab, upload + generate → one `.code-file` block with JSON syntax highlighting, no CTA section.
- [ ] Trigger an error (e.g. bad BPMN) — `.error-message` card shows in red tint, scrolls into view.
- [ ] CTA cards (Gradle / Maven / VALIDATE / SHIP / DOCS) link to the right docs paths and hover-animate an arrow.
- [ ] Footer: brand + credit + legal on the left, Medium / Maven Central / LinkedIn / GitHub on the right. When backend returns legal links, they render with " · " separators auto-inserted between "MIT Licence · Legal Notice · Privacy Policy".
- [ ] Responsive below 720px — hero shrinks, form row stacks to one column, install + learn grids stack to one column, footer stays legible.