### PR TITLE
fix(ci): enable artifact signing and fix Docker config cache for release

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -32,10 +32,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build Docker Image
-        run: ./gradlew :bpmn-to-code-web:dockerBuild
+        run: ./gradlew :bpmn-to-code-web:dockerBuild --no-configuration-cache
 
       - name: Push Docker Image
-        run: ./gradlew :bpmn-to-code-web:dockerPush
+        run: ./gradlew :bpmn-to-code-web:dockerPush --no-configuration-cache
 
       - name: Push Latest Tag
         run: docker push emaarco/bpmn-to-code-web:latest

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -33,4 +33,4 @@ jobs:
         run: ./gradlew build --warning-mode all
 
       - name: Publish to Maven Central
-        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -PsignArtifacts=true


### PR DESCRIPTION
## What failed

The v2.0.0 release workflow (run #24961500045) failed in two jobs. Nothing was published — all registries are clean.

## Bug 1: Maven Central — missing GPG signatures

`bpmn-to-code-testing`, `bpmn-to-code-maven`, and `bpmn-to-code-runtime` gate signing on `project.hasProperty("signArtifacts")`, but the workflow never passed that property. Maven Central rejected the deployment with "Missing signature for file" errors.

**Fix:** add `-PsignArtifacts=true` to the `publishAndReleaseToMavenCentral` call.

## Bug 2: Docker Hub — configuration cache incompatibility

`gradle.properties` enables the configuration cache globally. The `dockerBuild`/`dockerPush` tasks call `providers.exec { commandLine("which", "docker") }` which Gradle cannot serialize, causing the build to fail. The Maven workflow already uses `--no-configuration-cache`; the Docker workflow did not.

**Fix:** add `--no-configuration-cache` to both Docker Gradle commands.

## Re-release steps (after merge)

1. `gh release delete v2.0.0 --yes`
2. `git tag -d v2.0.0 && git push origin :refs/tags/v2.0.0`
3. `git tag v2.0.0 && git push origin v2.0.0`
4. `gh release create v2.0.0 --title "v2.0.0" --latest`