### PR TITLE
fix: eliminate double ByteArrayInputStream and document runCatching guard

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/SecureBpmnParser.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/SecureBpmnParser.kt
@@ -6,6 +6,7 @@ import org.xml.sax.Attributes
 import org.xml.sax.SAXException
 import org.xml.sax.SAXParseException
 import org.xml.sax.helpers.DefaultHandler
+import java.io.InputStream
 import javax.xml.parsers.SAXParserFactory
 
 /**
@@ -20,13 +21,15 @@ internal object SecureBpmnParser {
     }
 
     fun readModelFromBytes(bytes: ByteArray): BpmnModelInstance {
-        rejectDoctypeDeclaration(bytes)
-        return Bpmn.readModelFromStream(bytes.inputStream())
+        val stream = bytes.inputStream()
+        rejectDoctypeDeclaration(stream)
+        stream.reset()
+        return Bpmn.readModelFromStream(stream)
     }
 
-    private fun rejectDoctypeDeclaration(bytes: ByteArray) {
+    private fun rejectDoctypeDeclaration(stream: InputStream) {
         try {
-            saxFactory.newSAXParser().parse(bytes.inputStream(), object : DefaultHandler() {
+            saxFactory.newSAXParser().parse(stream, object : DefaultHandler() {
                 override fun startElement(uri: String, localName: String, qName: String, attributes: Attributes) {
                     // Abort as soon as we reach the first element — no DOCTYPE was encountered
                     throw EarlyAbortException()

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -107,6 +107,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         val flowNodes = modelInstance.getModelElementsByType(FlowNode::class.java)
         return flowNodes.associate { node ->
             val nodeId = node.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
+            // isCamundaAsync* throws for FlowNode subtypes that don't carry the Camunda extension attribute
             val asyncBefore = runCatching { node.isCamundaAsyncBefore }.getOrDefault(false)
             val asyncAfter = runCatching { node.isCamundaAsyncAfter }.getOrDefault(false)
             val exclusive = runCatching { node.isCamundaExclusive }.getOrDefault(true)


### PR DESCRIPTION
## Summary

- **M1**: `SecureBpmnParser` was creating two independent `ByteArrayInputStream` instances from the same `ByteArray` — one inside `rejectDoctypeDeclaration` and one passed to `Bpmn.readModelFromStream`. Fixed by creating a single stream, resetting it after the DOCTYPE check, and reusing it.
- **M2**: The `runCatching` in `Camunda7ModelExtractor.extractAsyncPerNode` looked inconsistent with `OperatonModelExtractor`'s `?.toBoolean() ?: false` approach. Added a comment clarifying that `isCamundaAsync*` are Camunda-typed accessors that throw for `FlowNode` subtypes without the Camunda extension attribute — making the guard intentional, not defensive noise.

## Test plan

- [ ] `./gradlew :bpmn-to-code-core:test` passes (all existing parser and extractor tests)