### PR TITLE
fix(web): prevent <none>:<none> dangling images on Docker rebuild

### DIFF
--- a/bpmn-to-code-web/build.gradle.kts
+++ b/bpmn-to-code-web/build.gradle.kts
@@ -133,6 +133,19 @@ tasks.register<Exec>("dockerBuild") {
     workingDir = rootProject.projectDir
 
     doFirst {
+        // Remove old tags before building so they don't become <none>:<none> dangling images.
+        // isIgnoreExitValue = true is the Gradle equivalent of "|| true": if the image doesn't
+        // exist yet (first-ever build), docker rmi exits non-zero — we want to continue anyway.
+        val docker = findDocker()
+        listOf("$dockerImageName:$dockerImageTag", "$dockerImageName:latest").forEach { tag ->
+            exec {
+                commandLine(docker, "rmi", tag)
+                isIgnoreExitValue = true
+            }
+        }
+    }
+
+    doFirst {
         val docker = findDocker()
         println("Building Docker image: $dockerImageName:$dockerImageTag")
         println("Using docker: $docker")

--- a/bpmn-to-code-web/build.gradle.kts
+++ b/bpmn-to-code-web/build.gradle.kts
@@ -138,7 +138,7 @@ tasks.register<Exec>("dockerBuild") {
         // exist yet (first-ever build), docker rmi exits non-zero — we want to continue anyway.
         val docker = findDocker()
         listOf("$dockerImageName:$dockerImageTag", "$dockerImageName:latest").forEach { tag ->
-            exec {
+            project.exec {
                 commandLine(docker, "rmi", tag)
                 isIgnoreExitValue = true
             }

--- a/bpmn-to-code-web/build.gradle.kts
+++ b/bpmn-to-code-web/build.gradle.kts
@@ -138,10 +138,7 @@ tasks.register<Exec>("dockerBuild") {
         // exist yet (first-ever build), docker rmi exits non-zero — we want to continue anyway.
         val docker = findDocker()
         listOf("$dockerImageName:$dockerImageTag", "$dockerImageName:latest").forEach { tag ->
-            project.exec {
-                commandLine(docker, "rmi", tag)
-                isIgnoreExitValue = true
-            }
+            ProcessBuilder(docker, "rmi", tag).inheritIO().start().waitFor()
         }
     }
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,8 @@
 pre-push:
   commands:
+    compile:
+      glob: "*.{kt,kts}"
+      run: ./gradlew compileKotlin
     coverage:
       glob: "*.{kt,kts}"
       run: ./gradlew :bpmn-to-code-core:jacocoTestCoverageVerification


### PR DESCRIPTION
## Summary

- Before each `dockerBuild`, explicitly remove the old `:<version>` and `:latest` tags
- This prevents them from becoming `<none>:<none>` dangling images in Docker Desktop
- Uses `isIgnoreExitValue = true` (equivalent of `|| true`) so first-ever builds don't fail when the image doesn't exist yet
- Only the two `emaarco/bpmn-to-code-web` tags are removed — no other images on the host are affected