### PR TITLE
fix: close file descriptors by storing BPMN content as ByteArray

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/SecureBpmnParser.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/SecureBpmnParser.kt
@@ -6,7 +6,6 @@ import org.xml.sax.Attributes
 import org.xml.sax.SAXException
 import org.xml.sax.SAXParseException
 import org.xml.sax.helpers.DefaultHandler
-import java.io.InputStream
 import javax.xml.parsers.SAXParserFactory
 
 /**
@@ -20,8 +19,7 @@ internal object SecureBpmnParser {
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
     }
 
-    fun readModelFromStream(inputStream: InputStream): BpmnModelInstance {
-        val bytes = inputStream.readBytes()
+    fun readModelFromBytes(bytes: ByteArray): BpmnModelInstance {
         rejectDoctypeDeclaration(bytes)
         return Bpmn.readModelFromStream(bytes.inputStream())
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -39,15 +39,13 @@ import org.camunda.bpm.model.bpmn.instance.ServiceTask
 import org.camunda.bpm.model.xml.ModelInstance
 import org.camunda.bpm.model.xml.instance.DomElement
 import org.camunda.bpm.model.xml.instance.ModelElementInstance
-import java.io.InputStream
-
 class Camunda7ModelExtractor : EngineSpecificExtractor {
 
     private val implKindKey = ServiceTaskDefinition.IMPL_KIND_KEY
     private val implValueKey = ServiceTaskDefinition.IMPL_VALUE_KEY
 
-    override fun extract(inputStream: InputStream): BpmnModel {
-        val modelInstance = SecureBpmnParser.readModelFromStream(inputStream)
+    override fun extract(bytes: ByteArray): BpmnModel {
+        val modelInstance = SecureBpmnParser.readModelFromBytes(bytes)
         val processId = modelInstance.getProcessId()
         val variantName = modelInstance.extractVariantName()
         val allMessages = findMessages(modelInstance)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/EngineSpecificExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/EngineSpecificExtractor.kt
@@ -1,13 +1,8 @@
 package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.BpmnModel
-import java.io.InputStream
 
 fun interface EngineSpecificExtractor {
 
-    /**
-     * Extracts the BPMN model from the given input stream.
-     * @param inputStream the input stream to extract the BPMN model from
-     */
-    fun extract(inputStream: InputStream): BpmnModel
+    fun extract(bytes: ByteArray): BpmnModel
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/EngineSpecificExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/EngineSpecificExtractor.kt
@@ -4,5 +4,9 @@ import io.github.emaarco.bpmn.domain.BpmnModel
 
 fun interface EngineSpecificExtractor {
 
+    /**
+     * Extracts the BPMN model from the given byte array.
+     * @param bytes the raw BPMN file content to extract the model from
+     */
     fun extract(bytes: ByteArray): BpmnModel
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -39,8 +39,6 @@ import org.camunda.bpm.model.bpmn.instance.ServiceTask
 import org.camunda.bpm.model.xml.ModelInstance
 import org.camunda.bpm.model.xml.instance.DomElement
 import org.camunda.bpm.model.xml.instance.ModelElementInstance
-import java.io.InputStream
-
 class OperatonModelExtractor : EngineSpecificExtractor {
 
     private val implKindKey = ServiceTaskDefinition.IMPL_KIND_KEY
@@ -50,8 +48,8 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         private const val NAMESPACE = "http://operaton.org/schema/1.0/bpmn"
     }
 
-    override fun extract(inputStream: InputStream): BpmnModel {
-        val modelInstance = SecureBpmnParser.readModelFromStream(inputStream)
+    override fun extract(bytes: ByteArray): BpmnModel {
+        val modelInstance = SecureBpmnParser.readModelFromBytes(bytes)
         val processId = modelInstance.getProcessId()
         val variantName = modelInstance.extractVariantName()
         val messages = findMessages(modelInstance)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -33,15 +33,13 @@ import org.camunda.bpm.model.bpmn.instance.Message
 import org.camunda.bpm.model.bpmn.instance.MultiInstanceLoopCharacteristics
 import org.camunda.bpm.model.xml.ModelInstance
 import org.camunda.bpm.model.xml.instance.ModelElementInstance
-import java.io.InputStream
-
 class ZeebeModelExtractor : EngineSpecificExtractor {
 
     private val implKindKey = ServiceTaskDefinition.IMPL_KIND_KEY
     private val implValueKey = ServiceTaskDefinition.IMPL_VALUE_KEY
 
-    override fun extract(inputStream: InputStream): BpmnModel {
-        val modelInstance = SecureBpmnParser.readModelFromStream(inputStream)
+    override fun extract(bytes: ByteArray): BpmnModel {
+        val modelInstance = SecureBpmnParser.readModelFromBytes(bytes)
         val processId = modelInstance.getProcessId()
         val variantName = modelInstance.extractVariantName()
         val allFlowNodes = modelInstance.findFlowNodes()

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/filesystem/BpmnFileLoader.kt
@@ -9,6 +9,7 @@ import java.nio.file.Path
 import java.nio.file.PathMatcher
 import kotlin.io.path.absolute
 import kotlin.io.path.name
+import kotlin.io.path.readBytes
 import kotlin.streams.toList
 
 class BpmnFileLoader : LoadBpmnFilesPort {
@@ -30,7 +31,7 @@ class BpmnFileLoader : LoadBpmnFilesPort {
         return files.map { file ->
             BpmnResource(
                 fileName = file.name,
-                content = file.toFile().inputStream(),
+                content = file.readBytes(),
             )
         }
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryService.kt
@@ -49,7 +49,7 @@ class GenerateProcessApiInMemoryService(
     ) = command.bpmnContents.map {
         BpmnResource(
             fileName = it.processName,
-            content = it.bpmnXml.byteInputStream(),
+            content = it.bpmnXml.encodeToByteArray(),
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonInMemoryService.kt
@@ -23,7 +23,7 @@ class GenerateProcessJsonInMemoryService(
     ): List<GeneratedJsonFile> {
         val validationService = BpmnValidationService(command.validationConfig)
         val bpmnResources = command.bpmnContents.map {
-            BpmnResource(fileName = it.processName, content = it.bpmnXml.byteInputStream())
+            BpmnResource(fileName = it.processName, content = it.bpmnXml.encodeToByteArray())
         }
         val models = bpmnResources.map { bpmnExtractor.extract(it, command.engine) }
         validationService.validate(models, command.engine, ValidationPhase.PRE_MERGE)

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnResource.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnResource.kt
@@ -1,8 +1,14 @@
 package io.github.emaarco.bpmn.domain
 
-import java.io.InputStream
-
 data class BpmnResource(
     val fileName: String,
-    val content: InputStream,
-)
+    val content: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BpmnResource) return false
+        return fileName == other.fileName && content.contentEquals(other.content)
+    }
+
+    override fun hashCode(): Int = 31 * fileName.hashCode() + content.contentHashCode()
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/ExtractBpmnAdapterTest.kt
@@ -27,7 +27,7 @@ class ExtractBpmnAdapterTest {
         val tempFile = File.createTempFile("dummy", ".bpmn").apply { deleteOnExit() }
         val bpmnResource = BpmnResource(
             fileName = "dummy.bpmn",
-            content = tempFile.inputStream(),
+            content = tempFile.readBytes(),
         )
         every { extractor.extract(any()) } returns expectedModel
 
@@ -46,7 +46,7 @@ class ExtractBpmnAdapterTest {
         val tempFile = File.createTempFile("dummy", ".bpmn").apply { deleteOnExit() }
         val bpmnResource = BpmnResource(
             fileName = "dummy.bpmn",
-            content = tempFile.inputStream(),
+            content = tempFile.readBytes(),
         )
 
         // when / then: an exception is thrown
@@ -59,7 +59,7 @@ class ExtractBpmnAdapterTest {
 
         // given: an extractor that throws during parsing
         val tempFile = File.createTempFile("invalid", ".bpmn").apply { deleteOnExit() }
-        val bpmnResource = BpmnResource(fileName = "invalid.bpmn", content = tempFile.inputStream())
+        val bpmnResource = BpmnResource(fileName = "invalid.bpmn", content = tempFile.readBytes())
         every { extractor.extract(any()) } throws IllegalArgumentException("invalid BPMN content")
 
         // when / then: the exception is wrapped in a RuntimeException with file name in the message

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/SecureBpmnParserTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/SecureBpmnParserTest.kt
@@ -12,17 +12,17 @@ class SecureBpmnParserTest {
             <?xml version="1.0" encoding="UTF-8"?>
             <!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
             <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"/>
-        """.trimIndent().byteInputStream()
+        """.trimIndent().encodeToByteArray()
 
-        assertThatThrownBy { SecureBpmnParser.readModelFromStream(malicious) }
+        assertThatThrownBy { SecureBpmnParser.readModelFromBytes(malicious) }
             .isInstanceOf(SecurityException::class.java)
             .hasMessageContaining("DOCTYPE")
     }
 
     @Test
     fun `parses valid BPMN files without DOCTYPE`() {
-        val stream = requireNotNull(javaClass.classLoader.getResourceAsStream("bpmn/c8-subscribe-newsletter.bpmn"))
-        assertThatCode { SecureBpmnParser.readModelFromStream(stream) }
+        val bytes = requireNotNull(javaClass.classLoader.getResourceAsStream("bpmn/c8-subscribe-newsletter.bpmn")).readBytes()
+        assertThatCode { SecureBpmnParser.readModelFromBytes(bytes) }
             .doesNotThrowAnyException()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -34,7 +34,7 @@ class Camunda7ModelExtractorTest {
         val file = File(resourceUrl.toURI())
 
         // when: extracting the model
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         // then: the model matches the expected structure
         val c7ServiceTasks = listOf(
@@ -163,7 +163,7 @@ class Camunda7ModelExtractorTest {
     fun `extract returns variantName from process-level extension properties`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variantName).isEqualTo("withApproval")
     }
 
@@ -171,7 +171,7 @@ class Camunda7ModelExtractorTest {
     fun `extract returns null variantName when not specified`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variantName).isNull()
     }
 
@@ -179,7 +179,7 @@ class Camunda7ModelExtractorTest {
     fun `extract returns additionalInputVariables and additionalOutputVariables from camunda properties`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-additional-variables.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variables).containsExactlyInAnyOrder(
             VariableDefinition("orderId", VariableDirection.INPUT),
             VariableDefinition("orderId", VariableDirection.OUTPUT),
@@ -193,7 +193,7 @@ class Camunda7ModelExtractorTest {
     fun `extract preserves direction when the same variable name is both input and output on one element`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-additional-variables.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         val activity = bpmnModel.flowNodes.single { it.id == "Activity_ProcessOrder" }
         assertThat(activity.variables).contains(
             VariableDefinition("orderId", VariableDirection.INPUT),
@@ -205,7 +205,7 @@ class Camunda7ModelExtractorTest {
     fun `extract returns multi-instance variables`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variables).containsExactlyInAnyOrder(
             VariableDefinition("test", VariableDirection.INPUT),
             VariableDefinition("authors", VariableDirection.INPUT),
@@ -221,7 +221,7 @@ class Camunda7ModelExtractorTest {
     fun `extract detects event subprocess type and extracts escalations`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         val eventSubProcess = bpmnModel.flowNodes.first { it.id == "eventSubProcess_errorHandling" }
         assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
@@ -236,7 +236,7 @@ class Camunda7ModelExtractorTest {
     fun `extract marks default sequence flow correctly`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         val flowsById = bpmnModel.sequenceFlows.associateBy { it.id }
         assertThat(flowsById["Flow_1jogut0"]).isEqualTo(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -34,7 +34,7 @@ class OperatonModelExtractorTest {
         val file = File(resourceUrl.toURI())
 
         // when: extracting the model
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         // then: the model matches the expected structure
         val opServiceTasks = listOf(
@@ -162,7 +162,7 @@ class OperatonModelExtractorTest {
     fun `extract returns variantName from process-level extension properties`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-subscribe-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variantName).isEqualTo("withApproval")
     }
 
@@ -170,7 +170,7 @@ class OperatonModelExtractorTest {
     fun `extract returns null variantName when not specified`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variantName).isNull()
     }
 
@@ -178,7 +178,7 @@ class OperatonModelExtractorTest {
     fun `extract returns additionalInputVariables and additionalOutputVariables from operaton properties`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-additional-variables.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variables).containsExactlyInAnyOrder(
             VariableDefinition("orderId", VariableDirection.INPUT),
             VariableDefinition("orderId", VariableDirection.OUTPUT),
@@ -192,7 +192,7 @@ class OperatonModelExtractorTest {
     fun `extract preserves direction when the same variable name is both input and output on one element`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-additional-variables.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         val activity = bpmnModel.flowNodes.single { it.id == "Activity_ProcessOrder" }
         assertThat(activity.variables).contains(
             VariableDefinition("orderId", VariableDirection.INPUT),
@@ -204,7 +204,7 @@ class OperatonModelExtractorTest {
     fun `extract returns multi-instance variables`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variables).containsExactlyInAnyOrder(
             VariableDefinition("authors", VariableDirection.INPUT),
             VariableDefinition("author", VariableDirection.INPUT),
@@ -219,7 +219,7 @@ class OperatonModelExtractorTest {
     fun `extract detects event subprocess type and extracts escalations`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         val eventSubProcess = bpmnModel.flowNodes.first { it.id == "eventSubProcess_errorHandling" }
         assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
@@ -234,7 +234,7 @@ class OperatonModelExtractorTest {
     fun `extract marks default sequence flow correctly`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/operaton-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         val flowsById = bpmnModel.sequenceFlows.associateBy { it.id }
         assertThat(flowsById["Flow_1jogut0"]).isEqualTo(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -32,7 +32,7 @@ class ZeebeModelExtractorTest {
         val file = File(resourceUrl.toURI())
 
         // when: extracting file to bpmn-model
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         // then: assert that the model has expected content
         assertThat(bpmnModel).isNotNull()
@@ -158,7 +158,7 @@ class ZeebeModelExtractorTest {
     fun `extract returns variantName from process-level extension properties`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-subscribe-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variantName).isEqualTo("withApproval")
     }
 
@@ -166,7 +166,7 @@ class ZeebeModelExtractorTest {
     fun `extract returns null variantName when not specified`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variantName).isNull()
     }
 
@@ -174,7 +174,7 @@ class ZeebeModelExtractorTest {
     fun `extract returns multi-instance variables`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variables).containsExactlyInAnyOrder(
             VariableDefinition("test", VariableDirection.INPUT),
             VariableDefinition("authors", VariableDirection.INPUT),
@@ -192,7 +192,7 @@ class ZeebeModelExtractorTest {
     fun `extract detects event subprocess type and extracts escalations`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         val eventSubProcess = bpmnModel.flowNodes.first { it.id == "eventSubProcess_errorHandling" }
         assertThat(eventSubProcess.elementType).isEqualTo(BpmnElementType.EVENT_SUB_PROCESS)
@@ -207,7 +207,7 @@ class ZeebeModelExtractorTest {
     fun `extract marks default sequence flow correctly`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-send-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
-        val bpmnModel = underTest.extract(file.inputStream())
+        val bpmnModel = underTest.extract(file.readBytes())
 
         val flowsById = bpmnModel.sequenceFlows.associateBy { it.id }
         assertThat(flowsById["Flow_1jogut0"]).isEqualTo(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
@@ -37,7 +37,7 @@ class GenerateProcessApiServiceTest {
         // given: a dummy BPMN resource and a command
         val dummyResource = BpmnResource(
             fileName = "dummy.bpmn",
-            content = "<bpmn></bpmn>".byteInputStream(),
+            content = "<bpmn></bpmn>".encodeToByteArray(),
         )
         val expectedGeneratedFile = GeneratedApiFile(
             fileName = "NewsletterSubscriptionProcessApi.kt",

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessJsonServiceTest.kt
@@ -33,7 +33,7 @@ class GenerateProcessJsonServiceTest {
     fun `generateProcessJson generates JSON and writes to disk`() {
 
         // given: a dummy BPMN resource and a command
-        val dummyResource = BpmnResource(fileName = "dummy.bpmn", content = "<bpmn></bpmn>".byteInputStream())
+        val dummyResource = BpmnResource(fileName = "dummy.bpmn", content = "<bpmn></bpmn>".encodeToByteArray())
         val expectedJsonFile = GeneratedJsonFile(fileName = "order.json", content = "{}")
         every { bpmnFileLoader.loadFrom("baseDir", "*.bpmn") } returns listOf(dummyResource)
         every { bpmnExtractor.extract(any(), any()) } returns dummyModel

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnServiceTest.kt
@@ -31,7 +31,7 @@ class ValidateBpmnServiceTest {
         engine = ProcessEngine.ZEEBE,
     )
 
-    private val dummyResource = BpmnResource(fileName = "dummy.bpmn", content = "<bpmn></bpmn>".byteInputStream())
+    private val dummyResource = BpmnResource(fileName = "dummy.bpmn", content = "<bpmn></bpmn>".encodeToByteArray())
 
     @Test
     fun `valid model returns empty result`() {

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/BpmnResourceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/BpmnResourceTest.kt
@@ -1,0 +1,44 @@
+package io.github.emaarco.bpmn.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BpmnResourceTest {
+
+    private val content = "content".encodeToByteArray()
+    private val resource = BpmnResource(fileName = "file.bpmn", content = content)
+
+    @Test
+    fun `equals returns true for same instance`() {
+        assertThat(resource).isEqualTo(resource)
+    }
+
+    @Test
+    fun `equals returns true for identical content`() {
+        val other = BpmnResource(fileName = "file.bpmn", content = "content".encodeToByteArray())
+        assertThat(resource).isEqualTo(other)
+    }
+
+    @Test
+    fun `equals returns false for different type`() {
+        assertThat(resource).isNotEqualTo("not a BpmnResource")
+    }
+
+    @Test
+    fun `equals returns false for different fileName`() {
+        val other = BpmnResource(fileName = "other.bpmn", content = content)
+        assertThat(resource).isNotEqualTo(other)
+    }
+
+    @Test
+    fun `equals returns false for different content`() {
+        val other = BpmnResource(fileName = "file.bpmn", content = "other".encodeToByteArray())
+        assertThat(resource).isNotEqualTo(other)
+    }
+
+    @Test
+    fun `hashCode is consistent for identical content`() {
+        val other = BpmnResource(fileName = "file.bpmn", content = "content".encodeToByteArray())
+        assertThat(resource.hashCode()).isEqualTo(other.hashCode())
+    }
+}

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoader.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnResourceLoader.kt
@@ -8,6 +8,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.extension
 import kotlin.io.path.name
+import kotlin.io.path.readBytes
 
 /**
  * Loads `.bpmn` files from either the classpath or a filesystem directory.
@@ -46,7 +47,7 @@ internal object BpmnResourceLoader {
 
     private fun loadFromPath(path: Path): List<BpmnResource> {
         if (Files.isRegularFile(path) && path.extension == "bpmn") {
-            return listOf(BpmnResource(fileName = path.name, content = Files.newInputStream(path)))
+            return listOf(BpmnResource(fileName = path.name, content = path.readBytes()))
         }
         require(Files.isDirectory(path)) {
             "Classpath resource is not a directory or .bpmn file: $path"
@@ -69,9 +70,7 @@ internal object BpmnResourceLoader {
             loadFromPath(existing.getPath(subPath))
         } catch (_: FileSystemNotFoundException) {
             FileSystems.newFileSystem(jarUri, emptyMap<String, Any>()).use { fs ->
-                loadFromPath(fs.getPath(subPath)).map { resource ->
-                    BpmnResource(fileName = resource.fileName, content = resource.content.readBytes().inputStream())
-                }
+                loadFromPath(fs.getPath(subPath))
             }
         }
     }
@@ -79,7 +78,7 @@ internal object BpmnResourceLoader {
     private fun walkForBpmnFiles(directory: Path): List<BpmnResource> {
         return Files.walk(directory)
             .filter { it.extension == "bpmn" }
-            .map { BpmnResource(fileName = it.name, content = Files.newInputStream(it)) }
+            .map { BpmnResource(fileName = it.name, content = it.readBytes()) }
             .toList()
     }
 }


### PR DESCRIPTION
## Summary

- `BpmnResource.content` was typed as `InputStream`, causing `BpmnFileLoader` and `BpmnResourceLoader` to open file handles that were never closed — leaking OS file descriptors (EMFILE under load)
- `SecureBpmnParser` already converted the incoming stream to `ByteArray` on its first line, meaning the live handle was held only to be immediately drained
- Changed `BpmnResource.content` to `ByteArray`, reading eagerly at the point of creation; updated `SecureBpmnParser` to accept `ByteArray` directly (`readModelFromBytes`), removing the redundant internal conversion; cascaded the type change through `EngineSpecificExtractor`, all three engine extractors, both in-memory services, and all affected tests

## Test plan

- [ ] `./gradlew :bpmn-to-code-core:build` passes
- [ ] `./gradlew :bpmn-to-code-testing:build` passes
- [ ] `./gradlew build` passes (full project)
- [ ] No `.inputStream()` calls remain in production sources under `src/main`