### PR TITLE
feat: verbose model output for Gradle and Maven plugins

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiFilesystemPlugin.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/inbound/CreateProcessApiFilesystemPlugin.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.inbound
 
 import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessApiFromFilesystemUseCase
 import io.github.emaarco.bpmn.application.service.GenerateProcessApiService
+import io.github.emaarco.bpmn.domain.BpmnFileResult
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
@@ -18,7 +19,7 @@ class CreateProcessApiFilesystemPlugin(
         outputLanguage: OutputLanguage,
         engine: ProcessEngine,
         validationConfig: ValidationConfig = ValidationConfig(),
-    ) = useCase.generateProcessApi(
+    ): List<BpmnFileResult> = useCase.generateProcessApi(
         GenerateProcessApiFromFilesystemUseCase.Command(
             baseDir = baseDir,
             filePattern = filePattern,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessApiFromFilesystemUseCase.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/port/inbound/GenerateProcessApiFromFilesystemUseCase.kt
@@ -1,11 +1,12 @@
 package io.github.emaarco.bpmn.application.port.inbound
 
+import io.github.emaarco.bpmn.domain.BpmnFileResult
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig
 
 interface GenerateProcessApiFromFilesystemUseCase {
-    fun generateProcessApi(command: Command)
+    fun generateProcessApi(command: Command): List<BpmnFileResult>
     data class Command(
         val baseDir: String,
         val filePattern: String,

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiService.kt
@@ -5,6 +5,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.ExtractBpmnAdapter
 import io.github.emaarco.bpmn.adapter.outbound.filesystem.BpmnFileLoader
 import io.github.emaarco.bpmn.adapter.outbound.filesystem.ProcessApiFileSaver
 import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessApiFromFilesystemUseCase
+import io.github.emaarco.bpmn.domain.BpmnFileResult
 import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
 import io.github.emaarco.bpmn.application.port.outbound.GenerateApiCodePort
 import io.github.emaarco.bpmn.application.port.outbound.LoadBpmnFilesPort
@@ -24,7 +25,7 @@ class GenerateProcessApiService(
 
     private val modelMergerService = ModelMergerService()
 
-    override fun generateProcessApi(command: GenerateProcessApiFromFilesystemUseCase.Command) {
+    override fun generateProcessApi(command: GenerateProcessApiFromFilesystemUseCase.Command): List<BpmnFileResult> {
         val validationService = BpmnValidationService(command.validationConfig)
         val inputFiles = bpmnFileLoader.loadFrom(command.baseDir, command.filePattern)
         val models = inputFiles.map { bpmnService.extract(it, command.engine) }
@@ -35,6 +36,14 @@ class GenerateProcessApiService(
             .flatMap { codeGenerator.generateCode(toBpmnModelApi(it, command)) }
             .distinctBy { it.packagePath to it.fileName }
         fileSystemOutput.writeFiles(generatedFiles, command.outputFolderPath)
+        val filesByProcessId = inputFiles.zip(models)
+            .groupBy({ (_, model) -> model.processId }, { (file, _) -> file.fileName })
+        return mergedModels.map { model ->
+            BpmnFileResult(
+                processId = model.processId,
+                sourceFiles = filesByProcessId[model.processId] ?: emptyList(),
+            )
+        }
     }
 
     private fun toBpmnModelApi(

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnFileResult.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnFileResult.kt
@@ -1,0 +1,3 @@
+package io.github.emaarco.bpmn.domain
+
+data class BpmnFileResult(val processId: String, val sourceFiles: List<String>)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
@@ -15,6 +15,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class GenerateProcessApiServiceTest {
@@ -59,7 +60,7 @@ class GenerateProcessApiServiceTest {
         )
 
         // when: generateProcessApi is invoked
-        underTest.generateProcessApi(command)
+        val results = underTest.generateProcessApi(command)
 
         // then: the API code is generated and written to disk
         val expectedModelApi = getExpectedModelApi()
@@ -67,6 +68,9 @@ class GenerateProcessApiServiceTest {
         verify { codeGenerator.generateCode(expectedModelApi) }
         verify { fileSystemOutput.writeFiles(listOf(expectedGeneratedFile), "outputFolder") }
         confirmVerified(codeGenerator, bpmnFileLoader, fileSystemOutput)
+        assertThat(results).hasSize(1)
+        assertThat(results[0].processId).isEqualTo("newsletterSubscription")
+        assertThat(results[0].sourceFiles).containsExactly("dummy.bpmn")
     }
 
     private val dummyModel = BpmnModel(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiServiceTest.kt
@@ -1,6 +1,7 @@
 package io.github.emaarco.bpmn.application.service
 
 import io.github.emaarco.bpmn.adapter.outbound.filesystem.ProcessApiFileSaver
+import io.github.emaarco.bpmn.domain.BpmnFileResult
 import io.github.emaarco.bpmn.application.port.inbound.GenerateProcessApiFromFilesystemUseCase
 import io.github.emaarco.bpmn.application.port.outbound.ExtractBpmnPort
 import io.github.emaarco.bpmn.application.port.outbound.GenerateApiCodePort
@@ -68,9 +69,7 @@ class GenerateProcessApiServiceTest {
         verify { codeGenerator.generateCode(expectedModelApi) }
         verify { fileSystemOutput.writeFiles(listOf(expectedGeneratedFile), "outputFolder") }
         confirmVerified(codeGenerator, bpmnFileLoader, fileSystemOutput)
-        assertThat(results).hasSize(1)
-        assertThat(results[0].processId).isEqualTo("newsletterSubscription")
-        assertThat(results[0].sourceFiles).containsExactly("dummy.bpmn")
+        assertThat(results).isEqualTo(listOf(BpmnFileResult(processId = "newsletterSubscription", sourceFiles = listOf("dummy.bpmn"))))
     }
 
     private val dummyModel = BpmnModel(

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
@@ -35,7 +35,7 @@ abstract class GenerateBpmnModelsTask : DefaultTask() {
     fun execute() {
         validate()
         val service = CreateProcessApiFilesystemPlugin()
-        service.execute(
+        val results = service.execute(
             baseDir = baseDir,
             filePattern = filePattern,
             outputFolderPath = outputFolderPath,
@@ -43,7 +43,15 @@ abstract class GenerateBpmnModelsTask : DefaultTask() {
             outputLanguage = outputLanguage,
             engine = processEngine,
         )
-        logger.lifecycle("BPMN models generated successfully")
+        if (results.isEmpty()) {
+            logger.lifecycle("No BPMN models found")
+            return
+        }
+        results.forEach { result ->
+            val files = result.sourceFiles.joinToString(", ")
+            logger.lifecycle("  Generated: ${result.processId} (from $files)")
+        }
+        logger.lifecycle("BPMN models generated successfully (${results.size} models)")
     }
 
     private fun validate() {

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
@@ -1,9 +1,12 @@
 package io.github.emaarco.bpmn.adapter;
 
 import io.github.emaarco.bpmn.adapter.inbound.CreateProcessApiFilesystemPlugin;
+import io.github.emaarco.bpmn.domain.BpmnFileResult;
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage;
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine;
 import io.github.emaarco.bpmn.domain.validation.model.ValidationConfig;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -76,8 +79,16 @@ public class BpmnModelMojo extends AbstractMojo {
 		CreateProcessApiFilesystemPlugin plugin = new CreateProcessApiFilesystemPlugin();
 		OutputLanguage language = OutputLanguage.valueOf(outputLanguage);
 		ProcessEngine engine = ProcessEngine.valueOf(processEngine);
-		plugin.execute(baseDir, filePattern, outputFolderPath, packagePath, language, engine, new ValidationConfig());
-		getLog().info("BPMN models generated successfully");
+		List<BpmnFileResult> results = plugin.execute(baseDir, filePattern, outputFolderPath, packagePath, language, engine, new ValidationConfig());
+		if (results.isEmpty()) {
+			getLog().info("No BPMN models found");
+			return;
+		}
+		for (BpmnFileResult result : results) {
+			String files = String.join(", ", result.getSourceFiles());
+			getLog().info("  Generated: " + result.getProcessId() + " (from " + files + ")");
+		}
+		getLog().info("BPMN models generated successfully (" + results.size() + " models)");
 	}
 	
 }


### PR DESCRIPTION
## Summary

- Each plugin now logs one line per generated process model instead of a single static summary
- Output includes `processId` and the source BPMN file(s) it was generated from
- Multiple source files per `processId` (merged variant models) are shown comma-separated
- Logs a clear message when no BPMN files are found instead of `"0 models"`

**Example output:**
```
> Task :services:foo:generateBpmnModelApi
  Generated: OrderProcess (from order-process.bpmn)
  Generated: PaymentProcess (from payment-process-v1.bpmn, payment-process-v2.bpmn)
  BPMN models generated successfully (2 models)
```

## Changes

- `BpmnFileResult` — new domain type carrying `processId` and `sourceFiles`
- `GenerateProcessApiFromFilesystemUseCase` — return type changed from `Unit` to `List<BpmnFileResult>`
- `GenerateProcessApiService` — builds result list by zipping input files with extracted models, grouped by `processId`
- `GenerateBpmnModelsTask` (Gradle) and `BpmnModelMojo` (Maven) — log verbose output from returned results

## Test plan

- [ ] `./gradlew :bpmn-to-code-core:test` — service test asserts `BpmnFileResult` content
- [ ] `./gradlew :bpmn-to-code-gradle:test`
- [ ] `./gradlew :bpmn-to-code-maven:test`