### PR TITLE
fix: escape quotes in generated Kotlin BpmnFlow condition

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -196,7 +196,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             if (name != null) add("name = %S,\n", name)
             add("sourceRef = %S,\n", sourceRef)
             add("targetRef = %S,\n", targetRef)
-            if (condition != null) add("condition = \"${condition.escapeDollarInterpolation()}\",\n")
+            if (condition != null) add("condition = %S,\n", condition)
             if (isDefault) add("isDefault = true,\n")
             unindent()
             add(")")

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
@@ -246,7 +246,7 @@ fun testSendNewsletterBpmnModel(
         SequenceFlowDefinition("Flow_0vtppnk", "event_mailRejected", "serviceTask_analyzeError"),
         SequenceFlowDefinition("Flow_13nmnag", "serviceTask_analyzeError", "gateway_canSendAgain"),
         SequenceFlowDefinition("Flow_1izucof", "gateway_canSendAgain", "serviceTask_sendMailAgain", flowName = "Yes", isDefault = true),
-        SequenceFlowDefinition("Flow_18nf2jh", "gateway_canSendAgain", "escalationEndEvent_nofitySupport", flowName = "No", conditionExpression = "\${canBeResolved == false}"),
+        SequenceFlowDefinition("Flow_18nf2jh", "gateway_canSendAgain", "escalationEndEvent_nofitySupport", flowName = "No", conditionExpression = "\${rejection.reason == \"PERMANENT\"}"),
         SequenceFlowDefinition("Flow_0vym6nu", "serviceTask_sendMailAgain", "eventGateway_afterSendingAgain"),
         SequenceFlowDefinition("Flow_0enjkoe", "eventGateway_afterSendingAgain", "timer_noRejectionForOneDay"),
         SequenceFlowDefinition("Flow_081cykl", "eventGateway_afterSendingAgain", "event_mailRejectedAgain"),

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiJava.txt
@@ -131,7 +131,7 @@ public final class SendNewsletterProcessApi {
 
         public static final BpmnFlow FLOW_1_IZUCOF = new BpmnFlow("Flow_1izucof", "Yes", "gateway_canSendAgain", "serviceTask_sendMailAgain", null, true);
 
-        public static final BpmnFlow FLOW_18_NF_2_JH = new BpmnFlow("Flow_18nf2jh", "No", "gateway_canSendAgain", "escalationEndEvent_nofitySupport", "${canBeResolved == false}", false);
+        public static final BpmnFlow FLOW_18_NF_2_JH = new BpmnFlow("Flow_18nf2jh", "No", "gateway_canSendAgain", "escalationEndEvent_nofitySupport", "${rejection.reason == \"PERMANENT\"}", false);
 
         public static final BpmnFlow FLOW_0_VYM_6_NU = new BpmnFlow("Flow_0vym6nu", null, "serviceTask_sendMailAgain", "eventGateway_afterSendingAgain", null, false);
 

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -146,7 +146,7 @@ object SendNewsletterProcessApi {
               name = "No",
               sourceRef = "gateway_hasSubscribers",
               targetRef = "endEvent_noSubscribers",
-              condition = "\${subscribers.size() > 0}",
+              condition = "${'$'}{subscribers.size() > 0}",
             )
 
         val FLOW_1_RUAYVL: BpmnFlow = BpmnFlow(
@@ -186,7 +186,7 @@ object SendNewsletterProcessApi {
               name = "No",
               sourceRef = "gateway_canSendAgain",
               targetRef = "escalationEndEvent_nofitySupport",
-              condition = "\${canBeResolved == false}",
+              condition = "${'$'}{rejection.reason == \"PERMANENT\"}",
             )
 
         val FLOW_0_VYM_6_NU: BpmnFlow = BpmnFlow(

--- a/bpmn-to-code-core/src/test/resources/json/MultiVariantNewsletterProcess.json
+++ b/bpmn-to-code-core/src/test/resources/json/MultiVariantNewsletterProcess.json
@@ -283,7 +283,7 @@
                     "sourceRef": "gateway_canSendAgain",
                     "targetRef": "escalationEndEvent_nofitySupport",
                     "name": "No",
-                    "conditionExpression": "${canBeResolved == false}",
+                    "conditionExpression": "${rejection.reason == \"PERMANENT\"}",
                     "isDefault": false
                 },
                 {


### PR DESCRIPTION
## Summary
- Switch `KotlinProcessApiBuilder.buildFlowInitializer` to KotlinPoet's `%S` placeholder so `BpmnFlow` `condition` strings containing inner double quotes (e.g. `${status != "VEREINNAHMT"}`) generate valid, compilable Kotlin.
- Update the multi-variant test fixture (`Flow_18nf2jh`) to use a newsletter-domain condition with a quoted string literal (`${rejection.reason == "PERMANENT"}`) so the regression is covered.

Closes #317

## Test plan
- [x] `./gradlew :bpmn-to-code-core:test` (the multi-variant Kotlin builder test runs `assertKotlinSyntaxValid` on the generated output)