### PR TITLE
refactor: remove skills symlink from root

### DIFF
--- a/skills
+++ b/skills
@@ -1,1 +1,0 @@
-.agent/skills


### PR DESCRIPTION
Removes the `skills -> .agent/skills` symbolic link from the repository root.

The symlink was not needed at the root level — skills are already accessible via `.agent/skills/`.