### PR TITLE
feat: use $$"..." syntax for generated BpmnFlow conditions

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -196,7 +196,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             if (name != null) add("name = %S,\n", name)
             add("sourceRef = %S,\n", sourceRef)
             add("targetRef = %S,\n", targetRef)
-            if (condition != null) add("condition = %S,\n", condition)
+            if (condition != null) add("condition = \$\$\"%L\",\n", condition)
             if (isDefault) add("isDefault = true,\n")
             unindent()
             add(")")

--- a/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/MultiVariantProcessApiKotlin.txt
@@ -146,7 +146,7 @@ object SendNewsletterProcessApi {
               name = "No",
               sourceRef = "gateway_hasSubscribers",
               targetRef = "endEvent_noSubscribers",
-              condition = "${'$'}{subscribers.size() > 0}",
+              condition = $$"${subscribers.size() > 0}",
             )
 
         val FLOW_1_RUAYVL: BpmnFlow = BpmnFlow(
@@ -186,7 +186,7 @@ object SendNewsletterProcessApi {
               name = "No",
               sourceRef = "gateway_canSendAgain",
               targetRef = "escalationEndEvent_nofitySupport",
-              condition = "${'$'}{rejection.reason == \"PERMANENT\"}",
+              condition = $$"${rejection.reason == "PERMANENT"}",
             )
 
         val FLOW_0_VYM_6_NU: BpmnFlow = BpmnFlow(


### PR DESCRIPTION
## Summary

- Switches `buildFlowInitializer` from `%S` to `%L` with a `$$"..."` wrapper so generated condition strings use Kotlin 2.2+ multi-dollar string interpolation
- Generated output no longer contains `\"` or `${'$'}` escaping — e.g. `$$"${rejection.reason == "PERMANENT"}"` instead of `"${rejection.reason == \"PERMANENT\"}"`
- Updates `MultiVariantProcessApiKotlin.txt` fixture to match the new output

## Note

Generated code now requires Kotlin 2.2+ in consuming projects (the project itself is on 2.3.20).