### PR TITLE
fix: address findings from repo analysis

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/JavaProcessApiBuilder.kt
@@ -66,7 +66,8 @@ class JavaProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<Ty
             fileName = "${modelApi.fileName()}.java",
             packagePath = modelApi.packagePath,
             content = fileContent,
-            language = modelApi.outputLanguage
+            language = modelApi.outputLanguage,
+            processId = modelApi.model.processId,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -67,7 +67,8 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             fileName = "$objectName.kt",
             packagePath = modelApi.packagePath,
             content = content,
-            language = modelApi.outputLanguage
+            language = modelApi.outputLanguage,
+            processId = modelApi.model.processId,
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/VariableNameSubtype.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/VariableNameSubtype.kt
@@ -19,7 +19,8 @@ internal enum class VariableNameSubtype(val simpleName: String) {
             return when {
                 hasInput && hasOutput -> IN_OUT
                 hasInput -> INPUT
-                else -> OUTPUT
+                hasOutput -> OUTPUT
+                else -> error("Unexpected variable directions: $directions")
             }
         }
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/GeneratedApiFile.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/GeneratedApiFile.kt
@@ -7,4 +7,5 @@ data class GeneratedApiFile(
     val packagePath: String,
     val content: String,
     val language: OutputLanguage,
+    val processId: String,
 )

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRule.kt
@@ -24,6 +24,11 @@ class InvalidIdentifierRule : BpmnValidationRule {
         checkMappings(violations, model.processId, model.messages, "Message")
         checkMappings(violations, model.processId, model.signals, "Signal")
         checkMappings(violations, model.processId, model.errors, "Error")
+        checkMappings(violations, model.processId, model.escalations, "Escalation")
+        checkMappings(violations, model.processId, model.compensations, "Compensation")
+        checkMappings(violations, model.processId, model.callActivities, "CallActivity")
+        checkMappings(violations, model.processId, model.timers, "Timer")
+        checkMappings(violations, model.processId, model.variables, "Variable")
         return violations
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiInMemoryPluginTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiInMemoryPluginTest.kt
@@ -68,7 +68,8 @@ class CreateProcessApiInMemoryPluginTest {
         fileName = fileName,
         packagePath = "com.example.api",
         content = "// $fileName api code",
-        language = OutputLanguage.KOTLIN
+        language = OutputLanguage.KOTLIN,
+        processId = fileName,
     )
 
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/CodeGenerationAdapterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/CodeGenerationAdapterTest.kt
@@ -28,6 +28,7 @@ class CodeGenerationAdapterTest {
             packagePath = "packagePath",
             content = "content",
             language = OutputLanguage.KOTLIN,
+            processId = "test",
         )
         every { kotlinProcessBuilder.buildApiFile(modelApi) } returns processFile
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessApiFileSaverTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/ProcessApiFileSaverTest.kt
@@ -19,19 +19,22 @@ class ProcessApiFileSaverTest {
             fileName = "OrderProcessApi.kt",
             packagePath = "com.example.order",
             content = "// order process api code",
-            language = OutputLanguage.KOTLIN
+            language = OutputLanguage.KOTLIN,
+            processId = "order",
         )
         val secondFile = GeneratedApiFile(
             fileName = "PaymentProcessApi.kt",
             packagePath = "com.example.payment",
             content = "// payment process api code",
-            language = OutputLanguage.KOTLIN
+            language = OutputLanguage.KOTLIN,
+            processId = "payment",
         )
         val thirdFile = GeneratedApiFile(
             fileName = "ShippingProcessApi.kt",
             packagePath = "com.example.order.shipping",
             content = "// shipping process api code",
-            language = OutputLanguage.KOTLIN
+            language = OutputLanguage.KOTLIN,
+            processId = "shipping",
         )
 
         // when: writeFiles is called

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryServiceTest.kt
@@ -36,7 +36,8 @@ class GenerateProcessApiInMemoryServiceTest {
             fileName = "TestProcessApi.kt",
             packagePath = "com.example",
             content = "// generated code",
-            language = OutputLanguage.KOTLIN
+            language = OutputLanguage.KOTLIN,
+            processId = "test",
         )
         every { bpmnService.extract(any(), any()) } returns dummyModel
         every { codeGenerator.generateCode(any()) } returns listOf(expectedGeneratedFile)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
@@ -43,7 +43,8 @@ class GenerateProcessApiServiceTest {
             fileName = "NewsletterSubscriptionProcessApi.kt",
             packagePath = "de.emaarco.example",
             content = "// generated code",
-            language = OutputLanguage.KOTLIN
+            language = OutputLanguage.KOTLIN,
+            processId = "newsletterSubscription",
         )
         every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(dummyResource)
         every { bpmnService.extract(any(), any()) } returns dummyModel

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/InvalidIdentifierRuleTest.kt
@@ -1,5 +1,8 @@
 package io.github.emaarco.bpmn.domain.validation.rules
 
+import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
+import io.github.emaarco.bpmn.domain.shared.CompensationType
+import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
@@ -42,6 +45,40 @@ class InvalidIdentifierRuleTest {
                     properties = FlowNodeProperties.Timer(TimerDefinition(id = "123-timer", type = "Duration", value = "PT1H")),
                 )
             )
+        )
+
+        // when: validating
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+
+        // then: two WARN violations — one for FlowNode, one for Timer (same underlying id)
+        assertThat(violations).hasSize(2)
+        assertThat(violations).allMatch { it.severity == Severity.WARN }
+        assertThat(violations).allMatch { it.message.contains("invalid identifier") }
+    }
+
+    @Test
+    fun `reports warning for escalation producing invalid identifier`() {
+
+        // given: an escalation whose name starts with a digit
+        val model = testBpmnModel(
+            escalations = listOf(EscalationDefinition(id = "esc1", name = "123-escalation", code = "ESC"))
+        )
+
+        // when: validating
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))
+
+        // then: a WARN violation mentioning "invalid identifier"
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].severity).isEqualTo(Severity.WARN)
+        assertThat(violations[0].message).contains("invalid identifier")
+    }
+
+    @Test
+    fun `reports warning for compensation producing invalid identifier`() {
+
+        // given: a compensation whose id starts with a digit
+        val model = testBpmnModel(
+            compensations = listOf(CompensationDefinition(id = "123-compensation", type = CompensationType.THROWING))
         )
 
         // when: validating

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnJsonTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnJsonTask.kt
@@ -26,6 +26,7 @@ abstract class GenerateBpmnJsonTask : DefaultTask() {
 
     @TaskAction
     fun execute() {
+        validate()
         val plugin = CreateProcessJsonFilesystemPlugin()
         plugin.execute(
             baseDir = baseDir,
@@ -34,5 +35,12 @@ abstract class GenerateBpmnJsonTask : DefaultTask() {
             engine = processEngine,
         )
         logger.lifecycle("BPMN JSON files generated successfully")
+    }
+
+    private fun validate() {
+        check(this::baseDir.isInitialized) { "baseDir must be configured in bpmnToCode { ... }" }
+        check(this::filePattern.isInitialized) { "filePattern must be configured in bpmnToCode { ... }" }
+        check(this::outputFolderPath.isInitialized) { "outputFolderPath must be configured in bpmnToCode { ... }" }
+        check(this::processEngine.isInitialized) { "processEngine must be configured in bpmnToCode { ... }" }
     }
 }

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
@@ -33,15 +33,25 @@ abstract class GenerateBpmnModelsTask : DefaultTask() {
 
     @TaskAction
     fun execute() {
+        validate()
         val service = CreateProcessApiFilesystemPlugin()
         service.execute(
-            baseDir,
-            filePattern,
-            outputFolderPath,
-            packagePath,
-            outputLanguage,
-            processEngine,
+            baseDir = baseDir,
+            filePattern = filePattern,
+            outputFolderPath = outputFolderPath,
+            packagePath = packagePath,
+            outputLanguage = outputLanguage,
+            engine = processEngine,
         )
         logger.lifecycle("BPMN models generated successfully")
+    }
+
+    private fun validate() {
+        check(this::baseDir.isInitialized) { "baseDir must be configured in bpmnToCode { ... }" }
+        check(this::filePattern.isInitialized) { "filePattern must be configured in bpmnToCode { ... }" }
+        check(this::outputFolderPath.isInitialized) { "outputFolderPath must be configured in bpmnToCode { ... }" }
+        check(this::packagePath.isInitialized) { "packagePath must be configured in bpmnToCode { ... }" }
+        check(this::outputLanguage.isInitialized) { "outputLanguage must be configured in bpmnToCode { ... }" }
+        check(this::processEngine.isInitialized) { "processEngine must be configured in bpmnToCode { ... }" }
     }
 }

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
@@ -34,13 +34,19 @@ abstract class ValidateBpmnModelsTask : DefaultTask() {
 
     @TaskAction
     fun execute() {
+        validate()
         logger.warn("[EXPERIMENTAL] The 'validateBpmnModels' task is experimental and may change in future releases.")
         val plugin = ValidateBpmnFilesystemPlugin()
         val config = ValidationConfig(
             failOnWarning = failOnWarning,
             disabledRules = disabledRules,
         )
-        val result = plugin.execute(baseDir, filePattern, processEngine, config)
+        val result = plugin.execute(
+            baseDir = baseDir,
+            filePattern = filePattern,
+            engine = processEngine,
+            validationConfig = config,
+        )
 
         result.warnings.forEach { v ->
             logger.warn("[BPMN VALIDATION WARN] ${formatLocation(v)}: ${v.message} (rule: ${v.ruleId})")
@@ -55,6 +61,12 @@ abstract class ValidateBpmnModelsTask : DefaultTask() {
             )
         }
         logger.lifecycle("BPMN validation passed")
+    }
+
+    private fun validate() {
+        check(this::baseDir.isInitialized) { "baseDir must be configured in bpmnToCode { ... }" }
+        check(this::filePattern.isInitialized) { "filePattern must be configured in bpmnToCode { ... }" }
+        check(this::processEngine.isInitialized) { "processEngine must be configured in bpmnToCode { ... }" }
     }
 
     private fun formatLocation(v: ValidationViolation): String =

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationService.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationService.kt
@@ -62,21 +62,6 @@ class WebGenerationService(
     ) = GenerateResponse.GeneratedFile(
         fileName = apiFile.fileName,
         content = apiFile.content,
-        processId = extractProcessIdFromFileName(apiFile.fileName)
+        processId = apiFile.processId,
     )
-
-    /**
-     * NewsletterSubscriptionProcessApi.kt -> newsletterSubscription
-     * Remove file extension and "ProcessApi" suffix
-     */
-    private fun extractProcessIdFromFileName(
-        fileName: String
-    ): String {
-        return fileName
-            .removeSuffix(".kt")
-            .removeSuffix(".java")
-            .replace(Regex("ProcessApiV\\d+$"), "ProcessApi")  // Handle versioned names
-            .removeSuffix("ProcessApi")
-            .replaceFirstChar { it.lowercase() }
-    }
 }


### PR DESCRIPTION
## Summary
- **M1** — `VariableNameSubtype.chooseFor()` now throws on empty direction sets instead of silently defaulting to `OUTPUT`
- **M2** — All three Gradle tasks validate their `lateinit var` fields at task-action start, giving a clear error message instead of an opaque `UninitializedPropertyAccessException`
- **L1** — `InvalidIdentifierRule` now checks escalations, compensations, callActivities, timers, and variables (in addition to the existing flowNodes, serviceTasks, messages, signals, errors)
- **L2** — `GeneratedApiFile` carries a `processId` field populated by the builders; `WebGenerationService` uses it directly instead of reverse-engineering it from the filename
- **L3** — Gradle task plugin calls standardized to named parameters throughout

## Test plan
- [ ] `./gradlew :bpmn-to-code-core:test` — all 142+ tests pass, including new InvalidIdentifierRule tests for escalations and compensations
- [ ] `./gradlew :bpmn-to-code-gradle:test` — all Gradle plugin smoke tests pass
- [ ] `./gradlew :bpmn-to-code-web:test` — web generation tests pass