### PR TITLE
fix: address high-severity findings from repo analysis

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
@@ -148,7 +148,7 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
         override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model is MergedBpmnModel
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
-            val model = modelApi.model as MergedBpmnModel
+            val model = modelApi.model as? MergedBpmnModel ?: return
             val variantsBuilder = TypeSpec.classBuilder("Variants").addModifiers(PUBLIC, STATIC, FINAL)
             model.variants.forEach { variant ->
                 val variantClass = buildVariantClass(modelApi.packagePath, variant)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -152,7 +152,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         override fun shouldWrite(modelApi: BpmnModelApi) = modelApi.model is MergedBpmnModel
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
-            val model = modelApi.model as MergedBpmnModel
+            val model = modelApi.model as? MergedBpmnModel ?: return
             val variantsBuilder = TypeSpec.objectBuilder("Variants")
             model.variants.forEach { variant ->
                 val variantObject = buildVariantObject(modelApi.packagePath, variant)

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
@@ -1,5 +1,6 @@
 package io.github.emaarco.bpmn.adapter
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.util.Properties
@@ -30,34 +31,26 @@ class BpmnModelGeneratorPlugin : Plugin<Project> {
     }
 
     private fun addRuntimeDependency(project: Project) {
-        val version = loadPluginVersion(project) ?: return
+        val version = loadPluginVersion()
         val coordinates = "$RUNTIME_GROUP:$RUNTIME_ARTIFACT:$version"
         project.plugins.withId("java") {
             project.dependencies.add("implementation", coordinates)
         }
     }
 
-    private fun loadPluginVersion(project: Project): String? {
+    private fun loadPluginVersion(): String {
         val stream = javaClass.classLoader.getResourceAsStream(VERSION_RESOURCE)
-        if (stream == null) {
-            project.logger.warn(
-                "[bpmn-to-code] Could not locate '$VERSION_RESOURCE' on the plugin classpath — " +
-                    "skipping auto-add of '$RUNTIME_GROUP:$RUNTIME_ARTIFACT'. " +
-                    "Add the dependency manually to ensure generated code compiles."
+            ?: throw GradleException(
+                "[bpmn-to-code] Could not locate '$VERSION_RESOURCE' on the plugin classpath. " +
+                    "This is a bug in the plugin distribution — please report it."
             )
-            return null
-        }
         val properties = stream.use {
             Properties().apply { load(it) }
         }
-        val version = properties.getProperty("version")?.takeIf { it.isNotBlank() }
-        if (version == null) {
-            project.logger.warn(
-                "[bpmn-to-code] '$VERSION_RESOURCE' is missing a non-blank 'version' entry — " +
-                    "skipping auto-add of '$RUNTIME_GROUP:$RUNTIME_ARTIFACT'. " +
-                    "Add the dependency manually to ensure generated code compiles."
+        return properties.getProperty("version")?.takeIf { it.isNotBlank() }
+            ?: throw GradleException(
+                "[bpmn-to-code] '$VERSION_RESOURCE' is missing a non-blank 'version' entry. " +
+                    "This is a bug in the plugin distribution — please report it."
             )
-        }
-        return version
     }
 }

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoader.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoader.kt
@@ -63,12 +63,17 @@ internal object BpmnResourceLoader {
      */
     private fun loadFromJar(url: URL): List<BpmnResource> {
         val jarUri = url.toURI()
-        val fs = try {
-            FileSystems.getFileSystem(jarUri)
+        val subPath = url.path.substringAfter("!")
+        return try {
+            val existing = FileSystems.getFileSystem(jarUri)
+            loadFromPath(existing.getPath(subPath))
         } catch (_: FileSystemNotFoundException) {
-            FileSystems.newFileSystem(jarUri, emptyMap<String, Any>())
+            FileSystems.newFileSystem(jarUri, emptyMap<String, Any>()).use { fs ->
+                loadFromPath(fs.getPath(subPath)).map { resource ->
+                    BpmnResource(fileName = resource.fileName, content = resource.content.readBytes().inputStream())
+                }
+            }
         }
-        return loadFromPath(fs.getPath(url.path.substringAfter("!")))
     }
 
     private fun walkForBpmnFiles(directory: Path): List<BpmnResource> {


### PR DESCRIPTION
## Summary

- **H1** (`BpmnResourceLoader.kt`): JAR `FileSystem` was never closed when created by us. Fixed by distinguishing ownership — existing FileSystems are used as-is, newly created ones are wrapped in `.use {}` with eager byte-array reads so `InputStream` references remain valid after the FileSystem closes.
- **H2** (`KotlinProcessApiBuilder.kt`): Hard cast `as MergedBpmnModel` replaced with safe cast `as? MergedBpmnModel ?: return` to prevent `ClassCastException` if `shouldWrite`/`write` are ever called out of sync.
- **H3** (`JavaProcessApiBuilder.kt`): Same fix as H2.
- **H4** (`BpmnModelGeneratorPlugin.kt`): `loadPluginVersion` used to return `null` with a silent warning when the version resource was missing, causing cryptic compile errors for users. Now throws `GradleException` with a clear message pointing to the plugin distribution as the source.

## Test plan

- [x] `./gradlew :bpmn-to-code-core:test :bpmn-to-code-testing:test :bpmn-to-code-gradle:test` — all pass