### PR TITLE
fix(core): ignore call-activity sourceExpression mappings

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -259,9 +259,8 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
         val inElements = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
         val outElements = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
         val sourceVars = inElements.extractAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE)
-        val sourceExprVars = inElements.extractAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE_EXPRESSION)
         val targetVars = outElements.extractAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TARGET)
-        val inputs = (sourceVars + sourceExprVars).map { it to VariableDirection.INPUT }
+        val inputs = sourceVars.map { it to VariableDirection.INPUT }
         val outputs = targetVars.map { it to VariableDirection.OUTPUT }
         return inputs + outputs
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -276,9 +276,8 @@ class OperatonModelExtractor : EngineSpecificExtractor {
         val inElements = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
         val outElements = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
         val sourceVars = inElements.extractAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE)
-        val sourceExprVars = inElements.extractAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE_EXPRESSION)
         val targetVars = outElements.extractAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TARGET)
-        val inputs = (sourceVars + sourceExprVars).map { it to VariableDirection.INPUT }
+        val inputs = sourceVars.map { it to VariableDirection.INPUT }
         val outputs = targetVars.map { it to VariableDirection.OUTPUT }
         return inputs + outputs
     }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -52,7 +52,7 @@ class Camunda7ModelExtractorTest {
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
-                        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT), VariableDefinition("reasonCode", VariableDirection.INPUT), VariableDefinition("abortResult", VariableDirection.OUTPUT)),
+                        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT), VariableDefinition("abortResult", VariableDirection.OUTPUT)),
                         previousElements = listOf("Timer_After3Days"),
                         followingElements = listOf("CompensationEndEvent_RegistrationAborted"),
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true)),

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -52,7 +52,7 @@ class OperatonModelExtractorTest {
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",
                         properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
-                        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT), VariableDefinition("reasonCode", VariableDirection.INPUT), VariableDefinition("abortResult", VariableDirection.OUTPUT)),
+                        variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT), VariableDefinition("abortResult", VariableDirection.OUTPUT)),
                         previousElements = listOf("Timer_After3Days"),
                         followingElements = listOf("CompensationEndEvent_RegistrationAborted"),
                         engineSpecificProperties = mapOf(ASYNC_BEFORE_KEY to true, ASYNC_AFTER_KEY to true)),

--- a/docs/contributing/adr/015-directional-variable-extraction.md
+++ b/docs/contributing/adr/015-directional-variable-extraction.md
@@ -36,12 +36,14 @@ Direction mapping per source:
 
 | Source | Direction |
 |--------|-----------|
-| `<zeebe:input>`, `<camunda:inputParameter>`, `<camunda:in source="…">` or `sourceExpression="…">` | INPUT |
+| `<zeebe:input>`, `<camunda:inputParameter>`, `<camunda:in source="…">` | INPUT |
 | `<zeebe:output>`, `<camunda:outputParameter>`, `<camunda:out target="…">` | OUTPUT |
 | Multi-instance `inputElement` / `inputCollection` (Zeebe), `camunda:collection` / `camunda:elementVariable` (C7/Operaton) | INPUT |
 | Multi-instance `outputElement` / `outputCollection` (Zeebe) | OUTPUT |
 | `additionalInputVariables` property | INPUT |
 | `additionalOutputVariables` property | OUTPUT |
+
+`<camunda:in sourceExpression="…">` mappings are **not** extracted: the value is arbitrary Expression Language (e.g. `${execution.getVariable('foo') != true}`) rather than a variable name, so any name we tried to derive would be misleading. Pair such mappings with a plain `<camunda:in source="…">` if the underlying variable should appear in the generated API.
 
 ## Consequences
 

--- a/shared/bpmn/c7-subscribe-newsletter.bpmn
+++ b/shared/bpmn/c7-subscribe-newsletter.bpmn
@@ -105,7 +105,7 @@
     <bpmn:callActivity id="CallActivity_AbortRegistration" name="Abort registration" camunda:asyncBefore="true" camunda:asyncAfter="true" calledElement="abort-registration">
       <bpmn:extensionElements>
         <camunda:in source="subscriptionId" target="childSubscriptionId" />
-        <camunda:in sourceExpression="${reasonCode}" target="childReasonCode" />
+        <camunda:in sourceExpression="${execution.getVariable('reasonCode') != true}" target="childReasonCode" />
         <camunda:out source="childAbortResult" target="abortResult" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1l1lj4m</bpmn:incoming>

--- a/shared/bpmn/operaton-subscribe-newsletter.bpmn
+++ b/shared/bpmn/operaton-subscribe-newsletter.bpmn
@@ -109,7 +109,7 @@
     <bpmn:callActivity id="CallActivity_AbortRegistration" name="Abort registration" operaton:asyncBefore="true" operaton:asyncAfter="true" calledElement="abort-registration">
       <bpmn:extensionElements>
         <operaton:in source="subscriptionId" target="childSubscriptionId" />
-        <operaton:in sourceExpression="${reasonCode}" target="childReasonCode" />
+        <operaton:in sourceExpression="${execution.getVariable('reasonCode') != true}" target="childReasonCode" />
         <operaton:out source="childAbortResult" target="abortResult" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1l1lj4m</bpmn:incoming>


### PR DESCRIPTION
## Summary
- `<camunda:in sourceExpression="…">` / `<operaton:in sourceExpression="…">` contains arbitrary EL (e.g. `${execution.getVariable('foo') != true}`), not a variable name. The extractor previously stripped `${}` and emitted mangled constants like `executionGetVariable`.
- Both Camunda 7 and Operaton extractors now ignore `sourceExpression` on call-activity in/out mappings; only plain `source="…"` / `target="…"` mappings contribute variables.
- ADR 015 updated to document the decision; fixtures changed to a complex EL expression to lock in the regression.

## Open design question

This PR takes the **drop-at-extraction** route. An alternative is **keep-in-domain, filter-at-codegen**, which preserves BPMN fidelity at the cost of overloading `VariableDefinition.name` and forcing every consumer to be audited. Tracked in #333 — please weigh in there before merging if the alternative is preferred.

## Test plan
- [x] `./gradlew :bpmn-to-code-core:test` (TDD red → green confirmed before/after the extractor change)
- [x] `./gradlew build` passes across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)