### PR TITLE
test: cover additionalInputVariables on non-interrupting message start event in event subprocess

### DIFF
--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -186,6 +186,8 @@ class Camunda7ModelExtractorTest {
             VariableDefinition("customerEmail", VariableDirection.OUTPUT),
             VariableDefinition("amount", VariableDirection.OUTPUT),
             VariableDefinition("shipmentId", VariableDirection.OUTPUT),
+            VariableDefinition("cancellationReason", VariableDirection.INPUT),
+            VariableDefinition("retryCount", VariableDirection.INPUT),
         )
     }
 
@@ -198,6 +200,18 @@ class Camunda7ModelExtractorTest {
         assertThat(activity.variables).contains(
             VariableDefinition("orderId", VariableDirection.INPUT),
             VariableDefinition("orderId", VariableDirection.OUTPUT),
+        )
+    }
+
+    @Test
+    fun `extract returns additionalInputVariables for non-interrupting message start event in event subprocess`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-additional-variables.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        val startEvent = bpmnModel.flowNodes.single { it.id == "StartEvent_OrderCancelled" }
+        assertThat(startEvent.variables).containsExactlyInAnyOrder(
+            VariableDefinition("cancellationReason", VariableDirection.INPUT),
+            VariableDefinition("retryCount", VariableDirection.INPUT),
         )
     }
 

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -185,6 +185,8 @@ class OperatonModelExtractorTest {
             VariableDefinition("customerEmail", VariableDirection.OUTPUT),
             VariableDefinition("amount", VariableDirection.OUTPUT),
             VariableDefinition("shipmentId", VariableDirection.OUTPUT),
+            VariableDefinition("cancellationReason", VariableDirection.INPUT),
+            VariableDefinition("retryCount", VariableDirection.INPUT),
         )
     }
 

--- a/shared/bpmn/c7-additional-variables.bpmn
+++ b/shared/bpmn/c7-additional-variables.bpmn
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0">
   <bpmn:message id="Message_1" name="Message_OrderReceived" />
+  <bpmn:message id="Message_2" name="Message_OrderCancelled" />
   <bpmn:process id="orderProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_OrderReceived" name="Order received">
       <bpmn:extensionElements>
@@ -30,6 +31,21 @@
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_OrderReceived" targetRef="Activity_ProcessOrder" />
     <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_ProcessOrder" targetRef="EndEvent_OrderProcessed" />
+    <bpmn:subProcess id="EventSubProcess_OrderCancelled" name="Order cancelled" triggeredByEvent="true">
+      <bpmn:startEvent id="StartEvent_OrderCancelled" name="Order cancelled" isInterrupting="false">
+        <bpmn:extensionElements>
+          <camunda:properties>
+            <camunda:property name="additionalInputVariables" value="cancellationReason, retryCount" />
+          </camunda:properties>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_3</bpmn:outgoing>
+        <bpmn:messageEventDefinition messageRef="Message_2" />
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_Cancelled">
+        <bpmn:incoming>Flow_3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_3" sourceRef="StartEvent_OrderCancelled" targetRef="EndEvent_Cancelled" />
+    </bpmn:subProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcess">
@@ -49,6 +65,19 @@
       <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
         <di:waypoint x="370" y="120" />
         <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EventSubProcess_OrderCancelled_di" bpmnElement="EventSubProcess_OrderCancelled" isExpanded="true">
+        <dc:Bounds x="160" y="220" width="350" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_OrderCancelled_di" bpmnElement="StartEvent_OrderCancelled">
+        <dc:Bounds x="200" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Cancelled_di" bpmnElement="EndEvent_Cancelled">
+        <dc:Bounds x="412" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="236" y="300" />
+        <di:waypoint x="412" y="300" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/shared/bpmn/operaton-additional-variables.bpmn
+++ b/shared/bpmn/operaton-additional-variables.bpmn
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.44.0">
   <bpmn:message id="Message_1" name="Message_OrderReceived" />
+  <bpmn:message id="Message_2" name="Message_OrderCancelled" />
   <bpmn:process id="orderProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_OrderReceived" name="Order received">
       <bpmn:extensionElements>
@@ -30,6 +31,21 @@
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_OrderReceived" targetRef="Activity_ProcessOrder" />
     <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_ProcessOrder" targetRef="EndEvent_OrderProcessed" />
+    <bpmn:subProcess id="EventSubProcess_OrderCancelled" name="Order cancelled" triggeredByEvent="true">
+      <bpmn:startEvent id="StartEvent_OrderCancelled" name="Order cancelled" isInterrupting="false">
+        <bpmn:extensionElements>
+          <operaton:properties>
+            <operaton:property name="additionalInputVariables" value="cancellationReason, retryCount" />
+          </operaton:properties>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_3</bpmn:outgoing>
+        <bpmn:messageEventDefinition messageRef="Message_2" />
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_Cancelled">
+        <bpmn:incoming>Flow_3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_3" sourceRef="StartEvent_OrderCancelled" targetRef="EndEvent_Cancelled" />
+    </bpmn:subProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcess">
@@ -49,6 +65,19 @@
       <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
         <di:waypoint x="370" y="120" />
         <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EventSubProcess_OrderCancelled_di" bpmnElement="EventSubProcess_OrderCancelled" isExpanded="true">
+        <dc:Bounds x="160" y="220" width="350" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_OrderCancelled_di" bpmnElement="StartEvent_OrderCancelled">
+        <dc:Bounds x="200" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Cancelled_di" bpmnElement="EndEvent_Cancelled">
+        <dc:Bounds x="412" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="236" y="300" />
+        <di:waypoint x="412" y="300" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
## Summary
- Extended `c7-additional-variables.bpmn` and `operaton-additional-variables.bpmn` with an event subprocess containing a non-interrupting message start event that carries `additionalInputVariables` (`cancellationReason`, `retryCount`).
- Extended the existing extractor tests to assert the new variables show up in `bpmnModel.variables`, and added a focused test verifying the start event's own `flowNode.variables`.
- Investigation showed the extraction layer already handles this case correctly — these tests lock that behavior in as a regression guard.

## Test plan
- [x] `./gradlew :bpmn-to-code-core:test --tests "*Camunda7ModelExtractorTest*"`
- [x] `./gradlew :bpmn-to-code-core:test --tests "*OperatonModelExtractorTest*"`
- [x] `./gradlew :bpmn-to-code-core:test`