### PR TITLE
docs: mark CIB7 as supported via Camunda 7 namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ dependencies {
 | Engine | Value |
 |--------|-------|
 | Camunda 8 / Zeebe | `ZEEBE` |
-| Camunda 7 | `CAMUNDA_7` |
+| Camunda 7 / CIB7 | `CAMUNDA_7` |
 | Operaton | `OPERATON` |
 
 ## Get It


### PR DESCRIPTION
CIB7 uses the same BPMN namespace as Camunda 7, so it works out of the box. Adds a note to the README engine support list.