### PR TITLE
fix: consistent indentation for Flows/Relations in generated Kotlin output

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -3,6 +3,7 @@ package io.github.emaarco.bpmn.adapter.outbound.codegen.builder
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LIST
@@ -167,16 +168,18 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         return flowsBuilder.build()
     }
 
-    private fun buildFlowInitializer(id: String, sourceRef: String, targetRef: String, condition: String?, isDefault: Boolean): String {
-        return buildString {
-            append("BpmnFlow(\n")
-            append("    id = \"$id\",\n")
-            append("    sourceRef = \"$sourceRef\",\n")
-            append("    targetRef = \"$targetRef\",\n")
-            if (condition != null) append("    condition = \"${condition.escapeDollarInterpolation()}\",\n")
-            if (isDefault) append("    isDefault = true,\n")
-            append(")")
-        }
+    private fun buildFlowInitializer(id: String, sourceRef: String, targetRef: String, condition: String?, isDefault: Boolean): CodeBlock {
+        return CodeBlock.builder().apply {
+            add("BpmnFlow(\n")
+            indent()
+            add("id = %S,\n", id)
+            add("sourceRef = %S,\n", sourceRef)
+            add("targetRef = %S,\n", targetRef)
+            if (condition != null) add("condition = \"${condition.escapeDollarInterpolation()}\",\n")
+            if (isDefault) add("isDefault = true,\n")
+            unindent()
+            add(")")
+        }.build()
     }
 
     private fun buildRelationsObject(packagePath: String, flowNodes: List<FlowNodeDefinition>): TypeSpec {
@@ -192,16 +195,18 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         return relationsBuilder.build()
     }
 
-    private fun buildRelationsInitializer(node: FlowNodeDefinition): String {
-        return buildString {
-            append("BpmnRelations(\n")
-            append("    incoming = ${listLiteral(node.incoming)},\n")
-            append("    outgoing = ${listLiteral(node.outgoing)},\n")
-            append("    parentId = ${nullableStringLiteral(node.parentId)},\n")
-            append("    attachedToRef = ${nullableStringLiteral(node.attachedToRef)},\n")
-            append("    attachedElements = ${listLiteral(node.attachedElements)},\n")
-            append(")")
-        }
+    private fun buildRelationsInitializer(node: FlowNodeDefinition): CodeBlock {
+        return CodeBlock.builder().apply {
+            add("BpmnRelations(\n")
+            indent()
+            add("incoming = %L,\n", listLiteral(node.incoming))
+            add("outgoing = %L,\n", listLiteral(node.outgoing))
+            add("parentId = %L,\n", nullableStringLiteral(node.parentId))
+            add("attachedToRef = %L,\n", nullableStringLiteral(node.attachedToRef))
+            add("attachedElements = %L,\n", listLiteral(node.attachedElements))
+            unindent()
+            add(")")
+        }.build()
     }
 
     private fun listLiteral(items: List<String>): String {

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
@@ -52,7 +52,7 @@ class KotlinProcessApiBuilderTest {
         assertThat(result.packagePath).isEqualTo("de.emaarco.example")
 
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/NewsletterSubscriptionProcessApiKotlin.txt")).toURI())
-        assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertThat(result.content).isEqualTo(expectedFile.readText())
         assertKotlinSyntaxValid(result.content)
     }
 
@@ -79,7 +79,7 @@ class KotlinProcessApiBuilderTest {
 
         // then: output contains Variants section instead of flat Flows/Relations
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/MultiVariantProcessApiKotlin.txt")).toURI())
-        assertThat(result.content).isEqualToIgnoringWhitespace(expectedFile.readText())
+        assertThat(result.content).isEqualTo(expectedFile.readText())
         assertKotlinSyntaxValid(result.content)
     }
 

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -92,244 +92,244 @@ object SendNewsletterProcessApi {
     object Send {
       object Flows {
         val FLOW_0_BIANZ_5: BpmnFlow = BpmnFlow(
-                id = "Flow_0bianz5",
-                sourceRef = "startEvent_editionCreated",
-                targetRef = "serviceTask_loadSubscribers",
+              id = "Flow_0bianz5",
+              sourceRef = "startEvent_editionCreated",
+              targetRef = "serviceTask_loadSubscribers",
             )
 
         val FLOW_04_ANDB_8: BpmnFlow = BpmnFlow(
-                id = "Flow_04andb8",
-                sourceRef = "serviceTask_loadSubscribers",
-                targetRef = "gateway_hasSubscribers",
+              id = "Flow_04andb8",
+              sourceRef = "serviceTask_loadSubscribers",
+              targetRef = "gateway_hasSubscribers",
             )
 
         val FLOW_1_JOGUT_0: BpmnFlow = BpmnFlow(
-                id = "Flow_1jogut0",
-                sourceRef = "gateway_hasSubscribers",
-                targetRef = "serviceTask_sendToSubscriber",
-                isDefault = true,
+              id = "Flow_1jogut0",
+              sourceRef = "gateway_hasSubscribers",
+              targetRef = "serviceTask_sendToSubscriber",
+              isDefault = true,
             )
 
         val FLOW_1_GSZ_7_WD: BpmnFlow = BpmnFlow(
-                id = "Flow_1gsz7wd",
-                sourceRef = "gateway_hasSubscribers",
-                targetRef = "endEvent_noSubscribers",
-                condition = "\${subscribers.size() > 0}",
+              id = "Flow_1gsz7wd",
+              sourceRef = "gateway_hasSubscribers",
+              targetRef = "endEvent_noSubscribers",
+              condition = "\${subscribers.size() > 0}",
             )
 
         val FLOW_1_RUAYVL: BpmnFlow = BpmnFlow(
-                id = "Flow_1ruayvl",
-                sourceRef = "serviceTask_sendToSubscriber",
-                targetRef = "serviceTask_notifyAuthor",
+              id = "Flow_1ruayvl",
+              sourceRef = "serviceTask_sendToSubscriber",
+              targetRef = "serviceTask_notifyAuthor",
             )
 
         val FLOW_0_V_2_V_55_N: BpmnFlow = BpmnFlow(
-                id = "Flow_0v2v55n",
-                sourceRef = "serviceTask_notifyAuthor",
-                targetRef = "endEvent_editionSent",
+              id = "Flow_0v2v55n",
+              sourceRef = "serviceTask_notifyAuthor",
+              targetRef = "endEvent_editionSent",
             )
 
         val FLOW_0_VTPPNK: BpmnFlow = BpmnFlow(
-                id = "Flow_0vtppnk",
-                sourceRef = "event_mailRejected",
-                targetRef = "serviceTask_analyzeError",
+              id = "Flow_0vtppnk",
+              sourceRef = "event_mailRejected",
+              targetRef = "serviceTask_analyzeError",
             )
 
         val FLOW_13_NMNAG: BpmnFlow = BpmnFlow(
-                id = "Flow_13nmnag",
-                sourceRef = "serviceTask_analyzeError",
-                targetRef = "gateway_canSendAgain",
+              id = "Flow_13nmnag",
+              sourceRef = "serviceTask_analyzeError",
+              targetRef = "gateway_canSendAgain",
             )
 
         val FLOW_1_IZUCOF: BpmnFlow = BpmnFlow(
-                id = "Flow_1izucof",
-                sourceRef = "gateway_canSendAgain",
-                targetRef = "serviceTask_sendMailAgain",
-                isDefault = true,
+              id = "Flow_1izucof",
+              sourceRef = "gateway_canSendAgain",
+              targetRef = "serviceTask_sendMailAgain",
+              isDefault = true,
             )
 
         val FLOW_18_NF_2_JH: BpmnFlow = BpmnFlow(
-                id = "Flow_18nf2jh",
-                sourceRef = "gateway_canSendAgain",
-                targetRef = "escalationEndEvent_nofitySupport",
-                condition = "\${canBeResolved == false}",
+              id = "Flow_18nf2jh",
+              sourceRef = "gateway_canSendAgain",
+              targetRef = "escalationEndEvent_nofitySupport",
+              condition = "\${canBeResolved == false}",
             )
 
         val FLOW_0_VYM_6_NU: BpmnFlow = BpmnFlow(
-                id = "Flow_0vym6nu",
-                sourceRef = "serviceTask_sendMailAgain",
-                targetRef = "eventGateway_afterSendingAgain",
+              id = "Flow_0vym6nu",
+              sourceRef = "serviceTask_sendMailAgain",
+              targetRef = "eventGateway_afterSendingAgain",
             )
 
         val FLOW_0_ENJKOE: BpmnFlow = BpmnFlow(
-                id = "Flow_0enjkoe",
-                sourceRef = "eventGateway_afterSendingAgain",
-                targetRef = "timer_noRejectionForOneDay",
+              id = "Flow_0enjkoe",
+              sourceRef = "eventGateway_afterSendingAgain",
+              targetRef = "timer_noRejectionForOneDay",
             )
 
         val FLOW_081_CYKL: BpmnFlow = BpmnFlow(
-                id = "Flow_081cykl",
-                sourceRef = "eventGateway_afterSendingAgain",
-                targetRef = "event_mailRejectedAgain",
+              id = "Flow_081cykl",
+              sourceRef = "eventGateway_afterSendingAgain",
+              targetRef = "event_mailRejectedAgain",
             )
 
         val FLOW_0_X_9_THPQ: BpmnFlow = BpmnFlow(
-                id = "Flow_0x9thpq",
-                sourceRef = "event_mailRejectedAgain",
-                targetRef = "escalationEndEvent_nofitySupportAfterRepeatedError",
+              id = "Flow_0x9thpq",
+              sourceRef = "event_mailRejectedAgain",
+              targetRef = "escalationEndEvent_nofitySupportAfterRepeatedError",
             )
 
         val FLOW_0338_XZF: BpmnFlow = BpmnFlow(
-                id = "Flow_0338xzf",
-                sourceRef = "timer_noRejectionForOneDay",
-                targetRef = "endEvent_issueResolved",
+              id = "Flow_0338xzf",
+              sourceRef = "timer_noRejectionForOneDay",
+              targetRef = "endEvent_issueResolved",
             )
       }
 
       object Relations {
         val END_EVENT_EDITION_SENT: BpmnRelations = BpmnRelations(
-                incoming = listOf("serviceTask_notifyAuthor"),
-                outgoing = emptyList(),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("serviceTask_notifyAuthor"),
+              outgoing = emptyList(),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val END_EVENT_ISSUE_RESOLVED: BpmnRelations = BpmnRelations(
-                incoming = listOf("timer_noRejectionForOneDay"),
-                outgoing = emptyList(),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("timer_noRejectionForOneDay"),
+              outgoing = emptyList(),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val END_EVENT_NO_SUBSCRIBERS: BpmnRelations = BpmnRelations(
-                incoming = listOf("gateway_hasSubscribers"),
-                outgoing = emptyList(),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("gateway_hasSubscribers"),
+              outgoing = emptyList(),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val ESCALATION_END_EVENT_NOFITY_SUPPORT: BpmnRelations = BpmnRelations(
-                incoming = listOf("gateway_canSendAgain"),
-                outgoing = emptyList(),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("gateway_canSendAgain"),
+              outgoing = emptyList(),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val ESCALATION_END_EVENT_NOFITY_SUPPORT_AFTER_REPEATED_ERROR: BpmnRelations =
             BpmnRelations(
-                incoming = listOf("event_mailRejectedAgain"),
-                outgoing = emptyList(),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("event_mailRejectedAgain"),
+              outgoing = emptyList(),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val EVENT_GATEWAY_AFTER_SENDING_AGAIN: BpmnRelations = BpmnRelations(
-                incoming = listOf("serviceTask_sendMailAgain"),
-                outgoing = listOf("timer_noRejectionForOneDay", "event_mailRejectedAgain"),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("serviceTask_sendMailAgain"),
+              outgoing = listOf("timer_noRejectionForOneDay", "event_mailRejectedAgain"),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val EVENT_SUB_PROCESS_ERROR_HANDLING: BpmnRelations = BpmnRelations(
-                incoming = emptyList(),
-                outgoing = emptyList(),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = emptyList(),
+              outgoing = emptyList(),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val EVENT_MAIL_REJECTED: BpmnRelations = BpmnRelations(
-                incoming = emptyList(),
-                outgoing = listOf("serviceTask_analyzeError"),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = emptyList(),
+              outgoing = listOf("serviceTask_analyzeError"),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val EVENT_MAIL_REJECTED_AGAIN: BpmnRelations = BpmnRelations(
-                incoming = listOf("eventGateway_afterSendingAgain"),
-                outgoing = listOf("escalationEndEvent_nofitySupportAfterRepeatedError"),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("eventGateway_afterSendingAgain"),
+              outgoing = listOf("escalationEndEvent_nofitySupportAfterRepeatedError"),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val GATEWAY_CAN_SEND_AGAIN: BpmnRelations = BpmnRelations(
-                incoming = listOf("serviceTask_analyzeError"),
-                outgoing = listOf("serviceTask_sendMailAgain", "escalationEndEvent_nofitySupport"),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("serviceTask_analyzeError"),
+              outgoing = listOf("serviceTask_sendMailAgain", "escalationEndEvent_nofitySupport"),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val GATEWAY_HAS_SUBSCRIBERS: BpmnRelations = BpmnRelations(
-                incoming = listOf("serviceTask_loadSubscribers"),
-                outgoing = listOf("serviceTask_sendToSubscriber", "endEvent_noSubscribers"),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("serviceTask_loadSubscribers"),
+              outgoing = listOf("serviceTask_sendToSubscriber", "endEvent_noSubscribers"),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val SERVICE_TASK_ANALYZE_ERROR: BpmnRelations = BpmnRelations(
-                incoming = listOf("event_mailRejected"),
-                outgoing = listOf("gateway_canSendAgain"),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("event_mailRejected"),
+              outgoing = listOf("gateway_canSendAgain"),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val SERVICE_TASK_LOAD_SUBSCRIBERS: BpmnRelations = BpmnRelations(
-                incoming = listOf("startEvent_editionCreated"),
-                outgoing = listOf("gateway_hasSubscribers"),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("startEvent_editionCreated"),
+              outgoing = listOf("gateway_hasSubscribers"),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val SERVICE_TASK_NOTIFY_AUTHOR: BpmnRelations = BpmnRelations(
-                incoming = listOf("serviceTask_sendToSubscriber"),
-                outgoing = listOf("endEvent_editionSent"),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("serviceTask_sendToSubscriber"),
+              outgoing = listOf("endEvent_editionSent"),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val SERVICE_TASK_SEND_MAIL_AGAIN: BpmnRelations = BpmnRelations(
-                incoming = listOf("gateway_canSendAgain"),
-                outgoing = listOf("eventGateway_afterSendingAgain"),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("gateway_canSendAgain"),
+              outgoing = listOf("eventGateway_afterSendingAgain"),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val SERVICE_TASK_SEND_TO_SUBSCRIBER: BpmnRelations = BpmnRelations(
-                incoming = listOf("gateway_hasSubscribers"),
-                outgoing = listOf("serviceTask_notifyAuthor"),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("gateway_hasSubscribers"),
+              outgoing = listOf("serviceTask_notifyAuthor"),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val START_EVENT_EDITION_CREATED: BpmnRelations = BpmnRelations(
-                incoming = emptyList(),
-                outgoing = listOf("serviceTask_loadSubscribers"),
-                parentId = null,
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = emptyList(),
+              outgoing = listOf("serviceTask_loadSubscribers"),
+              parentId = null,
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
 
         val TIMER_NO_REJECTION_FOR_ONE_DAY: BpmnRelations = BpmnRelations(
-                incoming = listOf("eventGateway_afterSendingAgain"),
-                outgoing = listOf("endEvent_issueResolved"),
-                parentId = "eventSubProcess_errorHandling",
-                attachedToRef = null,
-                attachedElements = emptyList(),
+              incoming = listOf("eventGateway_afterSendingAgain"),
+              outgoing = listOf("endEvent_issueResolved"),
+              parentId = "eventSubProcess_errorHandling",
+              attachedToRef = null,
+              attachedElements = emptyList(),
             )
       }
     }

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -35,7 +35,8 @@ object NewsletterSubscriptionProcessApi {
 
     const val END_EVENT_REGISTRATION_COMPLETED: String = "EndEvent_RegistrationCompleted"
 
-    const val END_EVENT_REGISTRATION_NOT_POSSIBLE: String = "EndEvent_RegistrationNotPossible"
+    const val END_EVENT_REGISTRATION_NOT_POSSIBLE: String =
+        "EndEvent_RegistrationNotPossible"
 
     const val END_EVENT_SUBSCRIPTION_CONFIRMED: String = "EndEvent_SubscriptionConfirmed"
 
@@ -85,9 +86,11 @@ object NewsletterSubscriptionProcessApi {
   }
 
   object Compensations {
-    const val COMPENSATION_END_EVENT_REGISTRATION_ABORTED: String = "CompensationEndEvent_RegistrationAborted"
+    const val COMPENSATION_END_EVENT_REGISTRATION_ABORTED: String =
+        "CompensationEndEvent_RegistrationAborted"
 
-    const val COMPENSATION_EVENT_ON_SUBSCRIPTION_COUNTER: String = "CompensationEvent_OnSubscriptionCounter"
+    const val COMPENSATION_EVENT_ON_SUBSCRIPTION_COUNTER: String =
+        "CompensationEvent_OnSubscriptionCounter"
   }
 
   object Signals {
@@ -124,207 +127,207 @@ object NewsletterSubscriptionProcessApi {
 
   object Flows {
     val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
-            id = "Flow_05i3x1y",
-            sourceRef = "StartEvent_RequestReceived",
-            targetRef = "Activity_SendConfirmationMail",
+          id = "Flow_05i3x1y",
+          sourceRef = "StartEvent_RequestReceived",
+          targetRef = "Activity_SendConfirmationMail",
         )
 
     val FLOW_09_CUVZP: BpmnFlow = BpmnFlow(
-            id = "Flow_09cuvzp",
-            sourceRef = "SubProcess_Confirmation",
-            targetRef = "Activity_SendWelcomeMail",
+          id = "Flow_09cuvzp",
+          sourceRef = "SubProcess_Confirmation",
+          targetRef = "Activity_SendWelcomeMail",
         )
 
     val FLOW_0_I_2_CTUV: BpmnFlow = BpmnFlow(
-            id = "Flow_0i2ctuv",
-            sourceRef = "ErrorEvent_InvalidMail",
-            targetRef = "EndEvent_RegistrationNotPossible",
+          id = "Flow_0i2ctuv",
+          sourceRef = "ErrorEvent_InvalidMail",
+          targetRef = "EndEvent_RegistrationNotPossible",
         )
 
     val FLOW_0_X_4_EWVB: BpmnFlow = BpmnFlow(
-            id = "Flow_0x4ewvb",
-            sourceRef = "Timer_EveryDay",
-            targetRef = "Activity_SendConfirmationMail",
+          id = "Flow_0x4ewvb",
+          sourceRef = "Timer_EveryDay",
+          targetRef = "Activity_SendConfirmationMail",
         )
 
     val FLOW_0_ZDMT_0_T: BpmnFlow = BpmnFlow(
-            id = "Flow_0zdmt0t",
-            sourceRef = "serviceTask_incrementSubscriptionCounter",
-            targetRef = "SubProcess_Confirmation",
+          id = "Flow_0zdmt0t",
+          sourceRef = "serviceTask_incrementSubscriptionCounter",
+          targetRef = "SubProcess_Confirmation",
         )
 
     val FLOW_1_BCKM_43: BpmnFlow = BpmnFlow(
-            id = "Flow_1bckm43",
-            sourceRef = "Activity_SendConfirmationMail",
-            targetRef = "Activity_ConfirmRegistration",
+          id = "Flow_1bckm43",
+          sourceRef = "Activity_SendConfirmationMail",
+          targetRef = "Activity_ConfirmRegistration",
         )
 
     val FLOW_1_BSB_8_NO: BpmnFlow = BpmnFlow(
-            id = "Flow_1bsb8no",
-            sourceRef = "CallActivity_AbortRegistration",
-            targetRef = "CompensationEndEvent_RegistrationAborted",
+          id = "Flow_1bsb8no",
+          sourceRef = "CallActivity_AbortRegistration",
+          targetRef = "CompensationEndEvent_RegistrationAborted",
         )
 
     val FLOW_1_CPWE_57: BpmnFlow = BpmnFlow(
-            id = "Flow_1cpwe57",
-            sourceRef = "Activity_ConfirmRegistration",
-            targetRef = "EndEvent_SubscriptionConfirmed",
+          id = "Flow_1cpwe57",
+          sourceRef = "Activity_ConfirmRegistration",
+          targetRef = "EndEvent_SubscriptionConfirmed",
         )
 
     val FLOW_1_CSFYYZ: BpmnFlow = BpmnFlow(
-            id = "Flow_1csfyyz",
-            sourceRef = "StartEvent_SubmitRegistrationForm",
-            targetRef = "serviceTask_incrementSubscriptionCounter",
+          id = "Flow_1csfyyz",
+          sourceRef = "StartEvent_SubmitRegistrationForm",
+          targetRef = "serviceTask_incrementSubscriptionCounter",
         )
 
     val FLOW_1_I_7_HJID: BpmnFlow = BpmnFlow(
-            id = "Flow_1i7hjid",
-            sourceRef = "Activity_SendWelcomeMail",
-            targetRef = "EndEvent_RegistrationCompleted",
+          id = "Flow_1i7hjid",
+          sourceRef = "Activity_SendWelcomeMail",
+          targetRef = "EndEvent_RegistrationCompleted",
         )
 
     val FLOW_1_L_1_LJ_4_M: BpmnFlow = BpmnFlow(
-            id = "Flow_1l1lj4m",
-            sourceRef = "Timer_After3Days",
-            targetRef = "CallActivity_AbortRegistration",
+          id = "Flow_1l1lj4m",
+          sourceRef = "Timer_After3Days",
+          targetRef = "CallActivity_AbortRegistration",
         )
   }
 
   object Relations {
     val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(
-            incoming = listOf("Activity_SendConfirmationMail"),
-            outgoing = listOf("EndEvent_SubscriptionConfirmed"),
-            parentId = "SubProcess_Confirmation",
-            attachedToRef = null,
-            attachedElements = listOf("Timer_EveryDay"),
+          incoming = listOf("Activity_SendConfirmationMail"),
+          outgoing = listOf("EndEvent_SubscriptionConfirmed"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = listOf("Timer_EveryDay"),
         )
 
     val ACTIVITY_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
-            incoming = listOf("StartEvent_RequestReceived", "Timer_EveryDay"),
-            outgoing = listOf("Activity_ConfirmRegistration"),
-            parentId = "SubProcess_Confirmation",
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = listOf("StartEvent_RequestReceived", "Timer_EveryDay"),
+          outgoing = listOf("Activity_ConfirmRegistration"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val ACTIVITY_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
-            incoming = listOf("SubProcess_Confirmation"),
-            outgoing = listOf("EndEvent_RegistrationCompleted"),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = listOf("SubProcess_Confirmation"),
+          outgoing = listOf("EndEvent_RegistrationCompleted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val CALL_ACTIVITY_ABORT_REGISTRATION: BpmnRelations = BpmnRelations(
-            incoming = listOf("Timer_After3Days"),
-            outgoing = listOf("CompensationEndEvent_RegistrationAborted"),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = listOf("Timer_After3Days"),
+          outgoing = listOf("CompensationEndEvent_RegistrationAborted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val COMPENSATION_END_EVENT_REGISTRATION_ABORTED: BpmnRelations = BpmnRelations(
-            incoming = listOf("CallActivity_AbortRegistration"),
-            outgoing = emptyList(),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = listOf("CallActivity_AbortRegistration"),
+          outgoing = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val COMPENSATION_EVENT_ON_SUBSCRIPTION_COUNTER: BpmnRelations = BpmnRelations(
-            incoming = emptyList(),
-            outgoing = emptyList(),
-            parentId = null,
-            attachedToRef = "serviceTask_incrementSubscriptionCounter",
-            attachedElements = emptyList(),
+          incoming = emptyList(),
+          outgoing = emptyList(),
+          parentId = null,
+          attachedToRef = "serviceTask_incrementSubscriptionCounter",
+          attachedElements = emptyList(),
         )
 
     val COMPENSATION_TASK_DECREMENT_SUBSCRIPTION_COUNTER: BpmnRelations = BpmnRelations(
-            incoming = emptyList(),
-            outgoing = emptyList(),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = emptyList(),
+          outgoing = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val END_EVENT_REGISTRATION_COMPLETED: BpmnRelations = BpmnRelations(
-            incoming = listOf("Activity_SendWelcomeMail"),
-            outgoing = emptyList(),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = listOf("Activity_SendWelcomeMail"),
+          outgoing = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val END_EVENT_REGISTRATION_NOT_POSSIBLE: BpmnRelations = BpmnRelations(
-            incoming = listOf("ErrorEvent_InvalidMail"),
-            outgoing = emptyList(),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = listOf("ErrorEvent_InvalidMail"),
+          outgoing = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val END_EVENT_SUBSCRIPTION_CONFIRMED: BpmnRelations = BpmnRelations(
-            incoming = listOf("Activity_ConfirmRegistration"),
-            outgoing = emptyList(),
-            parentId = "SubProcess_Confirmation",
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = listOf("Activity_ConfirmRegistration"),
+          outgoing = emptyList(),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val ERROR_EVENT_INVALID_MAIL: BpmnRelations = BpmnRelations(
-            incoming = emptyList(),
-            outgoing = listOf("EndEvent_RegistrationNotPossible"),
-            parentId = null,
-            attachedToRef = "SubProcess_Confirmation",
-            attachedElements = emptyList(),
+          incoming = emptyList(),
+          outgoing = listOf("EndEvent_RegistrationNotPossible"),
+          parentId = null,
+          attachedToRef = "SubProcess_Confirmation",
+          attachedElements = emptyList(),
         )
 
     val START_EVENT_REQUEST_RECEIVED: BpmnRelations = BpmnRelations(
-            incoming = emptyList(),
-            outgoing = listOf("Activity_SendConfirmationMail"),
-            parentId = "SubProcess_Confirmation",
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = emptyList(),
+          outgoing = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val START_EVENT_SUBMIT_REGISTRATION_FORM: BpmnRelations = BpmnRelations(
-            incoming = emptyList(),
-            outgoing = listOf("serviceTask_incrementSubscriptionCounter"),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = emptyList(),
+          incoming = emptyList(),
+          outgoing = listOf("serviceTask_incrementSubscriptionCounter"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
         )
 
     val SUB_PROCESS_CONFIRMATION: BpmnRelations = BpmnRelations(
-            incoming = listOf("serviceTask_incrementSubscriptionCounter"),
-            outgoing = listOf("Activity_SendWelcomeMail"),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = listOf("ErrorEvent_InvalidMail", "Timer_After3Days"),
+          incoming = listOf("serviceTask_incrementSubscriptionCounter"),
+          outgoing = listOf("Activity_SendWelcomeMail"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("ErrorEvent_InvalidMail", "Timer_After3Days"),
         )
 
     val TIMER_AFTER_3_DAYS: BpmnRelations = BpmnRelations(
-            incoming = emptyList(),
-            outgoing = listOf("CallActivity_AbortRegistration"),
-            parentId = null,
-            attachedToRef = "SubProcess_Confirmation",
-            attachedElements = emptyList(),
+          incoming = emptyList(),
+          outgoing = listOf("CallActivity_AbortRegistration"),
+          parentId = null,
+          attachedToRef = "SubProcess_Confirmation",
+          attachedElements = emptyList(),
         )
 
     val TIMER_EVERY_DAY: BpmnRelations = BpmnRelations(
-            incoming = emptyList(),
-            outgoing = listOf("Activity_SendConfirmationMail"),
-            parentId = "SubProcess_Confirmation",
-            attachedToRef = "Activity_ConfirmRegistration",
-            attachedElements = emptyList(),
+          incoming = emptyList(),
+          outgoing = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = "Activity_ConfirmRegistration",
+          attachedElements = emptyList(),
         )
 
     val SERVICE_TASK_INCREMENT_SUBSCRIPTION_COUNTER: BpmnRelations = BpmnRelations(
-            incoming = listOf("StartEvent_SubmitRegistrationForm"),
-            outgoing = listOf("SubProcess_Confirmation"),
-            parentId = null,
-            attachedToRef = null,
-            attachedElements = listOf("CompensationEvent_OnSubscriptionCounter"),
+          incoming = listOf("StartEvent_SubmitRegistrationForm"),
+          outgoing = listOf("SubProcess_Confirmation"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("CompensationEvent_OnSubscriptionCounter"),
         )
   }
 }


### PR DESCRIPTION
## Summary

- Replace raw `String` initializers in `buildFlowInitializer` and `buildRelationsInitializer` with `CodeBlock` using `indent()`/`unindent()`
- KotlinPoet was stacking its own continuation indent on top of the 4 hardcoded spaces, doubling the indentation for constructor args
- Args now have a consistent single-level indent regardless of property name length — no more linter/formatter churn on save