### PR TITLE
fix: normalize whitespace in BPMN element names

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/ModelInstanceUtils.kt
@@ -60,7 +60,7 @@ object ModelInstanceUtils {
         val flowNodes = this.getModelElementsByType(FlowNode::class.java)
         return flowNodes.map {
             val id = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            val name = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME)
+            val name = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME)?.normalizeWhitespace()
             val elementType = it.resolveElementType()
             val attachedToRef = if (it is BoundaryEvent) it.attachedTo?.id else null
             val parentId = (it.parentElement as? SubProcess)?.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
@@ -85,7 +85,7 @@ object ModelInstanceUtils {
             val id = flow.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val sourceRef = flow.source?.id ?: return@mapNotNull null
             val targetRef = flow.target?.id ?: return@mapNotNull null
-            val flowName = flow.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME)?.takeIf { it.isNotBlank() }
+            val flowName = flow.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_NAME)?.normalizeWhitespace()?.takeIf { it.isNotBlank() }
             val condition = flow.conditionExpression?.textContent?.takeIf { it.isNotBlank() }
             SequenceFlowDefinition(
                 id = id,
@@ -165,6 +165,8 @@ object ModelInstanceUtils {
             null
         }
     }
+
+    private fun String.normalizeWhitespace(): String = this.replace(Regex("\\s+"), " ").trim()
 
     private fun FlowNode.resolveElementType(): BpmnElementType {
         return if (this is SubProcess && this.triggeredByEvent()) {

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -122,7 +122,7 @@ class ZeebeModelExtractorTest {
                         attachedToRef = "SubProcess_Confirmation",
                         followingElements = listOf("CallActivity_AbortRegistration")),
                     FlowNodeDefinition("Timer_EveryDay", BpmnElementType.BOUNDARY_EVENT,
-                        displayName = "Every\nday",
+                        displayName = "Every day",
                         properties = FlowNodeProperties.Timer(TimerDefinition("Timer_EveryDay", "Duration", "PT1M")),
                         attachedToRef = "Activity_ConfirmRegistration",
                         parentId = "SubProcess_Confirmation",


### PR DESCRIPTION
## Summary
- BPMN element names with newlines (e.g. `"Every\nday"`) were passed raw to KotlinPoet/JavaPoet, which generated multiline `trimMargin()` raw string literals in the output
- Fix: normalize whitespace at extraction time in `ModelInstanceUtils.kt` — collapses any whitespace sequence to a single space and trims

## Test plan
- [ ] `./gradlew :bpmn-to-code-core:test` passes (140 tests)
- [ ] Generated `name` properties are now single-line strings