### PR TITLE
fix(web): correct broken doc links on landing page

### DIFF
--- a/bpmn-to-code-web/src/main/resources/static/index.html
+++ b/bpmn-to-code-web/src/main/resources/static/index.html
@@ -201,12 +201,12 @@
             <div class="learn-divider"><span>Keep exploring</span></div>
 
             <div class="learn-grid">
-                <a href="https://emaarco.github.io/bpmn-to-code/testing/" target="_blank" rel="noopener" class="learn-card">
+                <a href="https://emaarco.github.io/bpmn-to-code/validate/testing" target="_blank" rel="noopener" class="learn-card">
                     <span class="learn-tag tag-validate">VALIDATE</span>
                     <div class="learn-name">bpmn-to-code-testing</div>
                     <div class="learn-sub">ArchUnit-style rules that enforce BPMN conventions across your repo.</div>
                 </a>
-                <a href="https://emaarco.github.io/bpmn-to-code/agent-skills/" target="_blank" rel="noopener" class="learn-card">
+                <a href="https://emaarco.github.io/bpmn-to-code/skills/" target="_blank" rel="noopener" class="learn-card">
                     <span class="learn-tag tag-ship">SHIP</span>
                     <div class="learn-name">Agent skills</div>
                     <div class="learn-sub">Scaffold Spring process services from BPMN with Claude Code.</div>


### PR DESCRIPTION
## What

Fixes the two broken "Keep exploring" links at the bottom of the web landing page (`bpmn-to-code-web/.../static/index.html`).

| Card | Old (404) | New (200) |
|------|-----------|-----------|
| bpmn-to-code-testing | `/bpmn-to-code/testing/` | `/bpmn-to-code/validate/testing` |
| Agent skills | `/bpmn-to-code/agent-skills/` | `/bpmn-to-code/skills/` |

## Why

Both cards pointed at doc paths that don't exist and returned 404. The new paths match the VitePress nav config (`docs/.vitepress/config.mts`) and were verified to return 200 against the live docs site.