### PR TITLE
refactor: rename TaskTypes to ServiceTasks in generated API

### DIFF
--- a/.claude/skills/bpmn-to-code-validate-docs/SKILL.md
+++ b/.claude/skills/bpmn-to-code-validate-docs/SKILL.md
@@ -48,7 +48,7 @@ Compare `docs/guide/generated-api.md` against:
 - `bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/`
 
 Verify:
-- All sections listed (Elements, CallActivities, Messages, TaskTypes, Timers, Errors, Signals, Variables) actually get generated
+- All sections listed (Elements, CallActivities, Messages, ServiceTasks, Timers, Errors, Signals, Variables) actually get generated
 - The example code matches what the generators would produce
 - No generated sections are missing from the docs
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bpmn-to-code reads your BPMN files and generates typed constants from them. Ever
 fun send() { ... }
 
 // After — generated from the BPMN model
-@JobWorker(type = NewsletterSubscriptionProcessApi.TaskTypes.NEWSLETTER_SEND_CONFIRMATION_MAIL)
+@JobWorker(type = NewsletterSubscriptionProcessApi.ServiceTasks.NEWSLETTER_SEND_CONFIRMATION_MAIL)
 fun send() { ... }
 ```
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
@@ -247,7 +247,7 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model.serviceTasks.any { it.getRawName().isNotEmpty() }
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
-            val tasksBuilder = TypeSpec.classBuilder("TaskTypes").addModifiers(PUBLIC, STATIC, FINAL)
+            val tasksBuilder = TypeSpec.classBuilder("ServiceTasks").addModifiers(PUBLIC, STATIC, FINAL)
             modelApi.model.serviceTasks
                 .filter { it.getRawName().isNotEmpty() }
                 .forEach { task -> tasksBuilder.addField(createAttribute(task)) }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -242,7 +242,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model.serviceTasks.any { it.getRawName().isNotEmpty() }
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
-            val tasksBuilder = TypeSpec.objectBuilder("TaskTypes")
+            val tasksBuilder = TypeSpec.objectBuilder("ServiceTasks")
             modelApi.model.serviceTasks
                 .filter { it.getRawName().isNotEmpty() }
                 .forEach { task -> tasksBuilder.addProperty(createAttribute(task)) }

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
@@ -57,7 +57,7 @@ public final class SendNewsletterProcessApi {
     public static final String MESSAGE_MAIL_REJECTED_AGAIN = "Message_MailRejectedAgain";
   }
 
-  public static final class TaskTypes {
+  public static final class ServiceTasks {
     public static final String NEWSLETTER_ANALYZE_SEND_ERROR = "newsletter.analyzeSendError";
 
     public static final String NEWSLETTER_LOAD_SUBSCRIBERS = "newsletter.loadSubscribers";

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -61,7 +61,7 @@ object SendNewsletterProcessApi {
     const val MESSAGE_MAIL_REJECTED_AGAIN: String = "Message_MailRejectedAgain"
   }
 
-  object TaskTypes {
+  object ServiceTasks {
     const val NEWSLETTER_ANALYZE_SEND_ERROR: String = "newsletter.analyzeSendError"
 
     const val NEWSLETTER_LOAD_SUBSCRIBERS: String = "newsletter.loadSubscribers"

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -57,7 +57,7 @@ public final class NewsletterSubscriptionProcessApi {
     public static final String MESSAGE_FORM_SUBMITTED = "Message_FormSubmitted";
   }
 
-  public static final class TaskTypes {
+  public static final class ServiceTasks {
     public static final String NEWSLETTER_SEND_CONFIRMATION_MAIL = "#{newsletterSendConfirmationMail}";
 
     public static final String NEWSLETTER_SEND_WELCOME_MAIL = "${newsletterSendWelcomeMail}";

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -64,7 +64,7 @@ object NewsletterSubscriptionProcessApi {
     const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
   }
 
-  object TaskTypes {
+  object ServiceTasks {
     const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"
 
     const val NEWSLETTER_SEND_WELCOME_MAIL: String = "\${newsletterSendWelcomeMail}"

--- a/bpmn-to-code-skills/skills/create-process-service/SKILL.md
+++ b/bpmn-to-code-skills/skills/create-process-service/SKILL.md
@@ -191,7 +191,7 @@ Once complete, locate and read the generated `*ProcessApi.kt` (or `.java`) file 
 - **ProcessApi class/object name** (e.g. `NewsletterSubscriptionProcessApi`)
 - **`PROCESS_ID`** constant value → derive `{{processId}}` and `{{ProcessName}}`
 - **`PROCESS_ENGINE`** constant → confirm it matches the selected engine
-- **All `TaskTypes` entries** → drive worker/delegate generation (name + value)
+- **All `ServiceTasks` entries** → drive worker/delegate generation (name + value)
 - **`Variables` structure** — Variables contains **only** per-element nested objects; there are
   no top-level flat constants. Each nested object is named in PascalCase from the BPMN element ID
   and holds the variables scoped to that specific flow node:
@@ -239,7 +239,7 @@ actual values collected and derived during the preceding steps.
 For `{{taskTypesTable}}`, generate one Markdown table row per TaskType:
 
 ```
-| `{{ProcessApiClass}}.TaskTypes.{{TASK_CONST}}` | `{{taskTypeValue}}` |
+| `{{ProcessApiClass}}.ServiceTasks.{{TASK_CONST}}` | `{{taskTypeValue}}` |
 ```
 
 Include or omit conditional blocks (`<!-- Include ... -->`) according to engine and approach.

--- a/bpmn-to-code-skills/skills/create-process-service/resources/templates/code.md
+++ b/bpmn-to-code-skills/skills/create-process-service/resources/templates/code.md
@@ -69,7 +69,7 @@ private val log = KotlinLogging.logger {}
 @Component
 class {{TaskName}}Worker(private val useCase: {{TaskName}}UseCase) {
 
-    @ProcessEngineWorker(topic = {{ProcessApiClass}}.TaskTypes.{{TASK_CONST}})
+    @ProcessEngineWorker(topic = {{ProcessApiClass}}.ServiceTasks.{{TASK_CONST}})
     fun {{methodName}}(
         // @Variable(name = {{ProcessApiClass}}.Variables.{{ElementName}}.VARIABLE_NAME) variableName: String,
     ) {

--- a/bpmn-to-code-skills/skills/migrate-to-bpmn-to-code-apis/SKILL.md
+++ b/bpmn-to-code-skills/skills/migrate-to-bpmn-to-code-apis/SKILL.md
@@ -32,7 +32,7 @@ Replace hardcoded BPMN string literals in user code with references to the gener
 
 For each generated API file, extract a lookup table of string values mapped to their fully qualified API references:
 
-- **Kotlin `object`**: Parse `const val NAME: String = "value"` lines within the top-level object and each nested `object` (Elements, Messages, TaskTypes, Timers, Errors, Signals, Variables, CallActivities).
+- **Kotlin `object`**: Parse `const val NAME: String = "value"` lines within the top-level object and each nested `object` (Elements, Messages, ServiceTasks, Timers, Errors, Signals, Variables, CallActivities).
 - **Java `final class`**: Parse `public static final String NAME = "value";` lines within the top-level class and each nested `static final class`.
 - Record the fully qualified reference path. For example, a constant `PROCESS_ID` with value `"newsletterSubscription"` in `NewsletterSubscriptionProcessApiV1` becomes:
   - `NewsletterSubscriptionProcessApiV1.PROCESS_ID`

--- a/docs/.vitepress/theme/landing/data.ts
+++ b/docs/.vitepress/theme/landing/data.ts
@@ -154,7 +154,7 @@ export const generateCompare = {
     `<span class="cline">  .messageName(<span class="tok-t">Messages</span>.MESSAGE_FORM_SUBMITTED)</span>`,
     `<span class="cline">  .send()</span>`,
     `<span class="cline blank"> </span>`,
-    `<span class="cline"><span class="tok-a">@JobWorker</span>(type = <span class="tok-t">TaskTypes</span>.NEWSLETTER_SEND_CONFIRMATION_MAIL)</span>`,
+    `<span class="cline"><span class="tok-a">@JobWorker</span>(type = <span class="tok-t">ServiceTasks</span>.NEWSLETTER_SEND_CONFIRMATION_MAIL)</span>`,
     `<span class="cline"><span class="tok-k">fun</span> sendConfirmationMail() { <span class="tok-c">/* ... */</span> }</span>`,
   ].join(''),
 }

--- a/docs/contributing/adr/003-generated-api-structure.md
+++ b/docs/contributing/adr/003-generated-api-structure.md
@@ -17,7 +17,7 @@ object ProcessApi {
 
     object Elements { /* flow nodes */ }
     object Messages { /* message definitions */ }
-    object TaskTypes { /* service task types */ }
+    object ServiceTasks { /* service task types */ }
     object Timers { /* timer definitions */ }
     object Errors { /* error definitions */ }
     object Signals { /* signal definitions */ }

--- a/docs/engines/camunda7.md
+++ b/docs/engines/camunda7.md
@@ -16,7 +16,7 @@ Service tasks are detected via one of these `camunda:` attributes:
 </bpmn:serviceTask>
 ```
 
-The attribute value becomes the entry in the generated `TaskTypes` object.
+The attribute value becomes the entry in the generated `ServiceTasks` object.
 
 ## Variable Extraction
 

--- a/docs/engines/operaton.md
+++ b/docs/engines/operaton.md
@@ -22,7 +22,7 @@ Service tasks are detected via one of these `operaton:` attributes:
 </bpmn:serviceTask>
 ```
 
-The attribute value becomes the entry in the generated `TaskTypes` object.
+The attribute value becomes the entry in the generated `ServiceTasks` object.
 
 ## Variable Extraction
 

--- a/docs/engines/zeebe.md
+++ b/docs/engines/zeebe.md
@@ -14,7 +14,7 @@ Service tasks are detected via the `zeebe:taskDefinition` extension element:
 </bpmn:serviceTask>
 ```
 
-The `type` attribute becomes the value in the generated `TaskTypes` object.
+The `type` attribute becomes the value in the generated `ServiceTasks` object.
 
 ## Variable Extraction
 

--- a/docs/guide/generated-api.md
+++ b/docs/guide/generated-api.md
@@ -13,7 +13,7 @@ The generated Process API is an `object` (Kotlin) or `class` (Java) with nested 
 | `Elements` | All flow node IDs (tasks, events, gateways, subprocesses) |
 | `CallActivities` | Called process IDs for call activity elements |
 | `Messages` | Message names from message events and receive tasks |
-| `TaskTypes` | Worker types / topics / delegate expressions from service tasks |
+| `ServiceTasks` | Worker types / topics / delegate expressions from service tasks |
 | `Timers` | Timer configurations with type and value (`BpmnTimer`) |
 | `Errors` | Error definitions with name and code (`BpmnError`) |
 | `Compensations` | Compensation event IDs |
@@ -66,7 +66,7 @@ object NewsletterSubscriptionProcessApi {
     const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
   }
 
-  object TaskTypes {
+  object ServiceTasks {
     const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"
     const val NEWSLETTER_SEND_WELCOME_MAIL: String = "\${newsletterSendWelcomeMail}"
     const val NEWSLETTER_REGISTRATION_COMPLETED: String = "newsletter.registrationCompleted"
@@ -146,7 +146,7 @@ public class NewsletterSubscriptionProcessApi {
         public static final String MESSAGE_FORM_SUBMITTED = "Message_FormSubmitted";
     }
 
-    // ... same structure for TaskTypes, Timers, Errors, Compensations, Signals, Variables, Flows, Relations
+    // ... same structure for ServiceTasks, Timers, Errors, Compensations, Signals, Variables, Flows, Relations
 }
 ```
 


### PR DESCRIPTION
## Summary

- Renames the generated nested object/class `TaskTypes` → `ServiceTasks` across generators, test fixtures, docs, skills, README, and landing page
- No logic changes — purely a naming update

## Breaking Change

Consumers referencing `ProcessApi.TaskTypes.*` must update to `ProcessApi.ServiceTasks.*`.