### PR TITLE
refactor: emit KDoc on generated ProcessApi

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
@@ -101,6 +101,11 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val elementIdClass = ClassName.get("${modelApi.packagePath}.types", "ElementId")
             val elementsBuilder = TypeSpec.classBuilder("Elements").addModifiers(PUBLIC, STATIC, FINAL)
+                .addJavadoc(
+                    "BPMN element ids as declared in the source model.\n" +
+                        "Typically used in process-level tests or when searching for tasks.\n" +
+                        "Worker runtime code rarely needs these.\n"
+                )
             modelApi.model.flowNodes.forEach { flowNode ->
                 elementsBuilder.addField(createTypedAttribute(flowNode, elementIdClass))
             }
@@ -163,6 +168,11 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
     private fun buildFlowsClass(packagePath: String, sequenceFlows: List<SequenceFlowDefinition>): TypeSpec {
         val bpmnFlowClass = ClassName.get("${packagePath}.types", "BpmnFlow")
         val flowsBuilder = TypeSpec.classBuilder("Flows").addModifiers(PUBLIC, STATIC, FINAL)
+            .addJavadoc(
+                "Sequence flows between BPMN elements.\n" +
+                    "Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.\n" +
+                    "Worker code typically does not need these.\n"
+            )
         sequenceFlows.forEach { flow ->
             val initCode = buildFlowInitializer(bpmnFlowClass, flow.id ?: "", flow.flowName, flow.sourceRef, flow.targetRef, flow.conditionExpression, flow.isDefault)
             val fieldBuilder = FieldSpec.builder(bpmnFlowClass, flow.getName()).addModifiers(PUBLIC, STATIC, FINAL)
@@ -186,6 +196,10 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
     private fun buildRelationsClass(packagePath: String, flowNodes: List<FlowNodeDefinition>): TypeSpec {
         val bpmnRelationsClass = ClassName.get("${packagePath}.types", "BpmnRelations")
         val relationsBuilder = TypeSpec.classBuilder("Relations").addModifiers(PUBLIC, STATIC, FINAL)
+            .addJavadoc(
+                "Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).\n" +
+                    "Intended for tooling and tests, not worker runtime code.\n"
+            )
         flowNodes
             .filter { it.id != null }
             .sortedBy { it.getRawName() }
@@ -254,6 +268,7 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val messageNameClass = ClassName.get("${modelApi.packagePath}.types", "MessageName")
             val messagesBuilder = TypeSpec.classBuilder("Messages").addModifiers(PUBLIC, STATIC, FINAL)
+                .addJavadoc("BPMN message names used to correlate messages to running process instances.\n")
             modelApi.model.messages.forEach { message ->
                 messagesBuilder.addField(createTypedAttribute(message, messageNameClass))
             }
@@ -261,11 +276,6 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         }
     }
 
-    /**
-     * `ServiceTasks` intentionally emits `public static final String` rather than a typed wrapper.
-     * Its primary call site is `@JobWorker(type = ServiceTasks.X)` — Java annotation arguments
-     * require compile-time constants, which rules out record instances.
-     */
     private inner class ServiceTasksWriter : ObjectWriter<TypeSpec.Builder> {
 
         override val objectType = ApiObjectType.SERVICE_TASKS
@@ -274,9 +284,8 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val tasksBuilder = TypeSpec.classBuilder("ServiceTasks").addModifiers(PUBLIC, STATIC, FINAL)
                 .addJavadoc(
-                    "Task identifiers used as {@code @JobWorker(type = ...)} annotation arguments. Stays " +
-                        "{@code public static final String} because Java annotation arguments must be " +
-                        "compile-time constants, which excludes record instances."
+                    "Job worker task types used in {@code @JobWorker(type = ServiceTasks.X)} annotations.\n" +
+                        "Kept as {@code public static final String} because annotation arguments must be compile-time constants.\n"
                 )
             modelApi.model.serviceTasks
                 .filter { it.getRawName().isNotEmpty() }
@@ -308,6 +317,10 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val variableNameClass = ClassName.get("${modelApi.packagePath}.types", "VariableName")
             val variablesBuilder = TypeSpec.classBuilder("Variables").addModifiers(PUBLIC, STATIC, FINAL)
+                .addJavadoc(
+                    "Process variables grouped by the BPMN element that declares them.\n" +
+                        "When the element has explicit IO mappings, variables are further split into {@code Inputs} and {@code Outputs}; otherwise they appear as a flat list.\n"
+                )
             modelApi.model.flowNodes
                 .filter { it.variables.isNotEmpty() }
                 .sortedBy { it.getRawName() }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -107,7 +107,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             val elementsBuilder = TypeSpec.objectBuilder("Elements")
                 .addKdoc(
                     "BPMN element ids as declared in the source model.\n" +
-                        "Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling.\n" +
+                        "Typically used in process-level tests or when searching for tasks.\n" +
                         "Worker runtime code rarely needs these."
                 )
             modelApi.model.flowNodes.forEach { flowNode ->
@@ -283,9 +283,8 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val tasksBuilder = TypeSpec.objectBuilder("ServiceTasks")
                 .addKdoc(
-                    "Engine task types.\n" +
-                        "Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments.\n" +
-                        "This is why their shape differs from other constants in this API."
+                    "Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.\n" +
+                        "Kept as `const val String` because annotation arguments must be compile-time constants."
                 )
             modelApi.model.serviceTasks
                 .filter { it.getRawName().isNotEmpty() }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -106,8 +106,9 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             val elementIdClass = ClassName("${modelApi.packagePath}.types", "ElementId")
             val elementsBuilder = TypeSpec.objectBuilder("Elements")
                 .addKdoc(
-                    "BPMN element ids as declared in the source model. Typically used in process-level tests " +
-                        "(e.g. `startProcessAt(Elements.X)`) and by tooling. Worker runtime code rarely needs these."
+                    "BPMN element ids as declared in the source model.\n" +
+                        "Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling.\n" +
+                        "Worker runtime code rarely needs these."
                 )
             modelApi.model.flowNodes.forEach { flowNode ->
                 elementsBuilder.addProperty(createTypedAttribute(flowNode, elementIdClass))
@@ -172,8 +173,9 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         val bpmnFlowClass = ClassName("${packagePath}.types", "BpmnFlow")
         val flowsBuilder = TypeSpec.objectBuilder("Flows")
             .addKdoc(
-                "Sequence flows between BPMN elements. Mainly useful for process-model tooling, tests, and " +
-                    "AI-agent consumers reasoning about the process shape. Worker code typically does not need these."
+                "Sequence flows between BPMN elements.\n" +
+                    "Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.\n" +
+                    "Worker code typically does not need these."
             )
         sequenceFlows.forEach { flow ->
             val initStr = buildFlowInitializer(flow.id ?: "", flow.flowName, flow.sourceRef, flow.targetRef, flow.conditionExpression, flow.isDefault)
@@ -201,7 +203,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         val bpmnRelationsClass = ClassName("${packagePath}.types", "BpmnRelations")
         val relationsBuilder = TypeSpec.objectBuilder("Relations")
             .addKdoc(
-                "Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments). " +
+                "Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).\n" +
                     "Intended for tooling and tests, not worker runtime code."
             )
         flowNodes
@@ -281,9 +283,9 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val tasksBuilder = TypeSpec.objectBuilder("ServiceTasks")
                 .addKdoc(
-                    "Engine task types. Kept as `const val String` because they are used in `@JobWorker(type = ...)` " +
-                        "annotations, which cannot accept value-class arguments. This is why their shape differs " +
-                        "from other constants in this API."
+                    "Engine task types.\n" +
+                        "Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments.\n" +
+                        "This is why their shape differs from other constants in this API."
                 )
             modelApi.model.serviceTasks
                 .filter { it.getRawName().isNotEmpty() }
@@ -316,9 +318,8 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             val variableNameClass = ClassName("${modelApi.packagePath}.types", "VariableName")
             val variablesBuilder = TypeSpec.objectBuilder("Variables")
                 .addKdoc(
-                    "Process variables grouped by the BPMN element that declares them. When the element has " +
-                        "explicit IO mappings, variables are further split into `Inputs` and `Outputs`; " +
-                        "otherwise they appear as a flat list."
+                    "Process variables grouped by the BPMN element that declares them.\n" +
+                        "When the element has explicit IO mappings, variables are further split into `Inputs` and `Outputs`; otherwise they appear as a flat list."
                 )
             modelApi.model.flowNodes
                 .filter { it.variables.isNotEmpty() }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -105,6 +105,10 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val elementIdClass = ClassName("${modelApi.packagePath}.types", "ElementId")
             val elementsBuilder = TypeSpec.objectBuilder("Elements")
+                .addKdoc(
+                    "BPMN element ids as declared in the source model. Typically used in process-level tests " +
+                        "(e.g. `startProcessAt(Elements.X)`) and by tooling. Worker runtime code rarely needs these."
+                )
             modelApi.model.flowNodes.forEach { flowNode ->
                 elementsBuilder.addProperty(createTypedAttribute(flowNode, elementIdClass))
             }
@@ -167,6 +171,10 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
     private fun buildFlowsObject(packagePath: String, sequenceFlows: List<SequenceFlowDefinition>): TypeSpec {
         val bpmnFlowClass = ClassName("${packagePath}.types", "BpmnFlow")
         val flowsBuilder = TypeSpec.objectBuilder("Flows")
+            .addKdoc(
+                "Sequence flows between BPMN elements. Mainly useful for process-model tooling, tests, and " +
+                    "AI-agent consumers reasoning about the process shape. Worker code typically does not need these."
+            )
         sequenceFlows.forEach { flow ->
             val initStr = buildFlowInitializer(flow.id ?: "", flow.flowName, flow.sourceRef, flow.targetRef, flow.conditionExpression, flow.isDefault)
             flowsBuilder.addProperty(PropertySpec.builder(flow.getName(), bpmnFlowClass).initializer(initStr).build())
@@ -192,6 +200,10 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
     private fun buildRelationsObject(packagePath: String, flowNodes: List<FlowNodeDefinition>): TypeSpec {
         val bpmnRelationsClass = ClassName("${packagePath}.types", "BpmnRelations")
         val relationsBuilder = TypeSpec.objectBuilder("Relations")
+            .addKdoc(
+                "Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments). " +
+                    "Intended for tooling and tests, not worker runtime code."
+            )
         flowNodes
             .filter { it.id != null }
             .sortedBy { it.getRawName() }
@@ -248,6 +260,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val messageNameClass = ClassName("${modelApi.packagePath}.types", "MessageName")
             val messagesBuilder = TypeSpec.objectBuilder("Messages")
+                .addKdoc("BPMN message names used to correlate messages to running process instances.")
             modelApi.model.messages.forEach { message ->
                 messagesBuilder.addProperty(createTypedAttribute(message, messageNameClass))
             }
@@ -268,9 +281,9 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val tasksBuilder = TypeSpec.objectBuilder("ServiceTasks")
                 .addKdoc(
-                    "Task identifiers used as `@JobWorker(type = ...)` annotation arguments. Stays `const val String` " +
-                        "because Kotlin annotation arguments must be compile-time constants, which excludes " +
-                        "`@JvmInline value class` instances."
+                    "Engine task types. Kept as `const val String` because they are used in `@JobWorker(type = ...)` " +
+                        "annotations, which cannot accept value-class arguments. This is why their shape differs " +
+                        "from other constants in this API."
                 )
             modelApi.model.serviceTasks
                 .filter { it.getRawName().isNotEmpty() }
@@ -302,6 +315,11 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val variableNameClass = ClassName("${modelApi.packagePath}.types", "VariableName")
             val variablesBuilder = TypeSpec.objectBuilder("Variables")
+                .addKdoc(
+                    "Process variables grouped by the BPMN element that declares them. When the element has " +
+                        "explicit IO mappings, variables are further split into `Inputs` and `Outputs`; " +
+                        "otherwise they appear as a flat list."
+                )
             modelApi.model.flowNodes
                 .filter { it.variables.isNotEmpty() }
                 .sortedBy { it.getRawName() }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
@@ -69,7 +69,11 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
     private fun buildBpmnTimerFile(typesPackage: String, language: OutputLanguage): GeneratedApiFile {
         val typeSpec = TypeSpec.classBuilder("BpmnTimer")
             .addModifiers(KModifier.DATA)
-            .addKdoc("A BPMN timer definition.\n`type` is one of `Duration`, `Date`, or `Cycle`.")
+            .addKdoc(
+                "A BPMN timer definition.\n\n" +
+                    "@param type One of `Duration`, `Date`, or `Cycle`.\n" +
+                    "@param timerValue The timer expression (ISO 8601 duration, date, or cycle).\n"
+            )
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("type", STRING)
@@ -85,7 +89,11 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
     private fun buildBpmnErrorFile(typesPackage: String, language: OutputLanguage): GeneratedApiFile {
         val typeSpec = TypeSpec.classBuilder("BpmnError")
             .addModifiers(KModifier.DATA)
-            .addKdoc("A BPMN error definition referenced by error catch events and error end events.")
+            .addKdoc(
+                "A BPMN error definition referenced by error catch events and error end events.\n\n" +
+                    "@param name The error name as declared in the BPMN model.\n" +
+                    "@param code The error code used to match catch events at runtime.\n"
+            )
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("name", STRING)
@@ -101,7 +109,11 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
     private fun buildBpmnEscalationFile(typesPackage: String, language: OutputLanguage): GeneratedApiFile {
         val typeSpec = TypeSpec.classBuilder("BpmnEscalation")
             .addModifiers(KModifier.DATA)
-            .addKdoc("A BPMN escalation definition referenced by escalation catch events and escalation end events.")
+            .addKdoc(
+                "A BPMN escalation definition referenced by escalation catch events and escalation end events.\n\n" +
+                    "@param name The escalation name as declared in the BPMN model.\n" +
+                    "@param code The escalation code used to match catch events at runtime.\n"
+            )
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("name", STRING)
@@ -120,7 +132,10 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
             .addModifiers(KModifier.DATA)
             .addKdoc(
                 "A BPMN sequence flow connecting two elements in the process graph.\n\n" +
+                    "@param id The sequence flow id as declared in the BPMN model.\n" +
                     "@param name Label of the flow as shown in the BPMN diagram; null when unlabelled.\n" +
+                    "@param sourceRef Element id of the flow's source node.\n" +
+                    "@param targetRef Element id of the flow's target node.\n" +
                     "@param condition Condition expression evaluated at runtime; null for unconditional flows.\n" +
                     "@param isDefault True when this is the default flow of an exclusive or inclusive gateway.\n"
             )
@@ -151,10 +166,12 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
             .addModifiers(KModifier.DATA)
             .addKdoc(
                 "Per-element graph metadata capturing an element's neighbours in the process flow.\n\n" +
+                    "@param name Display name of the element, if set in the BPMN model.\n" +
                     "@param previousElements Element ids of preceding flow nodes — not sequence-flow ids (see `Flows`).\n" +
                     "@param followingElements Element ids of following flow nodes — not sequence-flow ids (see `Flows`).\n" +
                     "@param parentId Id of the containing subprocess, or null if top-level.\n" +
-                    "@param attachedToRef For boundary events: id of the host element; null otherwise.\n"
+                    "@param attachedToRef For boundary events: id of the host element; null otherwise.\n" +
+                    "@param attachedElements Ids of boundary events attached to this element; empty when none.\n"
             )
             .primaryConstructor(
                 FunSpec.constructorBuilder()

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
@@ -151,12 +151,10 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
             .addModifiers(KModifier.DATA)
             .addKdoc(
                 "Per-element graph metadata capturing an element's neighbours in the process flow.\n\n" +
-                    "@param previousElements Ids of the immediately preceding flow nodes. These are element ids,\n" +
-                    "    not sequence-flow ids — use `Flows` for edge data.\n" +
-                    "@param followingElements Ids of the immediately following flow nodes. These are element ids,\n" +
-                    "    not sequence-flow ids.\n" +
-                    "@param parentId Id of the containing subprocess element, or null if the element is top-level.\n" +
-                    "@param attachedToRef For boundary events: id of the host element; null for all other types.\n"
+                    "@param previousElements Element ids of preceding flow nodes — not sequence-flow ids (see `Flows`).\n" +
+                    "@param followingElements Element ids of following flow nodes — not sequence-flow ids (see `Flows`).\n" +
+                    "@param parentId Id of the containing subprocess, or null if top-level.\n" +
+                    "@param attachedToRef For boundary events: id of the host element; null otherwise.\n"
             )
             .primaryConstructor(
                 FunSpec.constructorBuilder()

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
@@ -69,6 +69,7 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
     private fun buildBpmnTimerFile(typesPackage: String, language: OutputLanguage): GeneratedApiFile {
         val typeSpec = TypeSpec.classBuilder("BpmnTimer")
             .addModifiers(KModifier.DATA)
+            .addKdoc("A BPMN timer definition. `type` is one of `Duration`, `Date`, or `Cycle`.")
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("type", STRING)
@@ -84,6 +85,7 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
     private fun buildBpmnErrorFile(typesPackage: String, language: OutputLanguage): GeneratedApiFile {
         val typeSpec = TypeSpec.classBuilder("BpmnError")
             .addModifiers(KModifier.DATA)
+            .addKdoc("A BPMN error definition referenced by error catch events and error end events.")
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("name", STRING)
@@ -99,6 +101,7 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
     private fun buildBpmnEscalationFile(typesPackage: String, language: OutputLanguage): GeneratedApiFile {
         val typeSpec = TypeSpec.classBuilder("BpmnEscalation")
             .addModifiers(KModifier.DATA)
+            .addKdoc("A BPMN escalation definition referenced by escalation catch events and escalation end events.")
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("name", STRING)
@@ -115,6 +118,12 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
         val nullableString = STRING.copy(nullable = true)
         val typeSpec = TypeSpec.classBuilder("BpmnFlow")
             .addModifiers(KModifier.DATA)
+            .addKdoc(
+                "A BPMN sequence flow connecting two elements in the process graph.\n\n" +
+                    "@param name Label of the flow as shown in the BPMN diagram; null when unlabelled.\n" +
+                    "@param condition Condition expression evaluated at runtime; null for unconditional flows.\n" +
+                    "@param isDefault True when this is the default flow of an exclusive or inclusive gateway.\n"
+            )
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("id", STRING)
@@ -140,6 +149,15 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
         val nullableString = STRING.copy(nullable = true)
         val typeSpec = TypeSpec.classBuilder("BpmnRelations")
             .addModifiers(KModifier.DATA)
+            .addKdoc(
+                "Per-element graph metadata capturing an element's neighbours in the process flow.\n\n" +
+                    "@param previousElements Ids of the immediately preceding flow nodes. These are element ids,\n" +
+                    "    not sequence-flow ids — use `Flows` for edge data.\n" +
+                    "@param followingElements Ids of the immediately following flow nodes. These are element ids,\n" +
+                    "    not sequence-flow ids.\n" +
+                    "@param parentId Id of the containing subprocess element, or null if the element is top-level.\n" +
+                    "@param attachedToRef For boundary events: id of the host element; null for all other types.\n"
+            )
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter(ParameterSpec.builder("name", nullableString).defaultValue("null").build())

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilder.kt
@@ -69,7 +69,7 @@ class KotlinSharedTypesBuilder : CodeGenerationAdapter.AbstractSharedTypesBuilde
     private fun buildBpmnTimerFile(typesPackage: String, language: OutputLanguage): GeneratedApiFile {
         val typeSpec = TypeSpec.classBuilder("BpmnTimer")
             .addModifiers(KModifier.DATA)
-            .addKdoc("A BPMN timer definition. `type` is one of `Duration`, `Date`, or `Cycle`.")
+            .addKdoc("A BPMN timer definition.\n`type` is one of `Duration`, `Date`, or `Cycle`.")
             .primaryConstructor(
                 FunSpec.constructorBuilder()
                     .addParameter("type", STRING)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
@@ -58,7 +58,7 @@ class KotlinProcessApiBuilderTest {
 
         // and: key KDoc blocks disambiguate the nested objects
         assertThat(result.content).contains("process-level tests")
-        assertThat(result.content).contains("@JobWorker(type = ...)")
+        assertThat(result.content).contains("@JobWorker(type = ServiceTasks.X)")
         assertThat(result.content).contains("Worker code typically does not need these")
         assertThat(result.content).contains("tooling and tests, not worker runtime code")
     }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilderTest.kt
@@ -55,6 +55,12 @@ class KotlinProcessApiBuilderTest {
         val expectedFile = File(requireNotNull(javaClass.getResource("/api/NewsletterSubscriptionProcessApiKotlin.txt")).toURI())
         assertThat(result.content).isEqualTo(expectedFile.readText())
         assertKotlinSyntaxValid(result.content)
+
+        // and: key KDoc blocks disambiguate the nested objects
+        assertThat(result.content).contains("process-level tests")
+        assertThat(result.content).contains("@JobWorker(type = ...)")
+        assertThat(result.content).contains("Worker code typically does not need these")
+        assertThat(result.content).contains("tooling and tests, not worker runtime code")
     }
 
     @Test

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilderTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinSharedTypesBuilderTest.kt
@@ -51,6 +51,13 @@ class KotlinSharedTypesBuilderTest {
             assertThat(typeFile.content).isEqualToIgnoringWhitespace(File(fixtureResource.toURI()).readText())
             assertKotlinSyntaxValid(typeFile.content)
         }
+
+        // and: key KDoc blocks are present in the relevant type files
+        val relationsFile = results.first { it.fileName == "BpmnRelations.kt" }
+        assertThat(relationsFile.content).contains("not sequence-flow ids")
+
+        val flowFile = results.first { it.fileName == "BpmnFlow.kt" }
+        assertThat(flowFile.content).contains("default flow")
     }
 
     companion object {

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
@@ -18,6 +18,11 @@ public final class SendNewsletterProcessApi {
 
   public static final BpmnEngine PROCESS_ENGINE = BpmnEngine.ZEEBE;
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   public static final class Elements {
     public static final ElementId START_EVENT_EDITION_CREATED = new ElementId("startEvent_editionCreated");
 
@@ -56,6 +61,9 @@ public final class SendNewsletterProcessApi {
     public static final ElementId END_EVENT_ISSUE_RESOLVED = new ElementId("endEvent_issueResolved");
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   public static final class Messages {
     public static final MessageName MESSAGE_MAIL_REJECTED = new MessageName("Message_MailRejected");
 
@@ -63,7 +71,8 @@ public final class SendNewsletterProcessApi {
   }
 
   /**
-   * Task identifiers used as {@code @JobWorker(type = ...)} annotation arguments. Stays {@code public static final String} because Java annotation arguments must be compile-time constants, which excludes record instances.
+   * Job worker task types used in {@code @JobWorker(type = ServiceTasks.X)} annotations.
+   * Kept as {@code public static final String} because annotation arguments must be compile-time constants.
    */
   public static final class ServiceTasks {
     public static final String NEWSLETTER_ANALYZE_SEND_ERROR = "newsletter.analyzeSendError";
@@ -83,6 +92,10 @@ public final class SendNewsletterProcessApi {
     public static final BpmnEscalation ESCALATION_NOTIFY_SUPPORT = new BpmnEscalation("escalation_notifySupport", "200");
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * When the element has explicit IO mappings, variables are further split into {@code Inputs} and {@code Outputs}; otherwise they appear as a flat list.
+   */
   public static final class Variables {
     public static final class ServiceTaskLoadSubscribers {
       public static final class Outputs {
@@ -95,6 +108,11 @@ public final class SendNewsletterProcessApi {
 
   public static final class Variants {
     public static final class Send {
+      /**
+       * Sequence flows between BPMN elements.
+       * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+       * Worker code typically does not need these.
+       */
       public static final class Flows {
         public static final BpmnFlow FLOW_0_BIANZ_5 = new BpmnFlow("Flow_0bianz5", null, "startEvent_editionCreated", "serviceTask_loadSubscribers", null, false);
 
@@ -127,6 +145,10 @@ public final class SendNewsletterProcessApi {
         public static final BpmnFlow FLOW_0338_XZF = new BpmnFlow("Flow_0338xzf", null, "timer_noRejectionForOneDay", "endEvent_issueResolved", null, false);
       }
 
+      /**
+       * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+       * Intended for tooling and tests, not worker runtime code.
+       */
       public static final class Relations {
         public static final BpmnRelations END_EVENT_EDITION_SENT = new BpmnRelations(null, List.of("serviceTask_notifyAuthor"), List.of(), null, null, List.of());
 

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -22,7 +22,7 @@ object SendNewsletterProcessApi {
 
   /**
    * BPMN element ids as declared in the source model.
-   * Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling.
+   * Typically used in process-level tests or when searching for tasks.
    * Worker runtime code rarely needs these.
    */
   object Elements {
@@ -78,9 +78,8 @@ object SendNewsletterProcessApi {
   }
 
   /**
-   * Engine task types.
-   * Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments.
-   * This is why their shape differs from other constants in this API.
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
    */
   object ServiceTasks {
     const val NEWSLETTER_ANALYZE_SEND_ERROR: String = "newsletter.analyzeSendError"

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -20,6 +20,9 @@ object SendNewsletterProcessApi {
 
   val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model. Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling. Worker runtime code rarely needs these.
+   */
   object Elements {
     val START_EVENT_EDITION_CREATED: ElementId = ElementId("startEvent_editionCreated")
 
@@ -63,6 +66,9 @@ object SendNewsletterProcessApi {
     val END_EVENT_ISSUE_RESOLVED: ElementId = ElementId("endEvent_issueResolved")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
     val MESSAGE_MAIL_REJECTED: MessageName = MessageName("Message_MailRejected")
 
@@ -70,7 +76,7 @@ object SendNewsletterProcessApi {
   }
 
   /**
-   * Task identifiers used as `@JobWorker(type = ...)` annotation arguments. Stays `const val String` because Kotlin annotation arguments must be compile-time constants, which excludes `@JvmInline value class` instances.
+   * Engine task types. Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments. This is why their shape differs from other constants in this API.
    */
   object ServiceTasks {
     const val NEWSLETTER_ANALYZE_SEND_ERROR: String = "newsletter.analyzeSendError"
@@ -91,6 +97,9 @@ object SendNewsletterProcessApi {
         BpmnEscalation("escalation_notifySupport", "200")
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them. When the element has explicit IO mappings, variables are further split into `Inputs` and `Outputs`; otherwise they appear as a flat list.
+   */
   object Variables {
     object ServiceTaskLoadSubscribers {
       object Outputs {
@@ -103,6 +112,9 @@ object SendNewsletterProcessApi {
 
   object Variants {
     object Send {
+      /**
+       * Sequence flows between BPMN elements. Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape. Worker code typically does not need these.
+       */
       object Flows {
         val FLOW_0_BIANZ_5: BpmnFlow = BpmnFlow(
               id = "Flow_0bianz5",
@@ -203,6 +215,9 @@ object SendNewsletterProcessApi {
             )
       }
 
+      /**
+       * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments). Intended for tooling and tests, not worker runtime code.
+       */
       object Relations {
         val END_EVENT_EDITION_SENT: BpmnRelations = BpmnRelations(
               previousElements = listOf("serviceTask_notifyAuthor"),

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -21,7 +21,9 @@ object SendNewsletterProcessApi {
   val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
   /**
-   * BPMN element ids as declared in the source model. Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling. Worker runtime code rarely needs these.
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling.
+   * Worker runtime code rarely needs these.
    */
   object Elements {
     val START_EVENT_EDITION_CREATED: ElementId = ElementId("startEvent_editionCreated")
@@ -76,7 +78,9 @@ object SendNewsletterProcessApi {
   }
 
   /**
-   * Engine task types. Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments. This is why their shape differs from other constants in this API.
+   * Engine task types.
+   * Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments.
+   * This is why their shape differs from other constants in this API.
    */
   object ServiceTasks {
     const val NEWSLETTER_ANALYZE_SEND_ERROR: String = "newsletter.analyzeSendError"
@@ -98,7 +102,8 @@ object SendNewsletterProcessApi {
   }
 
   /**
-   * Process variables grouped by the BPMN element that declares them. When the element has explicit IO mappings, variables are further split into `Inputs` and `Outputs`; otherwise they appear as a flat list.
+   * Process variables grouped by the BPMN element that declares them.
+   * When the element has explicit IO mappings, variables are further split into `Inputs` and `Outputs`; otherwise they appear as a flat list.
    */
   object Variables {
     object ServiceTaskLoadSubscribers {
@@ -113,7 +118,9 @@ object SendNewsletterProcessApi {
   object Variants {
     object Send {
       /**
-       * Sequence flows between BPMN elements. Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape. Worker code typically does not need these.
+       * Sequence flows between BPMN elements.
+       * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+       * Worker code typically does not need these.
        */
       object Flows {
         val FLOW_0_BIANZ_5: BpmnFlow = BpmnFlow(
@@ -216,7 +223,8 @@ object SendNewsletterProcessApi {
       }
 
       /**
-       * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments). Intended for tooling and tests, not worker runtime code.
+       * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+       * Intended for tooling and tests, not worker runtime code.
        */
       object Relations {
         val END_EVENT_EDITION_SENT: BpmnRelations = BpmnRelations(

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiJava.txt
@@ -19,6 +19,11 @@ public final class NewsletterSubscriptionProcessApi {
 
   public static final BpmnEngine PROCESS_ENGINE = BpmnEngine.ZEEBE;
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   public static final class Elements {
     public static final ElementId CALL_ACTIVITY_ABORT_REGISTRATION = new ElementId("CallActivity_AbortRegistration");
 
@@ -59,12 +64,16 @@ public final class NewsletterSubscriptionProcessApi {
     public static final ProcessId CALL_ACTIVITY_ABORT_REGISTRATION = new ProcessId("abort-registration");
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   public static final class Messages {
     public static final MessageName MESSAGE_FORM_SUBMITTED = new MessageName("Message_FormSubmitted");
   }
 
   /**
-   * Task identifiers used as {@code @JobWorker(type = ...)} annotation arguments. Stays {@code public static final String} because Java annotation arguments must be compile-time constants, which excludes record instances.
+   * Job worker task types used in {@code @JobWorker(type = ServiceTasks.X)} annotations.
+   * Kept as {@code public static final String} because annotation arguments must be compile-time constants.
    */
   public static final class ServiceTasks {
     public static final String NEWSLETTER_SEND_CONFIRMATION_MAIL = "#{newsletterSendConfirmationMail}";
@@ -96,6 +105,10 @@ public final class NewsletterSubscriptionProcessApi {
     public static final SignalName SIGNAL_REGISTRATION_NOT_POSSIBLE = new SignalName("Signal_RegistrationNotPossible");
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * When the element has explicit IO mappings, variables are further split into {@code Inputs} and {@code Outputs}; otherwise they appear as a flat list.
+   */
   public static final class Variables {
     public static final class ActivitySendConfirmationMail {
       public static final class Inputs {
@@ -136,6 +149,11 @@ public final class NewsletterSubscriptionProcessApi {
     }
   }
 
+  /**
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
+   */
   public static final class Flows {
     public static final BpmnFlow FLOW_05_I_3_X_1_Y = new BpmnFlow("Flow_05i3x1y", null, "StartEvent_RequestReceived", "Activity_SendConfirmationMail", null, false);
 
@@ -160,6 +178,10 @@ public final class NewsletterSubscriptionProcessApi {
     public static final BpmnFlow FLOW_1_L_1_LJ_4_M = new BpmnFlow("Flow_1l1lj4m", null, "Timer_After3Days", "CallActivity_AbortRegistration", null, false);
   }
 
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
+   */
   public static final class Relations {
     public static final BpmnRelations ACTIVITY_CONFIRM_REGISTRATION = new BpmnRelations("Confirm registration", List.of("Activity_SendConfirmationMail"), List.of("EndEvent_SubscriptionConfirmed"), "SubProcess_Confirmation", null, List.of("Timer_EveryDay"));
 

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -23,7 +23,7 @@ object NewsletterSubscriptionProcessApi {
 
   /**
    * BPMN element ids as declared in the source model.
-   * Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling.
+   * Typically used in process-level tests or when searching for tasks.
    * Worker runtime code rarely needs these.
    */
   object Elements {
@@ -84,9 +84,8 @@ object NewsletterSubscriptionProcessApi {
   }
 
   /**
-   * Engine task types.
-   * Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments.
-   * This is why their shape differs from other constants in this API.
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
    */
   object ServiceTasks {
     const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -21,6 +21,9 @@ object NewsletterSubscriptionProcessApi {
 
   val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model. Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling. Worker runtime code rarely needs these.
+   */
   object Elements {
     val CALL_ACTIVITY_ABORT_REGISTRATION: ElementId =
         ElementId("CallActivity_AbortRegistration")
@@ -71,12 +74,15 @@ object NewsletterSubscriptionProcessApi {
     val CALL_ACTIVITY_ABORT_REGISTRATION: ProcessId = ProcessId("abort-registration")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
     val MESSAGE_FORM_SUBMITTED: MessageName = MessageName("Message_FormSubmitted")
   }
 
   /**
-   * Task identifiers used as `@JobWorker(type = ...)` annotation arguments. Stays `const val String` because Kotlin annotation arguments must be compile-time constants, which excludes `@JvmInline value class` instances.
+   * Engine task types. Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments. This is why their shape differs from other constants in this API.
    */
   object ServiceTasks {
     const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"
@@ -111,6 +117,9 @@ object NewsletterSubscriptionProcessApi {
         SignalName("Signal_RegistrationNotPossible")
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them. When the element has explicit IO mappings, variables are further split into `Inputs` and `Outputs`; otherwise they appear as a flat list.
+   */
   object Variables {
     object ActivitySendConfirmationMail {
       object Inputs {
@@ -151,6 +160,9 @@ object NewsletterSubscriptionProcessApi {
     }
   }
 
+  /**
+   * Sequence flows between BPMN elements. Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape. Worker code typically does not need these.
+   */
   object Flows {
     val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
           id = "Flow_05i3x1y",
@@ -219,6 +231,9 @@ object NewsletterSubscriptionProcessApi {
         )
   }
 
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments). Intended for tooling and tests, not worker runtime code.
+   */
   object Relations {
     val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(
           name = "Confirm registration",

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -22,7 +22,9 @@ object NewsletterSubscriptionProcessApi {
   val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
   /**
-   * BPMN element ids as declared in the source model. Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling. Worker runtime code rarely needs these.
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests (e.g. `startProcessAt(Elements.X)`) and by tooling.
+   * Worker runtime code rarely needs these.
    */
   object Elements {
     val CALL_ACTIVITY_ABORT_REGISTRATION: ElementId =
@@ -82,7 +84,9 @@ object NewsletterSubscriptionProcessApi {
   }
 
   /**
-   * Engine task types. Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments. This is why their shape differs from other constants in this API.
+   * Engine task types.
+   * Kept as `const val String` because they are used in `@JobWorker(type = ...)` annotations, which cannot accept value-class arguments.
+   * This is why their shape differs from other constants in this API.
    */
   object ServiceTasks {
     const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"
@@ -118,7 +122,8 @@ object NewsletterSubscriptionProcessApi {
   }
 
   /**
-   * Process variables grouped by the BPMN element that declares them. When the element has explicit IO mappings, variables are further split into `Inputs` and `Outputs`; otherwise they appear as a flat list.
+   * Process variables grouped by the BPMN element that declares them.
+   * When the element has explicit IO mappings, variables are further split into `Inputs` and `Outputs`; otherwise they appear as a flat list.
    */
   object Variables {
     object ActivitySendConfirmationMail {
@@ -161,7 +166,9 @@ object NewsletterSubscriptionProcessApi {
   }
 
   /**
-   * Sequence flows between BPMN elements. Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape. Worker code typically does not need these.
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
    */
   object Flows {
     val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
@@ -232,7 +239,8 @@ object NewsletterSubscriptionProcessApi {
   }
 
   /**
-   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments). Intended for tooling and tests, not worker runtime code.
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
    */
   object Relations {
     val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnErrorKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnErrorKotlin.txt
@@ -5,6 +5,9 @@ import kotlin.String
 
 /**
  * A BPMN error definition referenced by error catch events and error end events.
+ *
+ * @param name The error name as declared in the BPMN model.
+ * @param code The error code used to match catch events at runtime.
  */
 data class BpmnError(
   val name: String,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnErrorKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnErrorKotlin.txt
@@ -3,6 +3,9 @@ package de.emaarco.example.types
 
 import kotlin.String
 
+/**
+ * A BPMN error definition referenced by error catch events and error end events.
+ */
 data class BpmnError(
   val name: String,
   val code: String,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnEscalationKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnEscalationKotlin.txt
@@ -5,6 +5,9 @@ import kotlin.String
 
 /**
  * A BPMN escalation definition referenced by escalation catch events and escalation end events.
+ *
+ * @param name The escalation name as declared in the BPMN model.
+ * @param code The escalation code used to match catch events at runtime.
  */
 data class BpmnEscalation(
   val name: String,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnEscalationKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnEscalationKotlin.txt
@@ -3,6 +3,9 @@ package de.emaarco.example.types
 
 import kotlin.String
 
+/**
+ * A BPMN escalation definition referenced by escalation catch events and escalation end events.
+ */
 data class BpmnEscalation(
   val name: String,
   val code: String,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnFlowKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnFlowKotlin.txt
@@ -4,6 +4,13 @@ package de.emaarco.example.types
 import kotlin.Boolean
 import kotlin.String
 
+/**
+ * A BPMN sequence flow connecting two elements in the process graph.
+ *
+ * @param name Label of the flow as shown in the BPMN diagram; null when unlabelled.
+ * @param condition Condition expression evaluated at runtime; null for unconditional flows.
+ * @param isDefault True when this is the default flow of an exclusive or inclusive gateway.
+ */
 data class BpmnFlow(
   val id: String,
   val name: String? = null,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnFlowKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnFlowKotlin.txt
@@ -7,7 +7,10 @@ import kotlin.String
 /**
  * A BPMN sequence flow connecting two elements in the process graph.
  *
+ * @param id The sequence flow id as declared in the BPMN model.
  * @param name Label of the flow as shown in the BPMN diagram; null when unlabelled.
+ * @param sourceRef Element id of the flow's source node.
+ * @param targetRef Element id of the flow's target node.
  * @param condition Condition expression evaluated at runtime; null for unconditional flows.
  * @param isDefault True when this is the default flow of an exclusive or inclusive gateway.
  */

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnRelationsKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnRelationsKotlin.txt
@@ -4,6 +4,16 @@ package de.emaarco.example.types
 import kotlin.String
 import kotlin.collections.List
 
+/**
+ * Per-element graph metadata capturing an element's neighbours in the process flow.
+ *
+ * @param previousElements Ids of the immediately preceding flow nodes. These are element ids,
+ *     not sequence-flow ids — use `Flows` for edge data.
+ * @param followingElements Ids of the immediately following flow nodes. These are element ids,
+ *     not sequence-flow ids.
+ * @param parentId Id of the containing subprocess element, or null if the element is top-level.
+ * @param attachedToRef For boundary events: id of the host element; null for all other types.
+ */
 data class BpmnRelations(
   val name: String? = null,
   val previousElements: List<String>,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnRelationsKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnRelationsKotlin.txt
@@ -7,12 +7,10 @@ import kotlin.collections.List
 /**
  * Per-element graph metadata capturing an element's neighbours in the process flow.
  *
- * @param previousElements Ids of the immediately preceding flow nodes. These are element ids,
- *     not sequence-flow ids — use `Flows` for edge data.
- * @param followingElements Ids of the immediately following flow nodes. These are element ids,
- *     not sequence-flow ids.
- * @param parentId Id of the containing subprocess element, or null if the element is top-level.
- * @param attachedToRef For boundary events: id of the host element; null for all other types.
+ * @param previousElements Element ids of preceding flow nodes — not sequence-flow ids (see `Flows`).
+ * @param followingElements Element ids of following flow nodes — not sequence-flow ids (see `Flows`).
+ * @param parentId Id of the containing subprocess, or null if top-level.
+ * @param attachedToRef For boundary events: id of the host element; null otherwise.
  */
 data class BpmnRelations(
   val name: String? = null,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnRelationsKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnRelationsKotlin.txt
@@ -7,10 +7,12 @@ import kotlin.collections.List
 /**
  * Per-element graph metadata capturing an element's neighbours in the process flow.
  *
+ * @param name Display name of the element, if set in the BPMN model.
  * @param previousElements Element ids of preceding flow nodes — not sequence-flow ids (see `Flows`).
  * @param followingElements Element ids of following flow nodes — not sequence-flow ids (see `Flows`).
  * @param parentId Id of the containing subprocess, or null if top-level.
  * @param attachedToRef For boundary events: id of the host element; null otherwise.
+ * @param attachedElements Ids of boundary events attached to this element; empty when none.
  */
 data class BpmnRelations(
   val name: String? = null,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnTimerKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnTimerKotlin.txt
@@ -5,7 +5,9 @@ import kotlin.String
 
 /**
  * A BPMN timer definition.
- * `type` is one of `Duration`, `Date`, or `Cycle`.
+ *
+ * @param type One of `Duration`, `Date`, or `Cycle`.
+ * @param timerValue The timer expression (ISO 8601 duration, date, or cycle).
  */
 data class BpmnTimer(
   val type: String,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnTimerKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnTimerKotlin.txt
@@ -4,7 +4,8 @@ package de.emaarco.example.types
 import kotlin.String
 
 /**
- * A BPMN timer definition. `type` is one of `Duration`, `Date`, or `Cycle`.
+ * A BPMN timer definition.
+ * `type` is one of `Duration`, `Date`, or `Cycle`.
  */
 data class BpmnTimer(
   val type: String,

--- a/bpmn-to-code-core/src/test/resources/api/types/BpmnTimerKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/types/BpmnTimerKotlin.txt
@@ -3,6 +3,9 @@ package de.emaarco.example.types
 
 import kotlin.String
 
+/**
+ * A BPMN timer definition. `type` is one of `Duration`, `Date`, or `Cycle`.
+ */
 data class BpmnTimer(
   val type: String,
   val timerValue: String,


### PR DESCRIPTION
Closes #292

## Summary

- Adds `addKdoc()` to all six top-level nested objects in the generated `*ProcessApi` (`Elements`, `Messages`, `ServiceTasks`, `Variables`, `Flows`, `Relations`)
- Adds class-level KDoc with `@param` docs for non-obvious fields to five shared data classes (`BpmnFlow`, `BpmnRelations`, `BpmnTimer`, `BpmnError`, `BpmnEscalation`)
- `BpmnRelations` KDoc explicitly states that `previousElements` / `followingElements` hold **element ids**, not sequence-flow ids
- `ServiceTasks` KDoc updated to match the issue's required text (explains why `const val String` instead of a typed wrapper)
- Updates all affected Kotlin fixture files and adds KDoc snippet assertions to both builder tests

## Out of scope

`BpmnMessage.correlationKey` is not addressed — `BpmnMessage` does not currently exist. Introducing it would require domain model changes and a breaking API change; tracked separately.