### PR TITLE
ci: trigger downstream workflows on automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-pull-request: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## What

Pass a dedicated `RELEASE_PLEASE_TOKEN` to the release-please action in `release-please.yml`.

## Why

A tag push or GitHub Release created with the built-in `GITHUB_TOKEN` does **not** trigger other workflows — GitHub's recursion guard. When release-please published 2.1.1 fully automatically (as `github-actions[bot]`), the `release: published` event was suppressed and `publish-all.yml` never started. Earlier releases only worked because they were published by a human identity.

With a non-`GITHUB_TOKEN` identity, the tag push and release it creates fire downstream events normally, so `publish-all` runs on its own. As a bonus, release PRs opened by release-please will also trigger PR CI (`build-backend.yml`).

## Required setup

The `RELEASE_PLEASE_TOKEN` secret must exist — a fine-grained PAT (or GitHub App token) scoped to this repo with `Contents: write` + `Pull requests: write`. (Already added.)

## Note

2.1.1 itself was published manually via `workflow_dispatch` of `publish-all`; this change prevents the gap on future releases.