### PR TITLE
fix(release-please): disable component prefix in tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
## Summary

Follow-up to #342. The first release-please run on `main` failed:

```
⚠ looking for tagName: bpmn-to-code-v2.0.4
⚠ Expected 1 releases, only found 0
⚠ Missing 1 paths: .
```

Cause: with `package-name: "bpmn-to-code"` set and `include-component-in-tag` unset, release-please defaults to prefixing tags with the package name (looking for `bpmn-to-code-v2.0.4`), which doesn't match our existing tag history (`v2.0.4`, `v2.0.3`, …).

Fix: add `"include-component-in-tag": false` at the top of `release-please-config.json`

After merge, the next run should:
- find the existing `v2.0.4` tag,
- collect commits since then,
- open a Release PR proposing the next semver bump.

The release-please-managed branch with the wrong name (`release-please--branches--main--components--bpmn-to-code`) will be superseded automatically; we can delete it manually afterwards if it lingers.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger the workflow manually (`gh workflow run "Release Please" -f dry_run=true`) to confirm it finds `v2.0.4` and computes the next bump without errors.
- [ ] Re-run without dry-run; a Release PR is opened with branch name `release-please--branches--main` (no component suffix) and the correct version bump.