### PR TITLE
fix: publishToMavenLocal and generateBpmnModelJson failures

### DIFF
--- a/bpmn-to-code-gradle/build.gradle.kts
+++ b/bpmn-to-code-gradle/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(kotlin("stdlib"))
     api(libs.bpmnmodel)
     api(libs.bundles.codegen)
+    api(libs.kotlinxSerializationJson)
     api(libs.slf4jApi)
     api(libs.kotlinLogging)
     compileOnly(project(":bpmn-to-code-core"))

--- a/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginDependencyResolutionSmokeTest.kt
+++ b/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginDependencyResolutionSmokeTest.kt
@@ -73,4 +73,52 @@ class GradlePluginDependencyResolutionSmokeTest {
         val typesDir = generatedFiles.first { it.isDirectory && it.name == "types" }
         assertThat(requireNotNull(typesDir.listFiles())).allSatisfy { file -> assertThat(file.name).endsWith(".kt") }
     }
+
+    @Test
+    fun `generateBpmnModelJson resolves kotlinx-serialization from published artifact`(@TempDir projectDir: File) {
+
+        // given: a minimal project configured to resolve the plugin from mavenLocal
+        val resourcesDir = File(projectDir, "src/main/resources").also { it.mkdirs() }
+        val bpmnStream = requireNotNull(javaClass.classLoader.getResourceAsStream("bpmn/c8-subscribe-newsletter.bpmn"))
+        File(resourcesDir, "c8-subscribe-newsletter.bpmn").writeBytes(bpmnStream.readBytes())
+        File(projectDir, "settings.gradle").writeText(
+            """
+            pluginManagement {
+                repositories {
+                    mavenLocal()
+                    gradlePluginPortal()
+                    mavenCentral()
+                }
+            }
+            """.trimIndent()
+        )
+        File(projectDir, "build.gradle").writeText(
+            """
+            plugins {
+                id 'io.github.emaarco.bpmn-to-code-gradle' version '$pluginVersion'
+            }
+
+            tasks.named('generateBpmnModelJson') {
+                baseDir = projectDir.toString()
+                filePattern = 'src/main/resources/*.bpmn'
+                outputFolderPath = "${'$'}{projectDir}/build/generated-json"
+                processEngine = io.github.emaarco.bpmn.domain.shared.ProcessEngine.ZEEBE
+            }
+            """.trimIndent()
+        )
+
+        // when: running WITHOUT withPluginClasspath() so Gradle resolves from mavenLocal
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("generateBpmnModelJson")
+            .build()
+
+        // then: the task succeeds and generates JSON files
+        assertThat(result.task(":generateBpmnModelJson")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        val outputDir = File(projectDir, "build/generated-json")
+        assertThat(outputDir).isDirectory()
+        val generatedFiles = requireNotNull(outputDir.listFiles())
+        assertThat(generatedFiles).isNotEmpty()
+        assertThat(generatedFiles).allSatisfy { file -> assertThat(file.name).endsWith(".json") }
+    }
 }

--- a/bpmn-to-code-maven/build.gradle.kts
+++ b/bpmn-to-code-maven/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(kotlin("stdlib"))
     api(libs.bpmnmodel)
     api(libs.bundles.codegen)
+    api(libs.kotlinxSerializationJson)
     api(libs.slf4jApi)
     api(libs.kotlinLogging)
     compileOnly(project(":bpmn-to-code-core"))
@@ -52,7 +53,7 @@ tasks.jar {
 mavenPublishing {
 
     publishToMavenCentral()
-    signAllPublications()
+    if (project.hasProperty("signArtifacts")) signAllPublications()
     coordinates("io.github.emaarco", "bpmn-to-code-maven", version.toString())
 
     // Configure the POM details.

--- a/bpmn-to-code-testing/build.gradle.kts
+++ b/bpmn-to-code-testing/build.gradle.kts
@@ -36,7 +36,7 @@ tasks.named<Test>("test") {
 mavenPublishing {
 
     publishToMavenCentral()
-    signAllPublications()
+    if (project.hasProperty("signArtifacts")) signAllPublications()
     coordinates("io.github.emaarco", "bpmn-to-code-testing", version.toString())
 
     pom {

--- a/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
+++ b/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
@@ -121,6 +121,35 @@ class WebGenerationServiceTest {
         assertThat(response.files).describedAs("Should generate at least one API file").isNotEmpty()
     }
 
+    @Test
+    fun `should generate Kotlin API from sample BPMN file`() {
+
+        // given: the same sample BPMN that the web app serves via 'Try with Newsletter Sample'
+        val request = GenerateRequest(
+            files = listOf(
+                GenerateRequest.BpmnFileData(
+                    fileName = "c8-newsletter.bpmn",
+                    content = loadBpmnBase64("samples/c8-newsletter.bpmn"),
+                )
+            ),
+            config = GenerateRequest.GenerationConfig(
+                outputLanguage = OutputLanguage.KOTLIN,
+                processEngine = ProcessEngine.ZEEBE,
+            )
+        )
+
+        // when: generating the API
+        val response = underTest.generate(request)
+
+        // then: generation succeeds
+        assertThat(response.success).describedAs("Generation should succeed but got: ${response.error}").isTrue()
+        assertThat(response.files).isNotEmpty()
+        assertThat(response.error).isNull()
+        val generatedFile = response.files.first()
+        assertThat(generatedFile.fileName).endsWith(".kt")
+        assertThat(generatedFile.content).contains("newsletterSubscription")
+    }
+
     private fun loadBpmnBase64(resourcePath: String): String {
         val bytes = javaClass.classLoader.getResourceAsStream(resourcePath)!!.readBytes()
         return Base64.getEncoder().encodeToString(bytes)

--- a/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
+++ b/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
@@ -121,35 +121,6 @@ class WebGenerationServiceTest {
         assertThat(response.files).describedAs("Should generate at least one API file").isNotEmpty()
     }
 
-    @Test
-    fun `should generate Kotlin API from sample BPMN file`() {
-
-        // given: the same sample BPMN that the web app serves via 'Try with Newsletter Sample'
-        val request = GenerateRequest(
-            files = listOf(
-                GenerateRequest.BpmnFileData(
-                    fileName = "c8-newsletter.bpmn",
-                    content = loadBpmnBase64("samples/c8-newsletter.bpmn"),
-                )
-            ),
-            config = GenerateRequest.GenerationConfig(
-                outputLanguage = OutputLanguage.KOTLIN,
-                processEngine = ProcessEngine.ZEEBE,
-            )
-        )
-
-        // when: generating the API
-        val response = underTest.generate(request)
-
-        // then: generation succeeds
-        assertThat(response.success).describedAs("Generation should succeed but got: ${response.error}").isTrue()
-        assertThat(response.files).isNotEmpty()
-        assertThat(response.error).isNull()
-        val generatedFile = response.files.first()
-        assertThat(generatedFile.fileName).endsWith(".kt")
-        assertThat(generatedFile.content).contains("newsletterSubscription")
-    }
-
     private fun loadBpmnBase64(resourcePath: String): String {
         val bytes = javaClass.classLoader.getResourceAsStream(resourcePath)!!.readBytes()
         return Base64.getEncoder().encodeToString(bytes)

--- a/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebJsonGenerationServiceTest.kt
+++ b/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebJsonGenerationServiceTest.kt
@@ -1,0 +1,47 @@
+package io.github.emaarco.bpmn.web.service
+
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.web.model.GenerateJsonRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class WebJsonGenerationServiceTest {
+
+    private val underTest = WebJsonGenerationService()
+
+    @Test
+    fun `should generate JSON from sample BPMN file`() {
+
+        // given: the sample BPMN served by the web app
+        val request = GenerateJsonRequest(
+            files = listOf(
+                GenerateJsonRequest.BpmnFileData(
+                    fileName = "c8-newsletter.bpmn",
+                    content = loadSampleBase64("samples/c8-newsletter.bpmn"),
+                )
+            ),
+            config = GenerateJsonRequest.JsonGenerationConfig(
+                processEngine = ProcessEngine.ZEEBE,
+            )
+        )
+
+        // when: generating JSON
+        val response = underTest.generate(request)
+
+        // then: generation succeeds
+        assertThat(response.success).describedAs("Generation should succeed but got: ${response.error}").isTrue()
+        assertThat(response.files).isNotEmpty()
+        assertThat(response.error).isNull()
+        val file = response.files.first()
+        assertThat(file.fileName).endsWith(".json")
+        assertThat(file.processId).isEqualTo("newsletterSubscription")
+    }
+
+    private fun loadSampleBase64(resourcePath: String): String {
+        val bytes = requireNotNull(javaClass.classLoader.getResourceAsStream(resourcePath)) {
+            "Could not find resource: $resourcePath"
+        }.readBytes()
+        return Base64.getEncoder().encodeToString(bytes)
+    }
+}


### PR DESCRIPTION
## Summary

- `publishToMavenLocal` failed on machines without GPG configured because `signAllPublications()` was unconditional. Signing is now gated on `-PsignArtifacts` (pass this property only when releasing to Maven Central).
- `generateBpmnModelJson` failed when the plugin was resolved from Maven Local/Central — `kotlinx-serialization-json` was bundled (class files from core) but not declared as a POM dependency, causing `NoClassDefFoundError` at runtime. Added `api(libs.kotlinxSerializationJson)` to both the Gradle and Maven plugin builds.

## Test plan

- [x] `./gradlew clean publishToMavenLocal` succeeds without GPG configured
- [x] `./gradlew :bpmn-to-code-gradle:test` — new `generateBpmnModelJson resolves kotlinx-serialization from published artifact` smoke test passes
- [x] `./gradlew :bpmn-to-code-web:test` — new tests for API and JSON generation with the web sample BPMN pass
- [x] `./gradlew publishToMavenLocal -PsignArtifacts` still signs when the property is set