### PR TITLE
fix: add maven publishing config to bpmn-to-code-core

### DIFF
--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -1,11 +1,13 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.mavenPublish)
     jacoco
     `java-test-fixtures`
 }
 
 group = "io.github.emaarco"
+version = property("projectVersion").toString()
 
 repositories {
     mavenCentral()
@@ -58,6 +60,39 @@ tasks.jacocoTestReport {
     classDirectories.setFrom(
         files(classDirectories.files.map { fileTree(it) { exclude(coverageExclusions) } })
     )
+}
+
+mavenPublishing {
+
+    publishToMavenCentral()
+    signAllPublications()
+    coordinates("io.github.emaarco", "bpmn-to-code-core", version.toString())
+
+    pom {
+        name.set("bpmn-to-code-core")
+        description.set("Core library for bpmn-to-code — generates type-safe API definitions from BPMN process models")
+        inceptionYear.set("2025")
+        url.set("https://github.com/emaarco/bpmn-to-code")
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
+                distribution.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("emaarco")
+                name.set("Marco Schaeck")
+                url.set("https://github.com/emaarco")
+            }
+        }
+        scm {
+            url.set("https://github.com/emaarco/bpmn-to-code")
+            connection.set("scm:git:git://github.com/emaarco/bpmn-to-code.git")
+            developerConnection.set("scm:git:ssh://git@github.com/emaarco/bpmn-to-code.git")
+        }
+    }
 }
 
 tasks.jacocoTestCoverageVerification {

--- a/bpmn-to-code-core/build.gradle.kts
+++ b/bpmn-to-code-core/build.gradle.kts
@@ -1,13 +1,11 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.mavenPublish)
     jacoco
     `java-test-fixtures`
 }
 
 group = "io.github.emaarco"
-version = property("projectVersion").toString()
 
 repositories {
     mavenCentral()
@@ -60,39 +58,6 @@ tasks.jacocoTestReport {
     classDirectories.setFrom(
         files(classDirectories.files.map { fileTree(it) { exclude(coverageExclusions) } })
     )
-}
-
-mavenPublishing {
-
-    publishToMavenCentral()
-    signAllPublications()
-    coordinates("io.github.emaarco", "bpmn-to-code-core", version.toString())
-
-    pom {
-        name.set("bpmn-to-code-core")
-        description.set("Core library for bpmn-to-code — generates type-safe API definitions from BPMN process models")
-        inceptionYear.set("2025")
-        url.set("https://github.com/emaarco/bpmn-to-code")
-        licenses {
-            license {
-                name.set("MIT License")
-                url.set("https://opensource.org/licenses/MIT")
-                distribution.set("https://opensource.org/licenses/MIT")
-            }
-        }
-        developers {
-            developer {
-                id.set("emaarco")
-                name.set("Marco Schaeck")
-                url.set("https://github.com/emaarco")
-            }
-        }
-        scm {
-            url.set("https://github.com/emaarco/bpmn-to-code")
-            connection.set("scm:git:git://github.com/emaarco/bpmn-to-code.git")
-            developerConnection.set("scm:git:ssh://git@github.com/emaarco/bpmn-to-code.git")
-        }
-    }
 }
 
 tasks.jacocoTestCoverageVerification {

--- a/bpmn-to-code-testing/build.gradle.kts
+++ b/bpmn-to-code-testing/build.gradle.kts
@@ -17,11 +17,16 @@ sourceSets {
 }
 
 dependencies {
-    implementation(project(":bpmn-to-code-core"))
+    compileOnly(project(":bpmn-to-code-core"))
     api(libs.assertj)
     compileOnly(libs.junit)
+    testImplementation(project(":bpmn-to-code-core"))
     testImplementation(libs.bundles.testing)
     testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.jar {
+    from(project(":bpmn-to-code-core").sourceSets.main.get().output)
 }
 
 tasks.named<Test>("test") {


### PR DESCRIPTION
## Summary
`bpmn-to-code-testing` declared an `implementation` dependency on `:bpmn-to-code-core`, which caused Gradle to warn that core has no publications — and would become a hard error in Gradle 10.

The gradle and maven plugins solve this by bundling core's output into their JAR and using `compileOnly` for the project dependency. Testing now follows the same pattern:
- `compileOnly(project(":bpmn-to-code-core"))` — available at compile time, not added to POM
- `testImplementation(project(":bpmn-to-code-core"))` — available for tests
- `tasks.jar { from(...core output...) }` — core classes bundled into the artifact