### PR TITLE
docs: add module x language support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ dependencies {
 }
 ```
 
+## Supported Languages
+
+| Module | Java | Kotlin |
+|--------|:---:|:---:|
+| Gradle plugin | ✅ | ✅ |
+| Maven plugin | ✅ | ✅ |
+| Web app | ✅ | ✅ |
+
+> Today, every module emits the same two languages. Additional output languages may be added in the future — most likely surfacing first in the Web app, where there is no JVM build integration to constrain the toolchain.
+
 ## Supported Engines
 
 | Engine | Value |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -32,6 +32,10 @@ Operaton is an open-source fork of Camunda 7. It uses the same patterns for I/O 
 | Kotlin | `KOTLIN` | `object` with `const val` properties |
 | Java | `JAVA` | `class` with `public static final` fields |
 
+::: info
+Currently, the Gradle plugin, Maven plugin, and Web app all emit the same set of languages. Future language support may differ per module — additional languages will likely appear in the Web app first.
+:::
+
 ## Examples
 
 ::: code-group

--- a/docs/overview/why.md
+++ b/docs/overview/why.md
@@ -142,9 +142,11 @@ Thus, bpmn-to-code ships with [AI Skills](/skills/) that automate these workflow
 
 The generation engine is the same everywhere. Pick the format that fits your workflow.
 
-| Format | Best for | |
-|---|---|---|
-| **Gradle plugin** | JVM projects using Gradle | [Setup guide](/getting-started/gradle) |
-| **Maven plugin** | JVM projects using Maven | [Setup guide](/getting-started/maven) |
-| **Web app** | Trying it out, one-off generation, non-JVM projects | [Web app](/web/) |
-| **MCP server** | AI-assisted generation inside your editor | [MCP Server](/mcp/) |
+| Format | Best for | Languages | |
+|---|---|---|---|
+| **Gradle plugin** | JVM projects using Gradle | Java, Kotlin | [Setup guide](/getting-started/gradle) |
+| **Maven plugin** | JVM projects using Maven | Java, Kotlin | [Setup guide](/getting-started/maven) |
+| **Web app** | Trying it out, one-off generation, non-JVM projects | Java, Kotlin | [Web app](/web/) |
+| **MCP server** | AI-assisted generation inside your editor | Java, Kotlin | [MCP Server](/mcp/) |
+
+Output languages may diverge across formats in the future — the Web app is the natural place to add non-JVM languages, since there is no JVM build integration constraining the toolchain.


### PR DESCRIPTION
## Summary

- Adds a **Module × Language** matrix to `README.md` (new `## Supported Languages` section, before `## Supported Engines`) so the supported output languages per module are visible at a glance.
- Extends the **"How to Get Started"** table in `docs/overview/why.md` with a `Languages` column.
- Adds a short note under the **Output Languages** section in `docs/guide/configuration.md` clarifying that today all modules emit the same set of languages.

All notes hint — without committing — that future language support will likely surface first in the Web app, since it is not constrained by a JVM build toolchain.

## Scope

- Pure documentation change. No code or test impact.
- Modules covered in the new README matrix: Gradle plugin, Maven plugin, Web app (Testing module validates rather than generates; MCP wraps the generation engine — both intentionally not in the matrix, though MCP keeps its row in the existing why.md table for consistency).

## Test plan

- [x] `npm run build` in `docs/` passes (VitePress 1.6.4, no markdown/link errors).
- [ ] Visual check `/overview/why` — new `Languages` column renders.
- [ ] Visual check `/guide/configuration` — info block renders below the Output Languages table.
- [ ] GitHub README preview — new `## Supported Languages` section sits between `## Testing Module` and `## Supported Engines`.