### PR TITLE
fix: resolve maven publish build service classloader conflict

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.mavenPublish) apply false
 }
 
 allprojects {


### PR DESCRIPTION
## Summary
- Add `alias(libs.plugins.mavenPublish) apply false` to the root `build.gradle.kts`
- Fixes a Gradle classloader conflict caused by `bpmn-to-code-maven` and `bpmn-to-code-testing` both applying the `com.vanniktech.maven.publish` plugin independently as sibling projects
- Both modules retain their own `mavenPublishing` configuration and can still be published independently

## Root Cause
When two sibling projects apply the same plugin, each gets its own classloader scope. The vanniktech plugin registers a shared `MavenCentralBuildService`, and Gradle rejects the second registration because the service type is loaded from a different classloader. Declaring the plugin at the root with `apply false` unifies the classloader scope without applying the plugin to the root project.