### PR TITLE
fix: hide include-sources toggle in JSON export tab

### DIFF
--- a/bpmn-to-code-web/src/main/resources/static/js/main.js
+++ b/bpmn-to-code-web/src/main/resources/static/js/main.js
@@ -64,6 +64,8 @@ function switchTab(tab) {
     document.getElementById('error-message').style.display = 'none';
     document.getElementById('results-content').innerHTML = '';
     state.generatedFiles = [];
+
+    document.querySelector('.include-sources-toggle').style.display = tab === 'json' ? 'none' : '';
 }
 
 function setupEventListeners() {


### PR DESCRIPTION
## What

The "Include library sources in ZIP" checkbox was visible in the JSON Export tab, where it has no meaning — the JSON response contains no library files.

## Why

The toggle element has no tab-aware visibility logic. Both tabs share the same HTML, so it always rendered.

## Fix

One line in `switchTab()` hides the toggle when the JSON tab is active.