### PR TITLE
chore: release 2.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-to-code",
   "description": "AI skills for developing and maintaining the bpmn-to-code plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": { "name": "emaarco" }
 }

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Works with Claude Code out of the box.
 
 ```kotlin
 plugins {
-    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.0"
+    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.1"
 }
 
 tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
@@ -101,7 +101,7 @@ tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <executions>
         <execution>
             <goals><goal>generate-bpmn-api</goal></goals>
@@ -122,7 +122,7 @@ tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
 
 ```kotlin
 dependencies {
-    testImplementation("io.github.emaarco:bpmn-to-code-testing:2.0.0")
+    testImplementation("io.github.emaarco:bpmn-to-code-testing:2.0.1")
 }
 ```
 

--- a/bpmn-to-code-gradle/README.md
+++ b/bpmn-to-code-gradle/README.md
@@ -14,7 +14,7 @@ To get started, apply the plugin in your build.gradle.kts file:
 
 ```kotlin
 plugins {
-    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.0"
+    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.1"
 }
 ```
 

--- a/bpmn-to-code-maven/README.md
+++ b/bpmn-to-code-maven/README.md
@@ -18,7 +18,7 @@ Add the `bpmn-to-code-runtime` dependency (it ships the shared types — `Proces
     <dependency>
         <groupId>io.github.emaarco</groupId>
         <artifactId>bpmn-to-code-runtime</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </dependency>
 </dependencies>
 ```
@@ -33,7 +33,7 @@ BPMN files, where to output the generated API files, and how to format the outpu
         <plugin>
             <groupId>io.github.emaarco</groupId>
             <artifactId>bpmn-to-code-maven</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
             <executions>
                 <execution>
                     <goals>

--- a/bpmn-to-code-mcp/README.md
+++ b/bpmn-to-code-mcp/README.md
@@ -40,7 +40,7 @@ The JAR is created at `bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-<version>-al
 
 **Test it manually:**
 ```bash
-java -jar bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-2.0.0-all.jar
+java -jar bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-2.0.1-all.jar
 ```
 
 ### Configuring Your MCP Client
@@ -54,7 +54,7 @@ Add to your `.claude/settings.json` (project-level) or `~/.claude/settings.json`
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.0-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]
     }
   }
 }
@@ -69,7 +69,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.0-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]
     }
   }
 }
@@ -80,6 +80,6 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 Most MCP clients follow a similar pattern — point them at the JAR using stdio transport:
 
 - **Command:** `java`
-- **Args:** `["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.0-all.jar"]`
+- **Args:** `["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]`
 
 Refer to your client's documentation for the exact configuration location.

--- a/bpmn-to-code-skills/.claude-plugin/plugin.json
+++ b/bpmn-to-code-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-to-code",
   "description": "AI skills for setting up and using the bpmn-to-code plugin (Gradle/Maven)",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": { "name": "emaarco" }
 }

--- a/docs/changelog/v2.md
+++ b/docs/changelog/v2.md
@@ -54,6 +54,13 @@ The legacy undirected `camunda:property name="additionalVariables"` extension pr
 
 ---
 
+## v2.0.1
+
+### Bug Fixes
+- Escape quotes in generated Kotlin `BpmnFlow` condition expressions (#318)
+
+---
+
 ## What's New
 
 ### New API Sections

--- a/docs/contributing/docker-hub-deployment.md
+++ b/docs/contributing/docker-hub-deployment.md
@@ -32,7 +32,7 @@ cd /path/to/bpmn-to-code
 
 Edit `bpmn-to-code-web/build.gradle.kts`:
 ```kotlin
-version = "2.0.0"  // Increment version
+version = "2.0.1"  // Increment version
 ```
 
 Follow semantic versioning:
@@ -51,7 +51,7 @@ This task:
 1. Builds the fat JAR: `./gradlew :bpmn-to-code-web:buildFatJar`
 2. Runs `docker build` using `bpmn-to-code-web/Dockerfile`
 3. Tags image as:
-   - `emaarco/bpmn-to-code-web:VERSION` (e.g., `2.0.0`)
+   - `emaarco/bpmn-to-code-web:VERSION` (e.g., `2.0.1`)
    - `emaarco/bpmn-to-code-web:latest`
 
 **Platform Architecture:**
@@ -75,7 +75,7 @@ docker images | grep bpmn-to-code-web
 
 Expected output:
 ```
-emaarco/bpmn-to-code-web   2.0.0    abc123def456   ...
+emaarco/bpmn-to-code-web   2.0.1    abc123def456   ...
 emaarco/bpmn-to-code-web   latest    abc123def456   ...
 ```
 
@@ -103,14 +103,14 @@ docker run -p 8080:8080 --rm emaarco/bpmn-to-code-web:latest
 
 Create Git tag for the version:
 ```bash
-git tag -a v2.0.0 -m "Release version 2.0.0"
-git push origin v2.0.0
+git tag -a v2.0.1 -m "Release version 2.0.1"
+git push origin v2.0.1
 ```
 
 Create a GitHub release:
 1. Go to: https://github.com/emaarco/bpmn-to-code/releases
 2. Click "Draft a new release"
-3. Select tag `v2.0.0`
+3. Select tag `v2.0.1`
 4. Add release notes
 5. Publish release
 
@@ -127,7 +127,7 @@ This pushes both tags:
 
 **Manual push (alternative):**
 ```bash
-docker push emaarco/bpmn-to-code-web:2.0.0
+docker push emaarco/bpmn-to-code-web:2.0.1
 docker push emaarco/bpmn-to-code-web:latest
 ```
 
@@ -140,8 +140,8 @@ Check Docker Hub:
 
 Pull and test from Docker Hub:
 ```bash
-docker pull emaarco/bpmn-to-code-web:2.0.0
-docker run -p 8080:8080 emaarco/bpmn-to-code-web:2.0.0
+docker pull emaarco/bpmn-to-code-web:2.0.1
+docker run -p 8080:8080 emaarco/bpmn-to-code-web:2.0.1
 ```
 
 ## Gradle Tasks Reference

--- a/docs/getting-started/gradle.md
+++ b/docs/getting-started/gradle.md
@@ -8,13 +8,13 @@ The bpmn-to-code Gradle plugin generates type-safe Process API files from your B
 
 ```kotlin [build.gradle.kts]
 plugins {
-    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.0"
+    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.1"
 }
 ```
 
 ```groovy [build.gradle]
 plugins {
-    id 'io.github.emaarco.bpmn-to-code-gradle' version '2.0.0'
+    id 'io.github.emaarco.bpmn-to-code-gradle' version '2.0.1'
 }
 ```
 

--- a/docs/getting-started/maven-advanced.md
+++ b/docs/getting-started/maven-advanced.md
@@ -10,7 +10,7 @@ Add separate `<execution>` blocks with their own `<configuration>` to generate f
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <executions>
         <!-- Camunda 7 processes -->
         <execution>
@@ -80,7 +80,7 @@ bpmn-to-code processes all files matching the `filePattern` glob — it has no b
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <executions>
         <execution>
             <goals><goal>generate-bpmn-api</goal></goals>

--- a/docs/getting-started/maven.md
+++ b/docs/getting-started/maven.md
@@ -12,7 +12,7 @@ Add the following to the `<build>` section of your `pom.xml`:
         <plugin>
             <groupId>io.github.emaarco</groupId>
             <artifactId>bpmn-to-code-maven</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
             <executions>
                 <execution>
                     <goals>

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -46,7 +46,7 @@ Add the server config to your client. Replace the JAR path with the absolute pat
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.0-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]
     }
   }
 }
@@ -58,7 +58,7 @@ Add the server config to your client. Replace the JAR path with the absolute pat
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.0-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]
     }
   }
 }
@@ -70,7 +70,7 @@ Add the server config to your client. Replace the JAR path with the absolute pat
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.0-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]
     }
   }
 }

--- a/docs/surface/json.md
+++ b/docs/surface/json.md
@@ -129,7 +129,7 @@ Run:
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <executions>
         <execution>
             <id>generate-bpmn-json</id>

--- a/docs/validate/index.md
+++ b/docs/validate/index.md
@@ -64,7 +64,7 @@ BPMN validation failed: 1 error(s), 1 warning(s)
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <executions>
         <execution>
             <id>validate-bpmn</id>

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -14,7 +14,7 @@ Add it to your test scope, write a test, and your CI will catch modeling issues 
 
 ```kotlin [Gradle]
 dependencies {
-    testImplementation("io.github.emaarco:bpmn-to-code-testing:2.0.0")
+    testImplementation("io.github.emaarco:bpmn-to-code-testing:2.0.1")
 }
 ```
 
@@ -22,7 +22,7 @@ dependencies {
 <dependency>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-testing</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
-projectVersion=2.0.0
+projectVersion=2.0.1


### PR DESCRIPTION
## Summary
- Bumps `projectVersion` to `2.0.1`
- Adds v2.0.1 changelog entry with the one bug fix since v2.0.0
- Updates all doc/README version references from `2.0.0` → `2.0.1`

## Changes since v2.0.0
- fix: escape quotes in generated Kotlin BpmnFlow condition (#318)