### PR TITLE
fix(testing): bundle BPMN model + logging deps transitively

### DIFF
--- a/bpmn-to-code-testing/build.gradle.kts
+++ b/bpmn-to-code-testing/build.gradle.kts
@@ -21,6 +21,8 @@ sourceSets {
 dependencies {
     compileOnly(project(":bpmn-to-code-core"))
     api(libs.assertj)
+    api(libs.bpmnmodel)
+    api(libs.kotlinLogging)
     compileOnly(libs.junit)
     testImplementation(project(":bpmn-to-code-core"))
     testImplementation(libs.bundles.testing)


### PR DESCRIPTION
## What

Declare `camunda-bpmn-model` and `kotlin-logging` as `api` dependencies in `bpmn-to-code-testing`.

## Why

`bpmn-to-code-testing` embeds `bpmn-to-code-core`'s classes into its own jar (`tasks.jar { from core output }`) but declares core as `compileOnly`. As a result, core's runtime dependencies were dropped from the published POM.

Consequences for consumers:
- They had to add `runtimeOnly("org.camunda.bpm.model:camunda-bpmn-model:7.24.0")` by hand (the parser used by the embedded `ExtractBpmnAdapter`).
- They would also hit a missing `kotlin-logging` — `ExtractBpmnAdapter` declares a class-init logger (`KotlinLogging.logger {}`), which is loaded on the `validate()` path. This usually didn't surface only because most consumer projects already have logging on the classpath.

The Gradle and Maven plugin modules already work around the same packaging trick by re-declaring core's runtime deps as `api`. This brings the testing module in line, limited to what the validate path actually needs. `slf4j-api` arrives transitively via `kotlin-logging-jvm`.

## Verification

Generated POM (`generatePomFileForMavenPublication`) now lists both `org.camunda.bpm.model:camunda-bpmn-model` and `io.github.oshai:kotlin-logging-jvm` as `compile` scope. `:bpmn-to-code-testing:build` passes.