### PR TITLE
fix: preserve additionalInputVariables across variants

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerService.kt
@@ -4,6 +4,7 @@ import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.MergedBpmnModel
 import io.github.emaarco.bpmn.domain.ProcessModel
 import io.github.emaarco.bpmn.domain.MergedBpmnModel.VariantData
+import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableMapping
 
 class ModelMergerService {
@@ -27,7 +28,7 @@ class ModelMergerService {
     private fun deduplicateSingleModel(model: BpmnModel): BpmnModel {
         val models = listOf(model)
         return model.copy(
-            flowNodes = mergeDistinctBy(models) { it.flowNodes },
+            flowNodes = mergeFlowNodes(models),
             messages = mergeDistinctBy(models) { it.messages },
             signals = mergeDistinctBy(models) { it.signals },
             errors = mergeDistinctBy(models) { it.errors },
@@ -44,7 +45,7 @@ class ModelMergerService {
         }
         return MergedBpmnModel(
             processId = processId,
-            flowNodes = mergeDistinctBy(models) { it.flowNodes },
+            flowNodes = mergeFlowNodes(models),
             messages = mergeDistinctBy(models) { it.messages },
             signals = mergeDistinctBy(models) { it.signals },
             errors = mergeDistinctBy(models) { it.errors },
@@ -58,6 +59,23 @@ class ModelMergerService {
                 )
             },
         )
+    }
+
+    /**
+     * Merges flow nodes across models by id, unioning additive list fields like `variables`
+     * and `attachedElements` so that variant-specific extension data (e.g. additionalInputVariables)
+     * is preserved instead of being dropped by simple deduplication.
+     */
+    private fun mergeFlowNodes(models: List<BpmnModel>): List<FlowNodeDefinition> {
+        return models.flatMap { it.flowNodes }
+            .filter { it.getRawName().isNotEmpty() }
+            .groupBy { it.getRawName() }
+            .map { (_, duplicates) ->
+                duplicates.first().copy(
+                    variables = duplicates.flatMap { it.variables }.distinct(),
+                    attachedElements = duplicates.flatMap { it.attachedElements }.distinct(),
+                )
+            }
     }
 
     private fun <T : VariableMapping<*>> mergeDistinctBy(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/ModelMergerServiceTest.kt
@@ -282,6 +282,88 @@ class ModelMergerServiceTest {
     }
 
     @Test
+    fun `unions additionalInputVariables across variants on a shared flow node`() {
+
+        // given: two variants both define the same message start event with different additional input variables
+        val variantA = testBpmnModel(
+            processId = "order-process",
+            variantName = "variantA",
+            flowNodes = listOf(
+                FlowNodeDefinition(
+                    id = "MessageStart_1",
+                    variables = listOf(
+                        VariableDefinition("varA1", VariableDirection.INPUT),
+                        VariableDefinition("shared", VariableDirection.INPUT),
+                    ),
+                ),
+            ),
+        )
+        val variantB = testBpmnModel(
+            processId = "order-process",
+            variantName = "variantB",
+            flowNodes = listOf(
+                FlowNodeDefinition(
+                    id = "MessageStart_1",
+                    variables = listOf(
+                        VariableDefinition("varB1", VariableDirection.INPUT),
+                        VariableDefinition("shared", VariableDirection.INPUT),
+                    ),
+                ),
+            ),
+        )
+
+        // when: merging the two variants
+        val result = underTest.mergeModels(listOf(variantA, variantB))
+
+        // then: the merged top-level flow node carries the union of all variants' variables, deduplicated
+        val merged = result.first() as MergedBpmnModel
+        val mergedNode = merged.flowNodes.first { it.getRawName() == "MessageStart_1" }
+        assertThat(mergedNode.variables).containsExactlyInAnyOrder(
+            VariableDefinition("varA1", VariableDirection.INPUT),
+            VariableDefinition("varB1", VariableDirection.INPUT),
+            VariableDefinition("shared", VariableDirection.INPUT),
+        )
+
+        // and: each variant retains its own original variables on its variant-scoped flow nodes
+        val variantANode = merged.variants.first { it.variantName == "variantA" }.flowNodes
+            .first { it.getRawName() == "MessageStart_1" }
+        assertThat(variantANode.variables).containsExactly(
+            VariableDefinition("varA1", VariableDirection.INPUT),
+            VariableDefinition("shared", VariableDirection.INPUT),
+        )
+    }
+
+    @Test
+    fun `preserves variables on a flow node that exists only in one variant`() {
+
+        // given: a node that exists only in variantB
+        val variantA = testBpmnModel(
+            processId = "order-process",
+            variantName = "variantA",
+            flowNodes = listOf(FlowNodeDefinition(id = "Task_Shared")),
+        )
+        val variantB = testBpmnModel(
+            processId = "order-process",
+            variantName = "variantB",
+            flowNodes = listOf(
+                FlowNodeDefinition(id = "Task_Shared"),
+                FlowNodeDefinition(
+                    id = "Task_OnlyInB",
+                    variables = listOf(VariableDefinition("onlyInB", VariableDirection.OUTPUT)),
+                ),
+            ),
+        )
+
+        // when: merging
+        val result = underTest.mergeModels(listOf(variantA, variantB))
+
+        // then: variant-only node and its variables surface in the merged top-level flow nodes
+        val merged = result.first() as MergedBpmnModel
+        val onlyInB = merged.flowNodes.first { it.getRawName() == "Task_OnlyInB" }
+        assertThat(onlyInB.variables).containsExactly(VariableDefinition("onlyInB", VariableDirection.OUTPUT))
+    }
+
+    @Test
     fun `returns single model as BpmnModel`() {
 
         // given: a single model


### PR DESCRIPTION
Closes #323

## Summary

- `ModelMergerService` now unions `variables` and `attachedElements` across duplicate flow node ids when merging variants, instead of dropping all but the first occurrence
- The top-level `MergedBpmnModel.flowNodes` is the canonical superset that `VariablesWriter` reads from, so variant-specific `additionalInputVariables` now surface in generated code
- Variant-scoped `VariantData.flowNodes` are untouched and still drive per-variant `Flows` / `Relations`

## Test plan

- [x] New test: union of `additionalInputVariables` across variants on a shared flow node (RED before fix, GREEN after)
- [x] New test: variables on a node that exists in only one variant survive the merge (regression guard)
- [x] `./gradlew :bpmn-to-code-core:test`
- [x] `./gradlew build`