### PR TITLE
feat: expose call-activity variable mappings for testing assertions

### DIFF
--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/CamundaModelConstants.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/CamundaModelConstants.kt
@@ -11,6 +11,9 @@ object CamundaModelConstants {
     const val ADDITIONAL_INPUT_VARIABLES_PROPERTY_NAME = "additionalInputVariables"
     const val ADDITIONAL_OUTPUT_VARIABLES_PROPERTY_NAME = "additionalOutputVariables"
 
+    const val VARIABLES_ATTRIBUTE = "variables"
+    const val VARIABLES_ALL_VALUE = "all"
+
     val callActivityMappingElements = listOf(
         BpmnModelConstants.CAMUNDA_ELEMENT_IN,
         BpmnModelConstants.CAMUNDA_ELEMENT_OUT

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/ZeebeModelConstants.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/constants/ZeebeModelConstants.kt
@@ -15,6 +15,8 @@ object ZeebeModelConstants {
 
     const val ATTRIBUTE_PROCESS_ID = "processId"
     const val ATTRIBUTE_CORRELATION_KEY = "correlationKey"
+    const val ATTRIBUTE_PROPAGATE_PARENT = "propagateAllParentVariables"
+    const val ATTRIBUTE_PROPAGATE_CHILD = "propagateAllChildVariables"
     const val ATTRIBUTE_TARGET = "target"
     const val ATTRIBUTE_SOURCE = "source"
     const val ATTRIBUTE_INPUT_ELEMENT = "inputElement"

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -147,15 +147,15 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
             val id = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val calledElement = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
             val extensions = activity.findExtensionElements()
+            val propagateAllInput = extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+            val propagateAllOutput = extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
             CallActivityDefinition(
                 id = id,
                 calledElement = calledElement,
                 mappings = extractCallActivityMappings(extensions),
                 engineSpecificProperties = buildMap {
-                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_IN)
-                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
-                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
-                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
+                    propagateAllInput?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
+                    propagateAllOutput?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
                 },
             )
         }
@@ -164,10 +164,10 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
     private fun extractCallActivityMappings(
         extensions: List<ModelElementInstance>
     ): List<CallActivityMapping> {
-        val inputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
-            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.INPUT) }
-        val outputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
-            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.OUTPUT) }
+        val rawInputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+        val inputs = rawInputs.mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.INPUT) }
+        val rawOutputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
+        val outputs = rawOutputs.mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.OUTPUT) }
         return inputs + outputs
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractor.kt
@@ -18,6 +18,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.e
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CallActivityMapping
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KEY
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_KEY
@@ -142,11 +143,50 @@ class Camunda7ModelExtractor : EngineSpecificExtractor {
 
     private fun findCallActivities(modelInstance: ModelInstance): List<CallActivityDefinition> {
         val callActivities = modelInstance.getModelElementsByType(CallActivity::class.java)
-        return callActivities.map {
-            val id = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            val calledElement = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
-            CallActivityDefinition(id, calledElement)
+        return callActivities.map { activity ->
+            val id = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
+            val calledElement = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
+            val extensions = activity.findExtensionElements()
+            CallActivityDefinition(
+                id = id,
+                calledElement = calledElement,
+                mappings = extractCallActivityMappings(extensions),
+                engineSpecificProperties = buildMap {
+                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
+                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
+                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
+                },
+            )
         }
+    }
+
+    private fun extractCallActivityMappings(
+        extensions: List<ModelElementInstance>
+    ): List<CallActivityMapping> {
+        val inputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.INPUT) }
+        val outputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
+            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.OUTPUT) }
+        return inputs + outputs
+    }
+
+    private fun DomElement.toCallActivityMapping(direction: VariableDirection): CallActivityMapping? {
+        val source = getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE)?.takeIf { it.isNotBlank() }
+        val sourceExpression = getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE_EXPRESSION)?.takeIf { it.isNotBlank() }
+        val target = getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TARGET)?.takeIf { it.isNotBlank() }
+        if (source == null && sourceExpression == null && target == null) return null
+        return CallActivityMapping(direction, source, sourceExpression, target)
+    }
+
+    private fun extractPropagateAll(
+        extensions: List<ModelElementInstance>,
+        elementType: String,
+    ): Boolean? {
+        val hasAll = extensions.filterByType(elementType).any {
+            it.domElement.getAttribute(CamundaModelConstants.VARIABLES_ATTRIBUTE) == CamundaModelConstants.VARIABLES_ALL_VALUE
+        }
+        return if (hasAll) true else null
     }
 
     private fun getServiceTaskTypes(modelInstance: ModelInstance): List<ServiceTaskDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -150,15 +150,15 @@ class OperatonModelExtractor : EngineSpecificExtractor {
             val id = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
             val calledElement = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
             val extensions = activity.findExtensionElements()
+            val propagateAllInput = extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+            val propagateAllOutput = extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
             CallActivityDefinition(
                 id = id,
                 calledElement = calledElement,
                 mappings = extractCallActivityMappings(extensions),
                 engineSpecificProperties = buildMap {
-                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_IN)
-                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
-                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
-                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
+                    propagateAllInput?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
+                    propagateAllOutput?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
                 },
             )
         }
@@ -167,10 +167,10 @@ class OperatonModelExtractor : EngineSpecificExtractor {
     private fun extractCallActivityMappings(
         extensions: List<ModelElementInstance>
     ): List<CallActivityMapping> {
-        val inputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
-            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.INPUT) }
-        val outputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
-            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.OUTPUT) }
+        val rawInputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+        val inputs = rawInputs.mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.INPUT) }
+        val rawOutputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
+        val outputs = rawOutputs.mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.OUTPUT) }
         return inputs + outputs
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractor.kt
@@ -18,6 +18,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.e
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CallActivityMapping
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_AFTER_KEY
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition.Companion.ASYNC_BEFORE_KEY
@@ -145,11 +146,50 @@ class OperatonModelExtractor : EngineSpecificExtractor {
 
     private fun findCallActivities(modelInstance: ModelInstance): List<CallActivityDefinition> {
         val callActivities = modelInstance.getModelElementsByType(CallActivity::class.java)
-        return callActivities.map {
-            val id = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            val calledElement = it.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
-            CallActivityDefinition(id, calledElement)
+        return callActivities.map { activity ->
+            val id = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
+            val calledElement = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
+            val extensions = activity.findExtensionElements()
+            CallActivityDefinition(
+                id = id,
+                calledElement = calledElement,
+                mappings = extractCallActivityMappings(extensions),
+                engineSpecificProperties = buildMap {
+                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
+                    extractPropagateAll(extensions, BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
+                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
+                },
+            )
         }
+    }
+
+    private fun extractCallActivityMappings(
+        extensions: List<ModelElementInstance>
+    ): List<CallActivityMapping> {
+        val inputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_IN)
+            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.INPUT) }
+        val outputs = extensions.filterByType(BpmnModelConstants.CAMUNDA_ELEMENT_OUT)
+            .mapNotNull { it.domElement.toCallActivityMapping(VariableDirection.OUTPUT) }
+        return inputs + outputs
+    }
+
+    private fun DomElement.toCallActivityMapping(direction: VariableDirection): CallActivityMapping? {
+        val source = getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE)?.takeIf { it.isNotBlank() }
+        val sourceExpression = getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_SOURCE_EXPRESSION)?.takeIf { it.isNotBlank() }
+        val target = getAttribute(BpmnModelConstants.CAMUNDA_ATTRIBUTE_TARGET)?.takeIf { it.isNotBlank() }
+        if (source == null && sourceExpression == null && target == null) return null
+        return CallActivityMapping(direction, source, sourceExpression, target)
+    }
+
+    private fun extractPropagateAll(
+        extensions: List<ModelElementInstance>,
+        elementType: String,
+    ): Boolean? {
+        val hasAll = extensions.filterByType(elementType).any {
+            it.domElement.getAttribute(CamundaModelConstants.VARIABLES_ATTRIBUTE) == CamundaModelConstants.VARIABLES_ALL_VALUE
+        }
+        return if (hasAll) true else null
     }
 
     private fun getServiceTaskTypes(modelInstance: ModelInstance): List<ServiceTaskDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -114,15 +114,15 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
             val calledElement = activity.findExtensionElement(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
             val processId = calledElement?.getAttributeValue(ZeebeModelConstants.ATTRIBUTE_PROCESS_ID)
             val ioMappings = activity.findExtensionElementsWithType(ZeebeModelConstants.ELEMENT_IO_MAPPING)
+            val propagateAllInput = calledElement?.propagateFlag(ZeebeModelConstants.ATTRIBUTE_PROPAGATE_PARENT)
+            val propagateAllOutput = calledElement?.propagateFlag(ZeebeModelConstants.ATTRIBUTE_PROPAGATE_CHILD)
             CallActivityDefinition(
                 id = elementId,
                 calledElement = processId,
                 mappings = extractCallActivityMappings(ioMappings),
                 engineSpecificProperties = buildMap {
-                    calledElement?.propagateFlag(ZeebeModelConstants.ATTRIBUTE_PROPAGATE_PARENT)
-                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
-                    calledElement?.propagateFlag(ZeebeModelConstants.ATTRIBUTE_PROPAGATE_CHILD)
-                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
+                    propagateAllInput?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
+                    propagateAllOutput?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
                 },
             )
         }
@@ -134,10 +134,10 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
 
     private fun extractCallActivityMappings(ioMappings: List<ModelElementInstance>): List<CallActivityMapping> {
         val elements = ioMappings.flatMap { it.domElement.childElements }
-        val inputs = elements.filter { it.localName == ZeebeModelConstants.ELEMENT_INPUT }
-            .mapNotNull { it.toCallActivityMapping(VariableDirection.INPUT) }
-        val outputs = elements.filter { it.localName == ZeebeModelConstants.ELEMENT_OUTPUT }
-            .mapNotNull { it.toCallActivityMapping(VariableDirection.OUTPUT) }
+        val rawInputs = elements.filter { it.localName == ZeebeModelConstants.ELEMENT_INPUT }
+        val inputs = rawInputs.mapNotNull { it.toCallActivityMapping(VariableDirection.INPUT) }
+        val rawOutputs = elements.filter { it.localName == ZeebeModelConstants.ELEMENT_OUTPUT }
+        val outputs = rawOutputs.mapNotNull { it.toCallActivityMapping(VariableDirection.OUTPUT) }
         return inputs + outputs
     }
 

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractor.kt
@@ -19,6 +19,7 @@ import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.e
 import io.github.emaarco.bpmn.adapter.outbound.engine.utils.ModelInstanceUtils.getProcessId
 import io.github.emaarco.bpmn.domain.BpmnModel
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CallActivityMapping
 import io.github.emaarco.bpmn.domain.shared.FlowNodeDefinition
 import io.github.emaarco.bpmn.domain.shared.FlowNodeProperties
 import io.github.emaarco.bpmn.domain.shared.MessageDefinition
@@ -33,6 +34,7 @@ import org.camunda.bpm.model.bpmn.instance.FlowNode
 import org.camunda.bpm.model.bpmn.instance.Message
 import org.camunda.bpm.model.bpmn.instance.MultiInstanceLoopCharacteristics
 import org.camunda.bpm.model.xml.ModelInstance
+import org.camunda.bpm.model.xml.instance.DomElement
 import org.camunda.bpm.model.xml.instance.ModelElementInstance
 class ZeebeModelExtractor : EngineSpecificExtractor {
 
@@ -109,10 +111,40 @@ class ZeebeModelExtractor : EngineSpecificExtractor {
         val callActivities = modelInstance.getModelElementsByType(CallActivity::class.java)
         return callActivities.map { activity ->
             val elementId = activity.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID)
-            val extension = activity.findExtensionElement(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
-            val processId = extension?.getAttributeValue(ZeebeModelConstants.ATTRIBUTE_PROCESS_ID)
-            CallActivityDefinition(elementId, processId)
+            val calledElement = activity.findExtensionElement(BpmnModelConstants.BPMN_ATTRIBUTE_CALLED_ELEMENT)
+            val processId = calledElement?.getAttributeValue(ZeebeModelConstants.ATTRIBUTE_PROCESS_ID)
+            val ioMappings = activity.findExtensionElementsWithType(ZeebeModelConstants.ELEMENT_IO_MAPPING)
+            CallActivityDefinition(
+                id = elementId,
+                calledElement = processId,
+                mappings = extractCallActivityMappings(ioMappings),
+                engineSpecificProperties = buildMap {
+                    calledElement?.propagateFlag(ZeebeModelConstants.ATTRIBUTE_PROPAGATE_PARENT)
+                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY, it) }
+                    calledElement?.propagateFlag(ZeebeModelConstants.ATTRIBUTE_PROPAGATE_CHILD)
+                        ?.let { put(CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY, it) }
+                },
+            )
         }
+    }
+
+    private fun ModelElementInstance.propagateFlag(attribute: String): Boolean? {
+        return getAttributeValue(attribute)?.takeIf { it.isNotBlank() }?.toBooleanStrictOrNull()
+    }
+
+    private fun extractCallActivityMappings(ioMappings: List<ModelElementInstance>): List<CallActivityMapping> {
+        val elements = ioMappings.flatMap { it.domElement.childElements }
+        val inputs = elements.filter { it.localName == ZeebeModelConstants.ELEMENT_INPUT }
+            .mapNotNull { it.toCallActivityMapping(VariableDirection.INPUT) }
+        val outputs = elements.filter { it.localName == ZeebeModelConstants.ELEMENT_OUTPUT }
+            .mapNotNull { it.toCallActivityMapping(VariableDirection.OUTPUT) }
+        return inputs + outputs
+    }
+
+    private fun DomElement.toCallActivityMapping(direction: VariableDirection): CallActivityMapping? {
+        val target = getAttribute(ZeebeModelConstants.ATTRIBUTE_TARGET)?.takeIf { it.isNotBlank() } ?: return null
+        val source = getAttribute(ZeebeModelConstants.ATTRIBUTE_SOURCE)?.takeIf { it.isNotBlank() }
+        return CallActivityMapping(direction, source = source, sourceExpression = null, target = target)
     }
 
     private fun findServiceTasks(modelInstance: ModelInstance): List<ServiceTaskDefinition> {

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CallActivityDefinition.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CallActivityDefinition.kt
@@ -5,10 +5,21 @@ import io.github.emaarco.bpmn.domain.utils.StringUtils.toUpperSnakeCase
 data class CallActivityDefinition(
     val id: String?,
     private val calledElement: String?,
+    val mappings: List<CallActivityMapping> = emptyList(),
     val engineSpecificProperties: Map<String, Any?> = emptyMap(),
 ) : VariableMapping<String> {
     override fun getName() = id?.toUpperSnakeCase() ?: ""
     override fun getValue() = calledElement ?: ""
     override fun getRawName() = id ?: ""
     fun hasCalledElement() = calledElement != null
+
+    val inputMappings get() = mappings.filter { it.direction == VariableDirection.INPUT }
+    val outputMappings get() = mappings.filter { it.direction == VariableDirection.OUTPUT }
+    val propagateAllInputVariables: Boolean? get() = engineSpecificProperties[PROPAGATE_ALL_INPUT_KEY] as? Boolean
+    val propagateAllOutputVariables: Boolean? get() = engineSpecificProperties[PROPAGATE_ALL_OUTPUT_KEY] as? Boolean
+
+    companion object {
+        const val PROPAGATE_ALL_INPUT_KEY = "propagateAllInputVariables"
+        const val PROPAGATE_ALL_OUTPUT_KEY = "propagateAllOutputVariables"
+    }
 }

--- a/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CallActivityMapping.kt
+++ b/bpmn-to-code-core/src/main/kotlin/io/github/emaarco/bpmn/domain/shared/CallActivityMapping.kt
@@ -1,0 +1,8 @@
+package io.github.emaarco.bpmn.domain.shared
+
+data class CallActivityMapping(
+    val direction: VariableDirection,
+    val source: String? = null,
+    val sourceExpression: String? = null,
+    val target: String? = null,
+)

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/Camunda7ModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CallActivityMapping
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.CompensationType
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
@@ -53,7 +54,12 @@ class Camunda7ModelExtractorTest {
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",
-                        properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
+                        properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration",
+                            mappings = listOf(
+                                CallActivityMapping(VariableDirection.INPUT, source = "subscriptionId", target = "childSubscriptionId"),
+                                CallActivityMapping(VariableDirection.INPUT, sourceExpression = "\${reasonCode}", target = "childReasonCode"),
+                                CallActivityMapping(VariableDirection.OUTPUT, source = "childAbortResult", target = "abortResult"),
+                            ))),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT, "subscriptionId"), VariableDefinition("reasonCode", VariableDirection.INPUT, "\${reasonCode}"), VariableDefinition("abortResult", VariableDirection.OUTPUT, "abortResult")),
                         previousElements = listOf("Timer_After3Days"),
                         followingElements = listOf("CompensationEndEvent_RegistrationAborted"),
@@ -162,6 +168,20 @@ class Camunda7ModelExtractorTest {
     }
 
     @Test
+    fun `extract captures call-activity input and output mapping targets`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn"))
+        val bpmnModel = underTest.extract(File(resourceUrl.toURI()).readBytes())
+        val callActivity = bpmnModel.callActivities.single { it.id == "CallActivity_AbortRegistration" }
+        assertThat(callActivity.inputMappings).containsExactlyInAnyOrder(
+            CallActivityMapping(VariableDirection.INPUT, source = "subscriptionId", target = "childSubscriptionId"),
+            CallActivityMapping(VariableDirection.INPUT, sourceExpression = "\${reasonCode}", target = "childReasonCode"),
+        )
+        assertThat(callActivity.outputMappings).containsExactly(
+            CallActivityMapping(VariableDirection.OUTPUT, source = "childAbortResult", target = "abortResult"),
+        )
+    }
+
+    @Test
     fun `extract returns variantName from process-level extension properties`() {
         val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn"))
         val file = File(resourceUrl.toURI())
@@ -263,5 +283,44 @@ class Camunda7ModelExtractorTest {
         assertThat(flowsById["Flow_1gsz7wd"]).isEqualTo(
             SequenceFlowDefinition("Flow_1gsz7wd", "gateway_hasSubscribers", "endEvent_noSubscribers", flowName = "No", conditionExpression = "\${subscribers.size() > 0}")
         )
+    }
+
+    @Test
+    fun `extract captures propagate-all and keeps named mappings alongside variables=all`() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                              xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                              targetNamespace="http://bpmn.io/schema/bpmn">
+              <bpmn:process id="propagate-all-process" isExecutable="true">
+                <bpmn:callActivity id="CallActivity_PropagateAll" name="Propagate all" calledElement="child-process">
+                  <bpmn:extensionElements>
+                    <camunda:in source="orderId" target="businessKey" />
+                    <camunda:in variables="all" />
+                    <camunda:out variables="all" />
+                  </bpmn:extensionElements>
+                </bpmn:callActivity>
+              </bpmn:process>
+            </bpmn:definitions>
+        """.trimIndent()
+
+        val bpmnModel = underTest.extract(xml.toByteArray())
+
+        val callActivity = bpmnModel.callActivities.single()
+        assertThat(callActivity.propagateAllInputVariables).isTrue()
+        assertThat(callActivity.propagateAllOutputVariables).isTrue()
+        assertThat(callActivity.inputMappings).containsExactly(
+            CallActivityMapping(VariableDirection.INPUT, source = "orderId", target = "businessKey")
+        )
+    }
+
+    @Test
+    fun `extract leaves propagate-all null when variables=all is not declared`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c7-subscribe-newsletter.bpmn"))
+        val file = File(resourceUrl.toURI())
+        val bpmnModel = underTest.extract(file.readBytes())
+        val callActivity = bpmnModel.callActivities.single { it.id == "CallActivity_AbortRegistration" }
+        assertThat(callActivity.propagateAllInputVariables).isNull()
+        assertThat(callActivity.propagateAllOutputVariables).isNull()
     }
 }

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/OperatonModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CallActivityMapping
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.CompensationType
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
@@ -53,7 +54,12 @@ class OperatonModelExtractorTest {
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",
-                        properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
+                        properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration",
+                            mappings = listOf(
+                                CallActivityMapping(VariableDirection.INPUT, source = "subscriptionId", target = "childSubscriptionId"),
+                                CallActivityMapping(VariableDirection.INPUT, sourceExpression = "\${reasonCode}", target = "childReasonCode"),
+                                CallActivityMapping(VariableDirection.OUTPUT, source = "childAbortResult", target = "abortResult"),
+                            ))),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT, "subscriptionId"), VariableDefinition("reasonCode", VariableDirection.INPUT, "\${reasonCode}"), VariableDefinition("abortResult", VariableDirection.OUTPUT, "abortResult")),
                         previousElements = listOf("Timer_After3Days"),
                         followingElements = listOf("CompensationEndEvent_RegistrationAborted"),

--- a/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
+++ b/bpmn-to-code-core/src/test/kotlin/io/github/emaarco/bpmn/adapter/outbound/engine/extractor/ZeebeModelExtractorTest.kt
@@ -2,6 +2,7 @@ package io.github.emaarco.bpmn.adapter.outbound.engine.extractor
 
 import io.github.emaarco.bpmn.domain.shared.BpmnElementType
 import io.github.emaarco.bpmn.domain.shared.CallActivityDefinition
+import io.github.emaarco.bpmn.domain.shared.CallActivityMapping
 import io.github.emaarco.bpmn.domain.shared.CompensationDefinition
 import io.github.emaarco.bpmn.domain.shared.CompensationType
 import io.github.emaarco.bpmn.domain.shared.EscalationDefinition
@@ -50,7 +51,14 @@ class ZeebeModelExtractorTest {
                 flowNodes = listOf(
                     FlowNodeDefinition("CallActivity_AbortRegistration", BpmnElementType.CALL_ACTIVITY,
                         displayName = "Abort registration",
-                        properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration")),
+                        properties = FlowNodeProperties.CallActivity(CallActivityDefinition("CallActivity_AbortRegistration", "abort-registration",
+                            mappings = listOf(
+                                CallActivityMapping(VariableDirection.INPUT, source = "=subscriptionId", target = "subscriptionId"),
+                            ),
+                            engineSpecificProperties = mapOf(
+                                CallActivityDefinition.PROPAGATE_ALL_INPUT_KEY to false,
+                                CallActivityDefinition.PROPAGATE_ALL_OUTPUT_KEY to false,
+                            ))),
                         variables = listOf(VariableDefinition("subscriptionId", VariableDirection.INPUT, "=subscriptionId")),
                         previousElements = listOf("Timer_After3Days"),
                         followingElements = listOf("CompensationEndEvent_RegistrationAborted")),
@@ -170,6 +178,19 @@ class ZeebeModelExtractorTest {
         val file = File(resourceUrl.toURI())
         val bpmnModel = underTest.extract(file.readBytes())
         assertThat(bpmnModel.variantName).isNull()
+    }
+
+    @Test
+    fun `extract captures call-activity io-mapping targets and propagate-all flags`() {
+        val resourceUrl = requireNotNull(javaClass.getResource("/bpmn/c8-subscribe-newsletter.bpmn"))
+        val bpmnModel = underTest.extract(File(resourceUrl.toURI()).readBytes())
+        val callActivity = bpmnModel.callActivities.single { it.id == "CallActivity_AbortRegistration" }
+        assertThat(callActivity.inputMappings).containsExactly(
+            CallActivityMapping(VariableDirection.INPUT, source = "=subscriptionId", target = "subscriptionId"),
+        )
+        assertThat(callActivity.outputMappings).isEmpty()
+        assertThat(callActivity.propagateAllInputVariables).isFalse()
+        assertThat(callActivity.propagateAllOutputVariables).isFalse()
     }
 
     @Test

--- a/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/CallActivityInputRuleTest.kt
+++ b/bpmn-to-code-testing/src/test/kotlin/io/github/emaarco/bpmn/testing/CallActivityInputRuleTest.kt
@@ -1,0 +1,106 @@
+package io.github.emaarco.bpmn.testing
+
+import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.github.emaarco.bpmn.domain.validation.BpmnValidationRule
+import io.github.emaarco.bpmn.domain.validation.model.Severity
+import io.github.emaarco.bpmn.domain.validation.model.ValidationContext
+import io.github.emaarco.bpmn.domain.validation.model.ValidationViolation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CallActivityInputRuleTest {
+
+    private class RequireCallActivityInputsRule(private val required: Set<String>) : BpmnValidationRule {
+        override val id = "call-activity-required-inputs"
+        override val severity = Severity.ERROR
+
+        override fun validate(context: ValidationContext): List<ValidationViolation> {
+            return context.model.callActivities.flatMap { callActivity ->
+                val declaredTargets = callActivity.inputMappings.mapNotNull { it.target }.toSet()
+                (required - declaredTargets).map { missing ->
+                    ValidationViolation(
+                        ruleId = id,
+                        severity = severity,
+                        elementId = callActivity.id,
+                        processId = context.model.processId,
+                        message = "Call activity '${callActivity.id}' must pass input variable '$missing' to the called process.",
+                    )
+                }
+            }
+        }
+    }
+
+    private class RequireCallActivityOutputsRule(private val required: Set<String>) : BpmnValidationRule {
+        override val id = "call-activity-required-outputs"
+        override val severity = Severity.ERROR
+
+        override fun validate(context: ValidationContext): List<ValidationViolation> {
+            return context.model.callActivities.flatMap { callActivity ->
+                val declaredTargets = callActivity.outputMappings.mapNotNull { it.target }.toSet()
+                (required - declaredTargets).map { missing ->
+                    ValidationViolation(
+                        ruleId = id,
+                        severity = severity,
+                        elementId = callActivity.id,
+                        processId = context.model.processId,
+                        message = "Call activity '${callActivity.id}' must return output variable '$missing' to the parent process.",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `custom rule passes when call activity declares the required input targets`() {
+        val result = BpmnValidator
+            .fromClasspath("bpmn/c7-subscribe-newsletter.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(RequireCallActivityInputsRule(setOf("childSubscriptionId", "childReasonCode")))
+            .validate()
+            .result()
+
+        assertThat(result.violations).isEmpty()
+    }
+
+    @Test
+    fun `custom rule flags a call activity missing a required input target`() {
+        val result = BpmnValidator
+            .fromClasspath("bpmn/c7-subscribe-newsletter.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(RequireCallActivityInputsRule(setOf("businessKey")))
+            .validate()
+            .result()
+
+        assertThat(result.violations).hasSize(1)
+        val violation = result.violations.single()
+        assertThat(violation.elementId).isEqualTo("CallActivity_AbortRegistration")
+        assertThat(violation.message).contains("businessKey")
+    }
+
+    @Test
+    fun `custom rule passes when call activity declares the required output target`() {
+        val result = BpmnValidator
+            .fromClasspath("bpmn/c7-subscribe-newsletter.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(RequireCallActivityOutputsRule(setOf("abortResult")))
+            .validate()
+            .result()
+
+        assertThat(result.violations).isEmpty()
+    }
+
+    @Test
+    fun `custom rule flags a call activity missing a required output target`() {
+        val result = BpmnValidator
+            .fromClasspath("bpmn/c7-subscribe-newsletter.bpmn")
+            .engine(ProcessEngine.CAMUNDA_7)
+            .withRules(RequireCallActivityOutputsRule(setOf("missingResult")))
+            .validate()
+            .result()
+
+        assertThat(result.violations).hasSize(1)
+        val violation = result.violations.single()
+        assertThat(violation.elementId).isEqualTo("CallActivity_AbortRegistration")
+        assertThat(violation.message).contains("missingResult")
+    }
+}

--- a/docs/validate/testing.md
+++ b/docs/validate/testing.md
@@ -169,6 +169,65 @@ BpmnValidator
     .assertNoViolations()
 ```
 
+## Asserting Call-Activity Variable Mappings
+
+Call activities expose their input/output variable mappings via `CallActivityDefinition.mappings`,
+with `inputMappings` / `outputMappings` helpers. Each `CallActivityMapping` keeps **both** sides of
+the mapping — the `source` (or `sourceExpression`) and the `target` — so you can assert on the name a
+variable gets inside the called process. For example, requiring every call activity to pass a
+`businessKey` and `correlationKey`:
+
+```kotlin
+class RequireCallActivityInputsRule(private val required: Set<String>) : BpmnValidationRule {
+
+    override val id = "call-activity-required-inputs"
+    override val severity = Severity.ERROR
+
+    override fun validate(context: ValidationContext): List<ValidationViolation> {
+        return context.model.callActivities.flatMap { callActivity ->
+            val declaredTargets = callActivity.inputMappings.mapNotNull { it.target }.toSet()
+            (required - declaredTargets).map { missing ->
+                ValidationViolation(
+                    ruleId = id,
+                    severity = severity,
+                    elementId = callActivity.id,
+                    processId = context.model.processId,
+                    message = "Call activity '${callActivity.id}' must pass '$missing' to the called process.",
+                )
+            }
+        }
+    }
+}
+```
+
+```kotlin
+BpmnValidator
+    .fromClasspath("bpmn/")
+    .engine(ProcessEngine.CAMUNDA_7)
+    .withRules(RequireCallActivityInputsRule(setOf("businessKey", "correlationKey")))
+    .validate()
+    .assertNoViolations()
+```
+
+::: tip Engine differences
+For **Camunda 7 / Operaton** (`camunda:in` / `camunda:out`), `source` is a plain variable name and
+`sourceExpression` holds a `${...}` expression. For **Zeebe** (`zeebe:input` / `zeebe:output`),
+`source` is a FEEL expression (e.g. `=orderId`) and `sourceExpression` is always `null`. The `target`
+— the name inside the called process — is populated the same way for all engines.
+
+The "pass all variables" mode (`variables="all"` / `propagateAll{Parent,Child}Variables`) is exposed
+separately via `propagateAllInputVariables` / `propagateAllOutputVariables`, which are tri-state:
+
+| Value | Meaning |
+|-------|---------|
+| `true` | The model explicitly enables pass-all (Camunda 7 / Operaton `variables="all"`; Zeebe `propagateAll…="true"`). |
+| `false` | The model explicitly disables it. **Zeebe only** — Camunda 7 / Operaton have no attribute to express this, so they never report `false`. |
+| `null` | Not declared in the model. |
+
+For a rule that should behave the same across engines, test `!= true` to mean "does not pass all
+variables" (this treats Camunda's "not declared" and Zeebe's explicit `false` alike).
+:::
+
 ::: tip ValidationContext
-`context.model` gives you the full `BpmnModel` — flow nodes, service tasks, messages, signals, errors, timers, and variables. `context.engine` tells you which engine was selected, so you can write engine-specific rules.
+`context.model` gives you the full `BpmnModel` — flow nodes, service tasks, call activities, messages, signals, errors, timers, and variables. `context.engine` tells you which engine was selected, so you can write engine-specific rules.
 :::


### PR DESCRIPTION
## Summary

Lets `bpmn-to-code-testing` assert on call-activity input/output variable mappings — specifically the **target** name a variable gets inside the called process (e.g. require every call activity to pass a `businessKey` / `correlationKey` input). Previously the Camunda 7 / Operaton extractor kept only the mapping's `source` and discarded the `target`, so this kind of assertion was impossible.

## What changed

- New `CallActivityMapping(direction, source, sourceExpression, target)`, exposed via `CallActivityDefinition.mappings` with `inputMappings` / `outputMappings` helpers.
- "Pass all variables" mode surfaced via `propagateAllInputVariables` / `propagateAllOutputVariables` (stored in the existing `engineSpecificProperties` map, same pattern as the async flags).
- Extractors populate the mappings for **Camunda 7, Operaton and Zeebe**.
- Purely additive: the legacy `node.variables` extraction and all generated code are unchanged.
- Docs: new "Asserting Call-Activity Variable Mappings" section in `docs/validate/testing.md`.

## Engine notes

- **Camunda 7 / Operaton** (`camunda:in` / `camunda:out`): `source` is a plain variable name, `sourceExpression` holds a `${...}` expression.
- **Zeebe** (`zeebe:input` / `zeebe:output`): `source` is a FEEL expression (e.g. `=orderId`), `sourceExpression` is always `null`.
- `propagateAll*` is tri-state (`true` / `false` / `null`). Camunda 7 / Operaton never report `false` — the engine has no attribute to express it; use `!= true` for cross-engine rules.

## Testing

`./gradlew :bpmn-to-code-core:test :bpmn-to-code-testing:test` — green. Adds extractor coverage for all three engines (including `variables="all"` and the null state) and a public-API custom-rule test covering both input and output targets.