### PR TITLE
refactor(core): use multi-dollar raw strings for Kotlin delegate expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target
 .claude/settings.local.json
 .claude/.tmp
 .claude/logs/
+.claude/scheduled_tasks.lock
 docs/node_modules
 docs/.vitepress/dist
 docs/.vitepress/cache

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/codegen/builder/KotlinProcessApiBuilder.kt
@@ -79,9 +79,8 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
 
         override fun write(builder: TypeSpec.Builder, modelApi: BpmnModelApi) {
             val processIdClass = ClassName(RUNTIME_PACKAGE, "ProcessId")
-            val cleanValue = modelApi.model.processId.escapeDollarInterpolation()
             val idProperty = PropertySpec.builder("PROCESS_ID", processIdClass)
-                .initializer("ProcessId(\"$cleanValue\")")
+                .initializer("%T(%L)", processIdClass, stringLiteral(modelApi.model.processId))
                 .build()
             builder.addProperty(idProperty)
         }
@@ -196,7 +195,7 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             if (name != null) add("name = %S,\n", name)
             add("sourceRef = %S,\n", sourceRef)
             add("targetRef = %S,\n", targetRef)
-            if (condition != null) add("condition = \$\$\"\"\"%L\"\"\",\n", condition)
+            if (condition != null) add("condition = %L,\n", stringLiteral(condition))
             if (isDefault) add("isDefault = true,\n")
             unindent()
             add(")")
@@ -345,10 +344,9 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
         }
 
         private fun createDirectionalAttribute(variable: VariableDefinition, subtype: VariableNameSubtype, wrapperClass: ClassName): PropertySpec {
-            val cleanValue = variable.getValue().escapeDollarInterpolation()
             val subtypeClass = wrapperClass.nestedClass(subtype.simpleName)
             return PropertySpec.builder(variable.getName(), subtypeClass)
-                .initializer("%T(\"$cleanValue\")", subtypeClass)
+                .initializer("%T(%L)", subtypeClass, stringLiteral(variable.getValue()))
                 .build()
         }
     }
@@ -414,9 +412,8 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
             val timersBuilder = TypeSpec.objectBuilder("Timers")
             modelApi.model.timers.forEach { timer ->
                 val (timerType, timerValue) = timer.getValue()
-                val cleanTimerValue = timerValue.escapeDollarInterpolation()
                 val instanceBuilder = PropertySpec.builder(timer.getName(), bpmnTimerClass)
-                val variable = instanceBuilder.initializer("BpmnTimer(\"$timerType\", \"$cleanTimerValue\")")
+                val variable = instanceBuilder.initializer("%T(%S, %L)", bpmnTimerClass, timerType, stringLiteral(timerValue))
                 timersBuilder.addProperty(variable.build())
             }
             builder.addType(timersBuilder.build())
@@ -424,22 +421,23 @@ class KotlinProcessApiBuilder : CodeGenerationAdapter.AbstractProcessApiBuilder<
     }
 
     private fun createAttribute(variable: VariableMapping<String>): PropertySpec {
-        val cleanValue = variable.getValue().escapeDollarInterpolation()
         return PropertySpec.builder(variable.getName(), String::class)
             .addModifiers(KModifier.CONST)
-            .initializer("\"$cleanValue\"")
+            .initializer("%L", stringLiteral(variable.getValue()))
             .build()
     }
 
     private fun createTypedAttribute(variable: VariableMapping<String>, wrapperClass: ClassName): PropertySpec {
-        val cleanValue = variable.getValue().escapeDollarInterpolation()
         return PropertySpec.builder(variable.getName(), wrapperClass)
-            .initializer("${wrapperClass.simpleName}(\"$cleanValue\")")
+            .initializer("%T(%L)", wrapperClass, stringLiteral(variable.getValue()))
             .build()
     }
 
-    private fun String.escapeDollarInterpolation(): String {
-        // Prevent KotlinPoet from interpreting "${...}" in string literals as interpolation
-        return this.replace("\${", "\\\${")
+    private fun stringLiteral(value: String): CodeBlock {
+        return if (value.contains("\${")) {
+            CodeBlock.of("\$\$\"\"\"%L\"\"\"", value)
+        } else {
+            CodeBlock.of("%S", value)
+        }
     }
 }

--- a/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
+++ b/bpmn-to-code-core/src/test/resources/api/NewsletterSubscriptionProcessApiKotlin.txt
@@ -90,7 +90,7 @@ object NewsletterSubscriptionProcessApi {
   object ServiceTasks {
     const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "#{newsletterSendConfirmationMail}"
 
-    const val NEWSLETTER_SEND_WELCOME_MAIL: String = "\${newsletterSendWelcomeMail}"
+    const val NEWSLETTER_SEND_WELCOME_MAIL: String = $$"""${newsletterSendWelcomeMail}"""
 
     const val COUNTER_CLASS: String = "counterClass"
 
@@ -98,7 +98,7 @@ object NewsletterSubscriptionProcessApi {
   }
 
   object Timers {
-    val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", "\${testVariable}")
+    val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", $$"""${testVariable}""")
 
     val TIMER_EVERY_DAY: BpmnTimer = BpmnTimer("Duration", "PT1M")
   }


### PR DESCRIPTION
## Summary

Closes #337.

Unifies how the Kotlin generator emits delegate expressions (`${...}`) into the generated API. `Flows.condition` already used Kotlin's multi-dollar raw string `$$"""..."""`; `ServiceTasks`, `Timers`, `Variables`, `ProcessId` and the typed wrappers escaped `$` to `\$` via a helper. Both now converge on the raw-string approach.

A small `stringLiteral()` helper returns `$$"""…"""` when the value contains `${`, and `%S` otherwise — so plain strings (e.g. `"counterClass"`, `"Duration"`) stay as regular literals and only delegate-containing values become raw strings. The `escapeDollarInterpolation()` helper is removed.

## Test plan

- [x] `./gradlew :bpmn-to-code-core:test` — generator tests + embedded Kotlin syntax validation pass
- [x] `./gradlew :bpmn-to-code-gradle:test` — Gradle smoke test compiles generated code with Kotlin 2.3.21
- [x] `./gradlew :bpmn-to-code-maven:test` — Maven smoke test compiles generated code