### PR TITLE
chore(release): prepare 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Works with Claude Code out of the box.
 
 ```kotlin
 plugins {
-    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.1"
+    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.2"
 }
 
 tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
@@ -101,7 +101,7 @@ tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
 <plugin>
     <groupId>io.github.emaarco</groupId>
     <artifactId>bpmn-to-code-maven</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <executions>
         <execution>
             <goals><goal>generate-bpmn-api</goal></goals>
@@ -122,7 +122,7 @@ tasks.named("generateBpmnModelApi", GenerateBpmnModelsTask::class) {
 
 ```kotlin
 dependencies {
-    testImplementation("io.github.emaarco:bpmn-to-code-testing:2.0.1")
+    testImplementation("io.github.emaarco:bpmn-to-code-testing:2.0.2")
 }
 ```
 

--- a/bpmn-to-code-gradle/README.md
+++ b/bpmn-to-code-gradle/README.md
@@ -14,7 +14,7 @@ To get started, apply the plugin in your build.gradle.kts file:
 
 ```kotlin
 plugins {
-    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.1"
+    id("io.github.emaarco.bpmn-to-code-gradle") version "2.0.2"
 }
 ```
 

--- a/bpmn-to-code-maven/README.md
+++ b/bpmn-to-code-maven/README.md
@@ -18,7 +18,7 @@ Add the `bpmn-to-code-runtime` dependency (it ships the shared types — `Proces
     <dependency>
         <groupId>io.github.emaarco</groupId>
         <artifactId>bpmn-to-code-runtime</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
     </dependency>
 </dependencies>
 ```
@@ -33,7 +33,7 @@ BPMN files, where to output the generated API files, and how to format the outpu
         <plugin>
             <groupId>io.github.emaarco</groupId>
             <artifactId>bpmn-to-code-maven</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
             <executions>
                 <execution>
                     <goals>

--- a/bpmn-to-code-mcp/README.md
+++ b/bpmn-to-code-mcp/README.md
@@ -40,7 +40,7 @@ The JAR is created at `bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-<version>-al
 
 **Test it manually:**
 ```bash
-java -jar bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-2.0.1-all.jar
+java -jar bpmn-to-code-mcp/build/libs/bpmn-to-code-mcp-2.0.2-all.jar
 ```
 
 ### Configuring Your MCP Client
@@ -54,7 +54,7 @@ Add to your `.claude/settings.json` (project-level) or `~/.claude/settings.json`
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.2-all.jar"]
     }
   }
 }
@@ -69,7 +69,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "bpmn-to-code": {
       "command": "java",
-      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]
+      "args": ["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.2-all.jar"]
     }
   }
 }
@@ -80,6 +80,6 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 Most MCP clients follow a similar pattern — point them at the JAR using stdio transport:
 
 - **Command:** `java`
-- **Args:** `["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.1-all.jar"]`
+- **Args:** `["-jar", "/absolute/path/to/bpmn-to-code-mcp-2.0.2-all.jar"]`
 
 Refer to your client's documentation for the exact configuration location.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
-projectVersion=2.0.1
+projectVersion=2.0.2


### PR DESCRIPTION
Bumps version from 2.0.1 → 2.0.2.

- `gradle.properties`: `projectVersion=2.0.2`
- README files updated with new version strings