### PR TITLE
feat: add dry-run support to publish pipelines

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -2,6 +2,11 @@ name: Publish All Artifacts
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build & verify only, no real publish)'
+        type: boolean
+        default: false
   release:
     types: [published]
 
@@ -13,14 +18,20 @@ jobs:
     name: Publish to Maven Central
     uses: ./.github/workflows/publish-to-maven.yml
     secrets: inherit
+    with:
+      dry_run: ${{ inputs.dry_run == true }}
 
   publish-gradle:
     name: Publish to Gradle Plugin Portal
     needs: publish-maven
     uses: ./.github/workflows/publish-to-gradle.yml
     secrets: inherit
+    with:
+      dry_run: ${{ inputs.dry_run == true }}
 
   publish-docker:
     name: Publish to Docker Hub
     uses: ./.github/workflows/publish-to-docker.yml
     secrets: inherit
+    with:
+      dry_run: ${{ inputs.dry_run == true }}

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -2,7 +2,17 @@ name: Publish to Docker Hub
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build & verify only, no real publish)'
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      dry_run:
+        description: 'Dry run (build & verify only, no real publish)'
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -26,6 +36,7 @@ jobs:
         run: ./gradlew build --warning-mode all
 
       - name: Log in to Docker Hub
+        if: inputs.dry_run != true
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -35,11 +46,13 @@ jobs:
         run: ./gradlew :bpmn-to-code-web:dockerBuild --no-configuration-cache
 
       - name: Push Docker Image
+        if: inputs.dry_run != true
         run: ./gradlew :bpmn-to-code-web:dockerPush --no-configuration-cache
 
       - name: Push Latest Tag
+        if: inputs.dry_run != true
         run: docker push emaarco/bpmn-to-code-web:latest
 
       - name: Log out from Docker Hub
-        if: always()
+        if: always() && inputs.dry_run != true
         run: docker logout

--- a/.github/workflows/publish-to-gradle.yml
+++ b/.github/workflows/publish-to-gradle.yml
@@ -2,7 +2,17 @@ name: Publish to Gradle Plugin Portal
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build & verify only, no real publish)'
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      dry_run:
+        description: 'Dry run (build & verify only, no real publish)'
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -33,4 +43,5 @@ jobs:
         run: ./gradlew publishPlugins --validate-only
 
       - name: Publish Plugin
+        if: inputs.dry_run != true
         run: ./gradlew publishPlugins

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -2,7 +2,17 @@ name: Publish to Maven Central
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build & verify only, no real publish)'
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      dry_run:
+        description: 'Dry run (build & verify only, no real publish)'
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -33,4 +43,9 @@ jobs:
         run: ./gradlew build --warning-mode all
 
       - name: Publish to Maven Central
+        if: inputs.dry_run != true
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -PsignArtifacts=true
+
+      - name: Publish to Maven Local (Dry Run)
+        if: inputs.dry_run == true
+        run: ./gradlew publishToMavenLocal --no-configuration-cache


### PR DESCRIPTION
## Summary

- Adds a `dry_run` boolean input to all four publish workflows (`publish-all`, `publish-to-maven`, `publish-to-gradle`, `publish-to-docker`)
- In dry-run mode: Maven publishes to local only, Gradle skips the actual portal publish (validate-only), Docker builds the image but skips all push steps
- The `release: published` trigger is unaffected — it always performs a real publish

## Test plan

- [ ] Trigger `publish-all.yml` manually via GitHub UI with `dry_run: true` and verify no artifacts are pushed
- [ ] Trigger each child workflow individually with `dry_run: true` to verify standalone behavior
- [ ] Verify a real release still works end-to-end (e.g. via a test release or by checking the `release:` trigger path)