### PR TITLE
fix(release-please): use block markers for gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
-# x-release-please-version
+# x-release-please-start-version
 projectVersion=2.0.4
+# x-release-please-end


### PR DESCRIPTION
## Summary

Follow-up to #343. The release-please run after merging #343 succeeded in opening PR #344 — but the diff only touches `.release-please-manifest.json` and `CHANGELOG.md`. `gradle.properties` is left at `2.0.4`, so the bump never reaches the actual artefacts.

Cause: `x-release-please-version` is an **inline** marker — release-please expects the version on the **same line**. In `.properties` files that's impossible: Gradle/Java interpret everything after `=` as the value, so `projectVersion=2.0.4 # x-release-please-version` would set the version to the literal string `2.0.4 # x-release-please-version`.

Fix: use the block-style markers, which the generic updater applies to every semver token between sentinels.

```properties
# x-release-please-start-version
projectVersion=2.0.4
# x-release-please-end
```

After merging this, release-please will refresh PR #344 (or open a new one) and the diff will include the `gradle.properties` bump.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger workflow manually: `gh workflow run "Release Please"`.
- [ ] Confirm the Release PR now updates `gradle.properties` from `2.0.4` to `2.0.5` (or higher).