### PR TITLE
fix(ci): post coverage comment even when coverage check fails

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Step 6: Post coverage summary as PR comment
       - name: Post Coverage Comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary

- The "Post Coverage Comment" step only ran on success, so when `jacocoTestCoverageVerification` failed (coverage below threshold), no PR comment was written
- Added `always()` condition so the coverage comment is posted regardless of whether the coverage gate passed or failed

## Test plan

- [ ] Open a PR where coverage is below threshold — comment should still appear on the PR