### PR TITLE
fix: tolerate engine-mismatched models in Zeebe extractor instead of crashing

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -110,7 +110,7 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         return callActivities.map { activity ->
             val elementId = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val extension = activity.findExtensionElement(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
-            val processId = extension.getAttributeValue(ZeebeModelConstants.ATTRIBUTE_PROCESS_ID)
+            val processId = extension?.getAttributeValue(ZeebeModelConstants.ATTRIBUTE_PROCESS_ID)
             CallActivityDefinition(elementId, processId)
         }
     }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/BaseElementUtils.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/utils/BaseElementUtils.kt
@@ -7,10 +7,8 @@ object BaseElementUtils {
 
     fun BaseElement.findExtensionElement(
         type: String,
-    ): ModelElementInstance {
-        val extensions = this.findExtensionElementsWithType(type)
-        return extensions.firstOrNull()
-            ?: error("No extension element of type $type found for flow node ${this.id}")
+    ): ModelElementInstance? {
+        return this.findExtensionElementsWithType(type).firstOrNull()
     }
 
     fun BaseElement.findExtensionElementsWithType(

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -220,4 +220,20 @@ class ZeebeModelExtractorTest {
         )
     }
 
+    @Test
+    fun `extract stays tolerant and leaves a call activity without calledElement for later validation`() {
+
+        // given: a Camunda 7 model with a call activity and no zeebe:calledElement
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+
+        // when: extracting the mismatched model
+        val bpmnModel = underTest.extract(file.readBytes())
+
+        // then: extraction does not validate or fail here
+        val callActivity = bpmnModel.callActivities.single { it.id == "CallActivity_AbortRegistration" }
+        assertThat(callActivity.hasCalledElement()).isFalse()
+        assertThat(bpmnModel.detectedEngine).isEqualTo(ProcessEngine.CAMUNDA_7)
+    }
+
 }


### PR DESCRIPTION
## What

Selecting a Camunda 7 model but generating for Camunda 8 (Zeebe) returned a confusing **"Unknown error occurred"** (HTTP 500) instead of the intended engine-mismatch validation error.

## Why

The extractor crashed *before* any validation could run. `ZeebeModelExtractor.findCallActivities` used the strict `BaseElementUtils.findExtensionElement` helper, which throws when the `zeebe:calledElement` extension is absent — exactly the case for a C7 call activity (e.g. `CallActivity_AbortRegistration`). `ExtractBpmnAdapter` wrapped that into a generic `IllegalStateException`, which the web layer turned into "Unknown error occurred". The `EngineMismatchRule` added in #365 never got the chance to run.

## Fix

Keep the extractor tolerant and let the validation layer report the problem:

- `findExtensionElement` is now nullable instead of throwing (it was used in exactly one place).
- `findCallActivities` keeps the call activity with an empty `calledElement` when the extension is missing (`.map`, not `mapNotNull`), consistent with how service tasks / messages already tolerate missing Zeebe extensions, and with `Camunda7ModelExtractor`.

Extraction now succeeds → `detectedEngine` is set → the existing `EngineMismatchRule` reports a clean `BpmnValidationException` (HTTP 400). A genuine Zeebe model with a missing `calledElement` is still surfaced by `MissingCalledElementRule` instead of crashing — correct layer separation.

## Tests

- `ZeebeModelExtractorTest`: extracting a mismatched model stays tolerant and leaves the call activity without a `calledElement` for later validation.
- Existing mocked `GenerateProcessApiInMemoryServiceTest` still verifies the mismatch is rejected before code generation.

`./gradlew :bpmn-to-code-core:test` and `:bpmn-to-code-web:test` pass.