### PR TITLE
feat: detect engine mismatch and add engine-matched demo samples

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/EngineDetector.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/EngineDetector.kt
@@ -1,0 +1,24 @@
+package io.github.emaarco.bpmn.adapter.outbound.engine
+
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+
+/**
+ * Detects which process engine a BPMN file targets by inspecting its XML namespaces.
+ *
+ * This is best-effort: it relies on the presence of the engine-specific namespace.
+ * It returns `null` for plain BPMN files that carry no engine extensions.
+ * The result is used to warn when the selected engine does not match the model's actual target.
+ */
+object EngineDetector {
+
+    private const val ZEEBE_NS = "http://camunda.org/schema/zeebe/"
+    private const val OPERATON_NS = "http://operaton.org/schema/"
+    private const val CAMUNDA_7_NS = "http://camunda.org/schema/1.0/bpmn"
+
+    fun detect(content: String): ProcessEngine? = when {
+        content.contains(ZEEBE_NS) -> ProcessEngine.ZEEBE
+        content.contains(OPERATON_NS) -> ProcessEngine.OPERATON
+        content.contains(CAMUNDA_7_NS) -> ProcessEngine.CAMUNDA_7
+        else -> null
+    }
+}

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -28,6 +28,7 @@ import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDirection
+import io.github.emaarco.bpmn.adapter.outbound.engine.EngineDetector
 import io.github.emaarco.bpmn.adapter.outbound.engine.SecureBpmnParser
 import io.github.emaarco.bpmn.domain.utils.StringUtils.removeExpressionSyntax
 import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
@@ -76,6 +77,7 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
             errors = errors,
             escalations = escalations,
             compensations = compensations,
+            detectedEngine = EngineDetector.detect(bytes.decodeToString()),
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -28,6 +28,7 @@ import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDirection
+import io.github.emaarco.bpmn.adapter.outbound.engine.EngineDetector
 import io.github.emaarco.bpmn.adapter.outbound.engine.SecureBpmnParser
 import io.github.emaarco.bpmn.domain.utils.StringUtils.removeExpressionSyntax
 import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
@@ -80,6 +81,7 @@ class OperatonModelExtractor : EngineSpecificExtractor {
             errors = errors,
             escalations = escalations,
             compensations = compensations,
+            detectedEngine = EngineDetector.detect(bytes.decodeToString()),
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -24,6 +24,7 @@ import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.MessageDefinition
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
+import io.github.emaarco.bpmn.adapter.outbound.engine.EngineDetector
 import io.github.emaarco.bpmn.adapter.outbound.engine.SecureBpmnParser
 import io.github.emaarco.bpmn.domain.shared.VariableDirection
 import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants
@@ -66,6 +67,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             errors = allErrorEvents,
             escalations = allEscalationEvents,
             compensations = allCompensationEvents,
+            detectedEngine = EngineDetector.detect(bytes.decodeToString()),
         )
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/BpmnModel.kt
@@ -7,6 +7,7 @@ import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.MessageDefinition
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.shared.SequenceFlowDefinition
 import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition
 import io.github.emaarco.bpmn.domain.shared.SignalDefinition
@@ -23,6 +24,7 @@ data class BpmnModel(
     override val errors: List<ErrorDefinition>,
     override val escalations: List<EscalationDefinition> = emptyList(),
     override val compensations: List<CompensationDefinition> = emptyList(),
+    val detectedEngine: ProcessEngine? = null,
 ) : ProcessModel {
     override val serviceTasks: List<ServiceTaskDefinition>
         get() = flowNodes.mapNotNull { (it.properties as? FlowNodeProperties.ServiceTask)?.definition }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationService.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationService.kt
@@ -10,6 +10,7 @@ import io.github.emaarco.bpmn.domain.validation.model.ValidationPhase
 import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
 import io.github.emaarco.bpmn.domain.validation.rules.CollisionDetectionRule
 import io.github.emaarco.bpmn.domain.validation.rules.EmptyProcessRule
+import io.github.emaarco.bpmn.domain.validation.rules.EngineMismatchRule
 import io.github.emaarco.bpmn.domain.validation.rules.InvalidIdentifierRule
 import io.github.emaarco.bpmn.domain.validation.rules.MissingCalledElementRule
 import io.github.emaarco.bpmn.domain.validation.rules.MissingElementIdRule
@@ -69,6 +70,7 @@ class BpmnValidationService(
     companion object {
 
         private fun builtInRules() = listOf(
+            EngineMismatchRule(),
             MissingServiceTaskImplementationRule(),
             MissingMessageNameRule(),
             MissingErrorDefinitionRule(),

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EngineMismatchRule.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EngineMismatchRule.kt
@@ -1,0 +1,67 @@
+package io.github.emaarco.bpmn.domain.validation.rules
+
+import io.github.emaarco.bpmn.domain.BpmnModel
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
+
+/**
+ * Flags when a model targets a different engine than the selected one, using the engine detected
+ * during extraction ([BpmnModel.detectedEngine]).
+ *
+ * Zeebe (Camunda 8), Camunda 7, and Operaton each use their own namespace and extension elements,
+ * and an extractor only understands its own — so generating for the wrong engine yields a broken API.
+ * - a clear mismatch (detected ≠ selected) is an **ERROR**;
+ * - an undetermined engine (no recognizable namespace) is a **WARN** — we cannot verify it;
+ * - a match produces nothing.
+ *
+ * Reported like any other rule, so it is collected together with the rest of the findings.
+ */
+class EngineMismatchRule : BpmnValidationRule {
+
+    override val id = "engine-mismatch"
+    override val severity = Severity.ERROR
+
+    override fun validate(context: ValidationContext): List<ValidationViolation> {
+        val detected = (context.model as? BpmnModel)?.detectedEngine
+        val selected = context.engine
+        val violation = when {
+            detected == selected -> null
+            detected == null -> violation(context, Severity.WARN, undeterminedMessage(selected))
+            else -> violation(context, Severity.ERROR, mismatchMessage(detected, selected))
+        }
+        return listOfNotNull(violation)
+    }
+
+    private fun violation(context: ValidationContext, severity: Severity, message: String): ValidationViolation {
+        return ValidationViolation(
+            ruleId = id,
+            severity = severity,
+            elementId = null,
+            processId = context.model.processId,
+            message = message,
+        )
+    }
+
+    private fun mismatchMessage(detected: ProcessEngine, selected: ProcessEngine): String {
+        val detectedName = displayName(detected)
+        val selectedName = displayName(selected)
+        return "This model targets $detectedName, but the selected engine is $selectedName. " +
+            "These engines use incompatible BPMN configurations — select '$detectedName' " +
+            "as the process engine, or provide a model built for $selectedName."
+    }
+
+    private fun undeterminedMessage(selected: ProcessEngine): String {
+        return "Could not determine this model's target engine from its BPMN namespaces, " +
+            "so it cannot be verified against the selected engine (${displayName(selected)}). " +
+            "Make sure the model carries the expected engine namespace."
+    }
+
+    private fun displayName(engine: ProcessEngine): String = when (engine) {
+        ProcessEngine.ZEEBE -> "Zeebe (Camunda 8)"
+        ProcessEngine.CAMUNDA_7 -> "Camunda 7"
+        ProcessEngine.OPERATON -> "Operaton"
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/EngineDetectorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/EngineDetectorTest.kt
@@ -1,0 +1,45 @@
+package io.github.emaarco.bpmn.adapter.outbound.engine
+
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EngineDetectorTest {
+
+    @Test
+    fun `detects Zeebe from its namespace`() {
+        val content = """<definitions xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" />"""
+        assertThat(EngineDetector.detect(content)).isEqualTo(ProcessEngine.ZEEBE)
+    }
+
+    @Test
+    fun `detects Operaton from its namespace`() {
+        val content = """<definitions xmlns:operaton="http://operaton.org/schema/1.0/bpmn" />"""
+        assertThat(EngineDetector.detect(content)).isEqualTo(ProcessEngine.OPERATON)
+    }
+
+    @Test
+    fun `detects Camunda 7 from its namespace`() {
+        val content = """<definitions xmlns:camunda="http://camunda.org/schema/1.0/bpmn" />"""
+        assertThat(EngineDetector.detect(content)).isEqualTo(ProcessEngine.CAMUNDA_7)
+    }
+
+    @Test
+    fun `prefers Zeebe over the Camunda modeler namespace`() {
+        // given: a Zeebe model that also carries the Camunda modeler namespace
+        val content = """
+            <definitions
+                xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" />
+        """.trimIndent()
+
+        // then: the modeler namespace must not be mistaken for Camunda 7
+        assertThat(EngineDetector.detect(content)).isEqualTo(ProcessEngine.ZEEBE)
+    }
+
+    @Test
+    fun `returns null for plain BPMN without engine extensions`() {
+        val content = """<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" />"""
+        assertThat(EngineDetector.detect(content)).isNull()
+    }
+}

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -17,6 +17,7 @@ import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDirection
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testSubscribeNewsletterBpmnModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -48,6 +49,7 @@ class Camunda7ModelExtractorTest {
         assertThat(bpmnModel).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(
             testSubscribeNewsletterBpmnModel(
                 variantName = "withApproval",
+                detectedEngine = ProcessEngine.CAMUNDA_7,
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -17,6 +17,7 @@ import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDirection
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.testSubscribeNewsletterBpmnModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -48,6 +49,7 @@ class OperatonModelExtractorTest {
         assertThat(bpmnModel).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(
             testSubscribeNewsletterBpmnModel(
                 variantName = "withApproval",
+                detectedEngine = ProcessEngine.OPERATON,
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -14,6 +14,7 @@ import io.github.emaarco.bpmn.domain.shared.ServiceTaskDefinition.Companion.IMPL
 import io.github.emaarco.bpmn.domain.shared.TimerDefinition
 import io.github.emaarco.bpmn.domain.shared.SequenceFlowDefinition
 import io.github.emaarco.bpmn.domain.shared.VariableDefinition
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
 import io.github.emaarco.bpmn.domain.shared.VariableDirection
 import io.github.emaarco.bpmn.domain.testSubscribeNewsletterBpmnModel
 import org.assertj.core.api.Assertions.assertThat
@@ -45,6 +46,7 @@ class ZeebeModelExtractorTest {
         assertThat(bpmnModel).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(
             testSubscribeNewsletterBpmnModel(
                 variantName = "withApproval",
+                detectedEngine = ProcessEngine.ZEEBE,
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/GenerateProcessApiInMemoryServiceTest.kt
@@ -7,11 +7,13 @@ import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.GeneratedApiFile
 import io.github.emaarco.bpmn.domain.shared.OutputLanguage
 import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.validation.BpmnValidationException
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 class GenerateProcessApiInMemoryServiceTest {
@@ -57,6 +59,30 @@ class GenerateProcessApiInMemoryServiceTest {
         assertThat(result).hasSize(1)
         assertThat(result[0]).isEqualTo(expectedGeneratedFile)
         confirmVerified(codeGenerator, bpmnService)
+    }
+
+    @Test
+    fun `service rejects a model that targets a different engine before generating`() {
+
+        // given: a model detected as Camunda 7 but generation requested for Operaton
+        val bpmnInput = GenerateProcessApiInMemoryUseCase.BpmnInput(
+            bpmnXml = "<bpmn>camunda</bpmn>",
+            processName = "newsletter.bpmn"
+        )
+        every { bpmnService.extract(any(), any()) } returns dummyModel.copy(detectedEngine = ProcessEngine.CAMUNDA_7)
+        val command = GenerateProcessApiInMemoryUseCase.Command(
+            bpmnContents = listOf(bpmnInput),
+            packagePath = "com.example",
+            outputLanguage = OutputLanguage.KOTLIN,
+            engine = ProcessEngine.OPERATON
+        )
+
+        // when / then: it fails with a single engine-mismatch error and never generates code
+        assertThatThrownBy { underTest.generateProcessApi(command) }
+            .isInstanceOf(BpmnValidationException::class.java)
+            .extracting("violations")
+            .matches { (it as List<*>).size == 1 }
+        verify(exactly = 0) { codeGenerator.generateCode(any()) }
     }
 
     private val dummyModel = BpmnModel(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/application/service/ValidateBpmnServiceTest.kt
@@ -36,9 +36,9 @@ class ValidateBpmnServiceTest {
     @Test
     fun `valid model returns empty result`() {
 
-        // given: a valid model
+        // given: a valid model whose detected engine matches the selected one
         every { bpmnFileLoader.loadFrom(any(), any()) } returns listOf(dummyResource)
-        every { bpmnExtractor.extract(any(), any()) } returns testBpmnModel()
+        every { bpmnExtractor.extract(any(), any()) } returns testBpmnModel(detectedEngine = ProcessEngine.ZEEBE)
 
         // when: validateBpmn is called
         val result = underTest.validateBpmn(command)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/TestBpmnModel.kt
@@ -32,6 +32,7 @@ fun testBpmnModel(
     errors: List<ErrorDefinition> = listOf(ErrorDefinition(id = "errorId", name = "errorName", code = "errorCode")),
     escalations: List<EscalationDefinition> = emptyList(),
     compensations: List<CompensationDefinition> = emptyList(),
+    detectedEngine: ProcessEngine? = null,
 ) = BpmnModel(
     processId = processId,
     variantName = variantName,
@@ -42,6 +43,7 @@ fun testBpmnModel(
     errors = errors,
     escalations = escalations,
     compensations = compensations,
+    detectedEngine = detectedEngine,
 )
 
 fun testBpmnModelApi(
@@ -163,6 +165,7 @@ fun testSubscribeNewsletterBpmnModel(
         CompensationDefinition("CompensationEndEvent_RegistrationAborted", CompensationType.THROWING),
         CompensationDefinition("CompensationEvent_OnSubscriptionCounter", CompensationType.CATCHING),
     ),
+    detectedEngine: ProcessEngine? = null,
 ) = testBpmnModel(
     processId = processId,
     variantName = variantName,
@@ -173,6 +176,7 @@ fun testSubscribeNewsletterBpmnModel(
     errors = errors,
     escalations = escalations,
     compensations = compensations,
+    detectedEngine = detectedEngine,
 )
 
 fun testSendNewsletterBpmnModel(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationServiceTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/service/BpmnValidationServiceTest.kt
@@ -21,8 +21,8 @@ class BpmnValidationServiceTest {
     @Test
     fun `valid model passes all pre-merge rules`() {
 
-        // given: a valid BPMN model
-        val model = testBpmnModel()
+        // given: a valid BPMN model whose detected engine matches the selected one
+        val model = testBpmnModel(detectedEngine = ProcessEngine.ZEEBE)
 
         // when / then: no exception is thrown
         assertDoesNotThrow { underTest.validate(listOf(model), ProcessEngine.ZEEBE, ValidationPhase.PRE_MERGE) }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EngineMismatchRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EngineMismatchRuleTest.kt
@@ -27,13 +27,21 @@ class EngineMismatchRuleTest {
 
     @Test
     fun `no violation when the detected engine matches the selected engine`() {
+
+        // given: a model whose detected engine matches the selected one
         val model = testBpmnModel(detectedEngine = ProcessEngine.ZEEBE)
+
+        // when / then: no violation is reported
         assertThat(underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))).isEmpty()
     }
 
     @Test
     fun `warns when the source engine could not be detected`() {
+
+        // given: a model whose target engine could not be determined
         val model = testBpmnModel(detectedEngine = null)
+
+        // when / then: a single engine-mismatch WARN is produced
         val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
         assertThat(violations).hasSize(1)
         assertThat(violations[0].ruleId).isEqualTo("engine-mismatch")

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EngineMismatchRuleTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/domain/validation/rules/EngineMismatchRuleTest.kt
@@ -1,0 +1,43 @@
+package io.github.emaarco.bpmn.domain.validation.rules
+
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.testBpmnModel
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EngineMismatchRuleTest {
+
+    private val underTest = EngineMismatchRule()
+
+    @Test
+    fun `reports an error when the model targets a different engine`() {
+
+        // given: a model detected as Camunda 7 but validated for Operaton (the reported case)
+        val model = testBpmnModel(detectedEngine = ProcessEngine.CAMUNDA_7)
+
+        // when / then: a single engine-mismatch ERROR is produced
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.OPERATON))
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].ruleId).isEqualTo("engine-mismatch")
+        assertThat(violations[0].severity).isEqualTo(Severity.ERROR)
+        assertThat(violations[0].message).contains("Camunda 7", "Operaton")
+    }
+
+    @Test
+    fun `no violation when the detected engine matches the selected engine`() {
+        val model = testBpmnModel(detectedEngine = ProcessEngine.ZEEBE)
+        assertThat(underTest.validate(ValidationContext(model = model, engine = ProcessEngine.ZEEBE))).isEmpty()
+    }
+
+    @Test
+    fun `warns when the source engine could not be detected`() {
+        val model = testBpmnModel(detectedEngine = null)
+        val violations = underTest.validate(ValidationContext(model = model, engine = ProcessEngine.CAMUNDA_7))
+        assertThat(violations).hasSize(1)
+        assertThat(violations[0].ruleId).isEqualTo("engine-mismatch")
+        assertThat(violations[0].severity).isEqualTo(Severity.WARN)
+        assertThat(violations[0].message).contains("Could not determine", "Camunda 7")
+    }
+}

--- a/bpmn-to-code-web/build.gradle.kts
+++ b/bpmn-to-code-web/build.gradle.kts
@@ -56,6 +56,18 @@ val copyLibrarySources by tasks.registering(Copy::class) {
     include("*.kt")
 }
 
+// Bundle one engine-specific newsletter example per engine for the demo
+val copyExampleModels by tasks.registering(Copy::class) {
+    from(rootProject.layout.projectDirectory.dir("shared/bpmn")) {
+        include(
+            "c8-subscribe-newsletter.bpmn",
+            "c7-subscribe-newsletter.bpmn",
+            "operaton-subscribe-newsletter.bpmn",
+        )
+    }
+    into(layout.buildDirectory.dir("generated/resources/examples/examples"))
+}
+
 val generateLibrarySourcesManifest by tasks.registering {
     dependsOn(copyLibrarySources)
     val outputDir = layout.buildDirectory.dir("generated/resources/library-sources/library-sources")
@@ -72,10 +84,11 @@ val generateLibrarySourcesManifest by tasks.registering {
 
 sourceSets.main {
     resources.srcDir(layout.buildDirectory.dir("generated/resources/library-sources"))
+    resources.srcDir(layout.buildDirectory.dir("generated/resources/examples"))
 }
 
 tasks.named("processResources") {
-    dependsOn(generateLibrarySourcesManifest)
+    dependsOn(generateLibrarySourcesManifest, copyExampleModels)
 }
 
 application {

--- a/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/Application.kt
+++ b/bpmn-to-code-web/src/main/kotlin/io/github/emaarco/bpmn/web/Application.kt
@@ -90,8 +90,8 @@ fun Application.configureApp(
         // Serve static files (frontend)
         staticResources("/static", "static")
 
-        // Serve sample BPMN files
-        staticResources("/samples", "samples")
+        // Serve the engine-specific example BPMN files
+        staticResources("/examples", "examples")
 
         // Root redirects to static index.html
         get("/") {

--- a/bpmn-to-code-web/src/main/resources/static/css/styles.css
+++ b/bpmn-to-code-web/src/main/resources/static/css/styles.css
@@ -391,6 +391,14 @@ main { display: flex; flex-direction: column; gap: 20px; padding-bottom: 56px; }
     cursor: not-allowed;
 }
 .sample-btn { width: 100%; }
+.sample-btn-group {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+}
+@media (max-width: 560px) {
+    .sample-btn-group { grid-template-columns: 1fr; }
+}
 
 /* Form */
 .form-row {
@@ -515,6 +523,27 @@ main { display: flex; flex-direction: column; gap: 20px; padding-bottom: 56px; }
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.55);
     overflow: hidden;
+}
+.bpmn-viewer-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 12px 16px;
+    border-bottom: 1px solid rgba(27, 30, 58, 0.08);
+    background: rgba(255, 255, 255, 0.4);
+}
+.bpmn-viewer-title {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--green-dark);
+}
+.bpmn-viewer-hint {
+    font-size: 11px;
+    color: var(--fg-subtle);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
 }
 #bpmn-canvas {
     width: 100%;

--- a/bpmn-to-code-web/src/main/resources/static/index.html
+++ b/bpmn-to-code-web/src/main/resources/static/index.html
@@ -83,12 +83,27 @@
                     <span class="upload-hint">.bpmn files only</span>
                 </label>
             </div>
-            <div class="sample-divider"><span>or</span></div>
-            <button class="btn btn-secondary sample-btn" id="try-sample-btn" type="button">
-                Try with Newsletter Sample
-            </button>
+            <div class="sample-divider"><span>or try a newsletter sample</span></div>
+            <div class="sample-btn-group">
+                <button class="btn btn-secondary sample-btn" type="button"
+                        data-sample-engine="ZEEBE" data-sample-file="c8-subscribe-newsletter.bpmn">
+                    Zeebe (Camunda 8)
+                </button>
+                <button class="btn btn-secondary sample-btn" type="button"
+                        data-sample-engine="CAMUNDA_7" data-sample-file="c7-subscribe-newsletter.bpmn">
+                    Camunda 7
+                </button>
+                <button class="btn btn-secondary sample-btn" type="button"
+                        data-sample-engine="OPERATON" data-sample-file="operaton-subscribe-newsletter.bpmn">
+                    Operaton
+                </button>
+            </div>
             <div class="file-list" id="file-list"></div>
             <div class="bpmn-viewer-container" id="bpmn-viewer-container" style="display: none;">
+                <div class="bpmn-viewer-header">
+                    <span class="bpmn-viewer-title">Model Preview</span>
+                    <span class="bpmn-viewer-hint">Rendered from the selected BPMN file</span>
+                </div>
                 <div id="bpmn-canvas"></div>
             </div>
         </section>

--- a/bpmn-to-code-web/src/main/resources/static/js/main.js
+++ b/bpmn-to-code-web/src/main/resources/static/js/main.js
@@ -72,7 +72,6 @@ function setupEventListeners() {
     const fileInput = document.getElementById('file-input');
     const uploadArea = document.getElementById('upload-area');
     const configForm = document.getElementById('config-form');
-    const trySampleBtn = document.getElementById('try-sample-btn');
 
     fileInput.addEventListener('change', handleFileSelect);
 
@@ -95,7 +94,8 @@ function setupEventListeners() {
     });
 
     configForm.addEventListener('submit', handleGenerate);
-    trySampleBtn.addEventListener('click', loadSample);
+    document.querySelectorAll('.sample-btn').forEach(btn =>
+        btn.addEventListener('click', () => loadSample(btn)));
 
     document.getElementById('download-all-btn').addEventListener('click', downloadAllAsZip);
     document.getElementById('reset-btn').addEventListener('click', resetGeneration);
@@ -203,29 +203,32 @@ async function renderBpmnDiagram(xml) {
     console.warn('Could not fit viewport, diagram rendered at default zoom');
 }
 
-async function loadSample() {
-    const trySampleBtn = document.getElementById('try-sample-btn');
+async function loadSample(button) {
+    const engine = button.dataset.sampleEngine;
+    const fileName = button.dataset.sampleFile;
+    const originalText = button.textContent;
     try {
-        trySampleBtn.disabled = true;
-        trySampleBtn.textContent = 'Loading...';
+        button.disabled = true;
+        button.textContent = 'Loading...';
 
-        const response = await fetch('/samples/c8-newsletter.bpmn');
+        const response = await fetch(`/examples/${fileName}`);
         if (!response.ok) throw new Error('Failed to fetch sample');
         const xml = await response.text();
 
         const blob = new Blob([xml], { type: 'application/xml' });
-        const file = new File([blob], 'c8-newsletter.bpmn', { type: 'application/xml' });
+        const file = new File([blob], fileName, { type: 'application/xml' });
 
         state.files = [];
         addFiles([file]);
 
-        document.getElementById('process-engine').value = 'ZEEBE';
+        // Keep the engine in sync with the chosen sample so generation never mismatches.
+        document.getElementById('process-engine').value = engine;
 
     } catch (err) {
         showError('Failed to load sample: ' + err.message);
     } finally {
-        trySampleBtn.disabled = false;
-        trySampleBtn.textContent = 'Try with Newsletter Sample';
+        button.disabled = false;
+        button.textContent = originalText;
     }
 }
 

--- a/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
+++ b/bpmn-to-code-web/src/test/kotlin/io/github/emaarco/bpmn/web/service/WebGenerationServiceTest.kt
@@ -70,6 +70,58 @@ class WebGenerationServiceTest {
     }
 
     @Test
+    fun `should reject a model whose target engine does not match the selected engine`() {
+
+        // given: a Zeebe model but Camunda 7 selected (the demo's original failure mode)
+        val request = GenerateRequest(
+            files = listOf(
+                GenerateRequest.BpmnFileData(
+                    fileName = "c8-subscribe-newsletter.bpmn",
+                    content = loadBpmnBase64("bpmn/c8-subscribe-newsletter.bpmn"),
+                )
+            ),
+            config = GenerateRequest.GenerationConfig(
+                outputLanguage = OutputLanguage.KOTLIN,
+                processEngine = ProcessEngine.CAMUNDA_7,
+            )
+        )
+
+        // when: generating the API
+        val response = underTest.generate(request)
+
+        // then: the engine-mismatch error is reported (collected alongside any other problems)
+        assertThat(response.success).isFalse()
+        assertThat(response.files).isEmpty()
+        assertThat(response.error)
+            .contains("engine-mismatch", "targets Zeebe (Camunda 8)", "selected engine is Camunda 7")
+    }
+
+    @Test
+    fun `should reject a Camunda 7 model when Operaton is selected`() {
+
+        // given: a Camunda 7 model but Operaton selected (the reported case)
+        val request = GenerateRequest(
+            files = listOf(
+                GenerateRequest.BpmnFileData(
+                    fileName = "c7-subscribe-newsletter.bpmn",
+                    content = loadBpmnBase64("bpmn/c7-subscribe-newsletter.bpmn"),
+                )
+            ),
+            config = GenerateRequest.GenerationConfig(
+                outputLanguage = OutputLanguage.KOTLIN,
+                processEngine = ProcessEngine.OPERATON,
+            )
+        )
+
+        // when: generating the API
+        val response = underTest.generate(request)
+
+        // then: surfaced as an engine-mismatch error, not a swallowed warning
+        assertThat(response.success).isFalse()
+        assertThat(response.error).contains("targets Camunda 7", "selected engine is Operaton")
+    }
+
+    @Test
     fun `should handle invalid Base64 content gracefully`() {
 
         // given: a request with invalid Base64 content

--- a/docs/validate/index.md
+++ b/docs/validate/index.md
@@ -21,7 +21,7 @@ bpmn-to-code can validate your BPMN models against a set of built-in rules — i
 | `empty-process` | ERROR | Process with no flow nodes |
 | `invalid-identifier` | WARN | Element ID that produces an invalid UPPER_SNAKE_CASE identifier in the generated API |
 | `collision-detection` | ERROR | Two different element IDs that normalize to the same constant name (post-merge) |
-| `engine-mismatch` | ERROR / WARN | Model's target engine (detected from its XML namespace) doesn't match the selected one — ERROR on a clear mismatch (e.g. a Zeebe model generated for Camunda 7), WARN when the engine can't be determined |
+| `engine-mismatch` | ERROR / WARN | Model's target engine (from its XML namespace) differs from the selected one |
 
 ## Gradle
 

--- a/docs/validate/index.md
+++ b/docs/validate/index.md
@@ -21,6 +21,7 @@ bpmn-to-code can validate your BPMN models against a set of built-in rules — i
 | `empty-process` | ERROR | Process with no flow nodes |
 | `invalid-identifier` | WARN | Element ID that produces an invalid UPPER_SNAKE_CASE identifier in the generated API |
 | `collision-detection` | ERROR | Two different element IDs that normalize to the same constant name (post-merge) |
+| `engine-mismatch` | ERROR / WARN | Model's target engine (detected from its XML namespace) doesn't match the selected one — ERROR on a clear mismatch (e.g. a Zeebe model generated for Camunda 7), WARN when the engine can't be determined |
 
 ## Gradle
 


### PR DESCRIPTION
## Summary
Fixes the website demo (#364). The demo offered a single **Zeebe** newsletter sample, so generating for **Camunda 7** or **Operaton** failed with a confusing wall of `missing-service-task-implementation` errors — the real cause (the model targets a different engine) was never surfaced.

## What changed
**Core — engine-mismatch validation**
- Each extractor records the model's target engine, detected from its BPMN namespaces (`EngineDetector`), on `BpmnModel.detectedEngine`.
- New `EngineMismatchRule` (a normal validation rule, collected alongside everything else): **ERROR** on a clear mismatch (e.g. a Zeebe model generated for Camunda 7), **WARN** when the engine can't be determined. Benefits the web demo, Gradle, and Maven.

**Web — engine-matched samples**
- Replaced the single sample button with three engine-labeled buttons (Zeebe / Camunda 7 / Operaton); each loads the matching `shared/bpmn` model and sets the engine, so the demo never mismatches by default.
- Added a "Model Preview" titled separator above the rendered diagram.

## Verification
`./gradlew build` green. New/updated tests: `EngineDetectorTest`, `EngineMismatchRuleTest`, extractor `detectedEngine` assertions, and end-to-end `WebGenerationServiceTest` cases for c8→Camunda 7 and c7→Operaton. Docs updated (`docs/validate/index.md`).

Closes #364