### PR TITLE
ci: authenticate release-please via GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,10 +31,15 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - id: rp
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-pull-request: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Summary

Migrates the `release-please` job to authenticate via a **GitHub App** token instead of the built-in `GITHUB_TOKEN`.

- Adds an `actions/create-github-app-token@v2` step that mints a short-lived installation token from the App (`vars.RELEASE_PLEASE_APP_ID` + `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY`).
- Passes `token: ${{ steps.app-token.outputs.token }}` to `googleapis/release-please-action@v5` (replacing the previous `secrets.RELEASE_PLEASE_TOKEN`).
- No `permissions:` change; the `gate` / `publish-*` / `deploy-docs` jobs are untouched.

## Why

- `GITHUB_TOKEN`-created events are suppressed by GitHub's loop prevention, so the release-please PR and its release commit/tag **don't trigger downstream CI**. An App token fixes this.
- Commits, tags and releases get attributed to a **named release bot** instead of `github-actions[bot]`.

## Required repo configuration

Already provisioned — the App is installed and these are set:

- Variable `RELEASE_PLEASE_APP_ID`
- Secret `RELEASE_PLEASE_APP_PRIVATE_KEY`

## Verification

- [x] Workflow YAML parses.
- [ ] After merge: confirm the next release-please PR is opened by the App bot (not `github-actions[bot]`) and that downstream workflows trigger on it.
- [ ] Confirm publish (Maven/Gradle/Docker) and Pages deploy jobs still run on an actual release.
