### PR TITLE
feat: deprecate io.github.emaarco — bpmn-to-code moves to io.miragon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> ## ⚠️ Moving to io.miragon
+> bpmn-to-code is **moving to the `io.miragon` namespace** ([github.com/miragon/bpmn-to-code](https://github.com/miragon/bpmn-to-code)). As of this release the `io.github.emaarco` coordinates and the `io.github.emaarco.bpmn-to-code-gradle` plugin id are **deprecated** and will receive no further updates — migrate to `io.miragon`. See the [migration note](docs/changelog/moved-to-miragon.md).
+
 > **bpmn-to-code is early-stage and actively developing.**
 > The four pillars — Generate, Validate, Surface, Ship — are taking shape, but expect rough edges.
 > Feedback and contributions are very welcome.

--- a/bpmn-to-code-gradle/README.md
+++ b/bpmn-to-code-gradle/README.md
@@ -1,5 +1,8 @@
 # 🚀 bpmn-to-code-gradle
 
+> ## ⚠️ Moving to io.miragon
+> bpmn-to-code is **moving to the `io.miragon` namespace**. As of this release the `io.github.emaarco` coordinates and the `io.github.emaarco.bpmn-to-code-gradle` plugin id are **deprecated** and will receive no further updates — migrate to `io.miragon.bpmn-to-code-gradle` ([github.com/miragon/bpmn-to-code](https://github.com/miragon/bpmn-to-code), [migration note](../docs/changelog/moved-to-miragon.md)).
+
 bpmn-to-code is a plugin designed to simplify process automation.
 Its vision is to foster clean & robust solutions for BPMN-based process automation.
 Therefore, it aims to provide a range of features —

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
@@ -5,7 +5,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.util.Properties
 
-@Suppress("unused")
+@Deprecated(
+    "bpmn-to-code is moving to the io.miragon namespace; the 'io.github.emaarco' coordinates and the " +
+        "'io.github.emaarco.bpmn-to-code-gradle' plugin id are deprecated and will receive no further updates. " +
+        "Migrate to io.miragon — https://github.com/miragon/bpmn-to-code"
+)
+@Suppress("unused", "DEPRECATION")
 class BpmnModelGeneratorPlugin : Plugin<Project> {
 
     companion object {

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/BpmnModelGeneratorPlugin.kt
@@ -15,6 +15,12 @@ class BpmnModelGeneratorPlugin : Plugin<Project> {
     }
 
     override fun apply(project: Project) {
+        project.logger.warn(
+            "[bpmn-to-code] bpmn-to-code will be moved to the io.miragon namespace. The 'io.github.emaarco' " +
+                "coordinates and the 'io.github.emaarco.bpmn-to-code-gradle' plugin id are DEPRECATED and will not " +
+                "receive further updates. Migrate to 'io.miragon.bpmn-to-code-gradle' / 'io.miragon:bpmn-to-code-*' " +
+                "— see https://github.com/miragon/bpmn-to-code"
+        )
         project.tasks.register("generateBpmnModelApi", GenerateBpmnModelsTask::class.java) {
             it.group = "BPMN"
             it.description = "Generates API-files from BPMN files to interact with a process-engine."

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnJsonTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnJsonTask.kt
@@ -7,6 +7,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
+@Deprecated(
+    "bpmn-to-code is moving to the io.miragon namespace; the 'io.github.emaarco' coordinates are deprecated " +
+        "and will receive no further updates. Migrate to io.miragon — https://github.com/miragon/bpmn-to-code"
+)
 @DisableCachingByDefault(
     because = "Task produces output based on files that can change at any time without the plugin knowing about it"
 )

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/GenerateBpmnModelsTask.kt
@@ -8,6 +8,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
+@Deprecated(
+    "bpmn-to-code is moving to the io.miragon namespace; the 'io.github.emaarco' coordinates are deprecated " +
+        "and will receive no further updates. Migrate to io.miragon — https://github.com/miragon/bpmn-to-code"
+)
 @DisableCachingByDefault(
     because = "Task produces output based on files that can change at any time without the plugin knowing about it"
 )

--- a/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
+++ b/bpmn-to-code-gradle/src/main/kotlin/io/github/emaarco/bpmn/adapter/ValidateBpmnModelsTask.kt
@@ -11,6 +11,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
+@Deprecated(
+    "bpmn-to-code is moving to the io.miragon namespace; the 'io.github.emaarco' coordinates are deprecated " +
+        "and will receive no further updates. Migrate to io.miragon — https://github.com/miragon/bpmn-to-code"
+)
 @Incubating
 @DisableCachingByDefault(
     because = "Validation depends on BPMN files that can change at any time without the plugin knowing about it"

--- a/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginDeprecationWarningSmokeTest.kt
+++ b/bpmn-to-code-gradle/src/test/kotlin/io/github/emaarco/bpmn/adapter/GradlePluginDeprecationWarningSmokeTest.kt
@@ -1,0 +1,38 @@
+package io.github.emaarco.bpmn.adapter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class GradlePluginDeprecationWarningSmokeTest {
+
+    @Test
+    fun `applying the plugin logs the io_miragon deprecation warning`(
+        @TempDir projectDir: File,
+    ) {
+        // given: a minimal Gradle project that only applies the plugin
+        File(projectDir, "settings.gradle").writeText("")
+        File(projectDir, "build.gradle").writeText(
+            """
+            plugins {
+                id 'io.github.emaarco.bpmn-to-code-gradle'
+            }
+            """.trimIndent()
+        )
+
+        // when: configuring the project (any task triggers plugin apply)
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments("help")
+            .build()
+
+        // then: the apply-time deprecation warning is printed
+        assertThat(result.output)
+            .contains("bpmn-to-code will be moved to the io.miragon namespace")
+            .contains("io.github.emaarco")
+            .contains("https://github.com/miragon/bpmn-to-code")
+    }
+}

--- a/bpmn-to-code-maven/README.md
+++ b/bpmn-to-code-maven/README.md
@@ -1,5 +1,8 @@
 # 🚀 bpmn-to-code Maven Plugin
 
+> ## ⚠️ Moving to io.miragon
+> bpmn-to-code is **moving to the `io.miragon` namespace**. As of this release the `io.github.emaarco` coordinates are **deprecated** and will receive no further updates — migrate to the `io.miragon:bpmn-to-code-maven` plugin ([github.com/miragon/bpmn-to-code](https://github.com/miragon/bpmn-to-code), [migration note](../docs/changelog/moved-to-miragon.md)).
+
 bpmn-to-code is a plugin designed to simplify process automation.
 Its vision is to foster clean & robust solutions for BPMN-based process automation.
 Therefore, it aims to provide a range of features —

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
@@ -36,6 +36,12 @@ public class BpmnJsonMojo extends AbstractMojo {
 
 	@Override
 	public void execute() {
+		getLog().warn(
+				"[bpmn-to-code] bpmn-to-code will be moved to the io.miragon namespace. The 'io.github.emaarco' " +
+						"coordinates and the 'io.github.emaarco:bpmn-to-code-maven' plugin are DEPRECATED and will not " +
+						"receive further updates. Migrate to the io.miragon:bpmn-to-code-maven plugin / " +
+						"'io.miragon:bpmn-to-code-*' — see https://github.com/miragon/bpmn-to-code"
+		);
 		CreateProcessJsonFilesystemPlugin plugin = new CreateProcessJsonFilesystemPlugin();
 		ProcessEngine engine = ProcessEngine.valueOf(processEngine);
 		plugin.execute(baseDir, filePattern, outputFolderPath, engine, new ValidationConfig());

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnJsonMojo.java
@@ -10,7 +10,12 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Maven Mojo for generating JSON representations of BPMN process models
+ *
+ * @deprecated bpmn-to-code is moving to the io.miragon namespace; the io.github.emaarco coordinates are
+ * deprecated and will receive no further updates. Migrate to the io.miragon:bpmn-to-code-maven plugin —
+ * see https://github.com/miragon/bpmn-to-code
  */
+@Deprecated
 @Mojo(
 		name = "generate-bpmn-json",
 		defaultPhase = LifecyclePhase.NONE,

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
@@ -14,7 +14,12 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Maven Mojo for generating type-safe API definitions from BPMN process models
+ *
+ * @deprecated bpmn-to-code is moving to the io.miragon namespace; the io.github.emaarco coordinates are
+ * deprecated and will receive no further updates. Migrate to the io.miragon:bpmn-to-code-maven plugin —
+ * see https://github.com/miragon/bpmn-to-code
  */
+@Deprecated
 @Mojo(
 		name = "generate-bpmn-api",
 		defaultPhase = LifecyclePhase.NONE,

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnModelMojo.java
@@ -76,6 +76,12 @@ public class BpmnModelMojo extends AbstractMojo {
 	 */
 	@Override
 	public void execute() {
+		getLog().warn(
+				"[bpmn-to-code] bpmn-to-code will be moved to the io.miragon namespace. The 'io.github.emaarco' " +
+						"coordinates and the 'io.github.emaarco:bpmn-to-code-maven' plugin are DEPRECATED and will not " +
+						"receive further updates. Migrate to the io.miragon:bpmn-to-code-maven plugin / " +
+						"'io.miragon:bpmn-to-code-*' — see https://github.com/miragon/bpmn-to-code"
+		);
 		CreateProcessApiFilesystemPlugin plugin = new CreateProcessApiFilesystemPlugin();
 		OutputLanguage language = OutputLanguage.valueOf(outputLanguage);
 		ProcessEngine engine = ProcessEngine.valueOf(processEngine);

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
@@ -17,7 +17,12 @@ import java.util.Set;
 /**
  * [Experimental] Maven Mojo for validating BPMN models against built-in rules without generating code.
  * This goal is experimental and may change in future releases.
+ *
+ * @deprecated bpmn-to-code is moving to the io.miragon namespace; the io.github.emaarco coordinates are
+ * deprecated and will receive no further updates. Migrate to the io.miragon:bpmn-to-code-maven plugin —
+ * see https://github.com/miragon/bpmn-to-code
  */
+@Deprecated
 @Mojo(
 		name = "validate-bpmn",
 		defaultPhase = LifecyclePhase.NONE,

--- a/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
+++ b/bpmn-to-code-maven/src/main/java/io/github/emaarco/bpmn/adapter/BpmnValidateMojo.java
@@ -71,6 +71,12 @@ public class BpmnValidateMojo extends AbstractMojo {
 	 */
 	@Override
 	public void execute() throws MojoFailureException {
+		getLog().warn(
+				"[bpmn-to-code] bpmn-to-code will be moved to the io.miragon namespace. The 'io.github.emaarco' " +
+						"coordinates and the 'io.github.emaarco:bpmn-to-code-maven' plugin are DEPRECATED and will not " +
+						"receive further updates. Migrate to the io.miragon:bpmn-to-code-maven plugin / " +
+						"'io.miragon:bpmn-to-code-*' — see https://github.com/miragon/bpmn-to-code"
+		);
 		getLog().warn("[EXPERIMENTAL] The 'validate-bpmn' goal is experimental and may change in future releases.");
 		if (processEngine == null || processEngine.isBlank()) {
 			throw new MojoFailureException("processEngine is required (valid values: CAMUNDA_7, ZEEBE, OPERATON)");

--- a/bpmn-to-code-skills/README.md
+++ b/bpmn-to-code-skills/README.md
@@ -1,5 +1,8 @@
 # bpmn-to-code Skills Plugin
 
+> ## ⚠️ Moving to io.miragon
+> bpmn-to-code is **moving to the `io.miragon` namespace** ([github.com/miragon/bpmn-to-code](https://github.com/miragon/bpmn-to-code)). As of this release the `io.github.emaarco` coordinates are **deprecated** and will receive no further updates — see the [migration note](../docs/changelog/moved-to-miragon.md).
+
 Claude Code plugin with AI skills for setting up and using the [bpmn-to-code](https://github.com/emaarco/bpmn-to-code) Gradle/Maven plugin.
 
 ## Installation

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
@@ -78,6 +78,14 @@ class BpmnValidator private constructor(
      * Executes validation and returns a [BpmnValidationAssert] for fluent assertions.
      */
     fun validate(): BpmnValidationAssert {
+        // Written directly to stderr — not via a logging facade — so the notice is visible to every
+        // consumer regardless of whether they have an SLF4J backend configured in their test classpath.
+        System.err.println(
+            "[bpmn-to-code] bpmn-to-code will be moved to the io.miragon namespace. The 'io.github.emaarco' " +
+                "coordinates and the 'io.github.emaarco:bpmn-to-code-testing' library are DEPRECATED and will not " +
+                "receive further updates. Migrate to 'io.miragon:bpmn-to-code-testing' / 'io.miragon:bpmn-to-code-*' " +
+                "— see https://github.com/miragon/bpmn-to-code"
+        )
         val selectedEngine = requireNotNull(engine) {
             "Process engine must be set. Call .engine(ProcessEngine.CAMUNDA_7) or similar before .validate()"
         }

--- a/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
+++ b/bpmn-to-code-testing/src/main/kotlin/io/github/emaarco/bpmn/testing/BpmnValidator.kt
@@ -25,6 +25,11 @@ import java.nio.file.Path
  *     .assertNoViolations()
  * ```
  */
+@Deprecated(
+    "bpmn-to-code is moving to the io.miragon namespace; the 'io.github.emaarco' coordinates are deprecated " +
+        "and will receive no further updates. Migrate to io.miragon — https://github.com/miragon/bpmn-to-code"
+)
+@Suppress("DEPRECATION")
 class BpmnValidator private constructor(
     private val resourceLoader: () -> List<BpmnResource>,
 ) {

--- a/bpmn-to-code-web/README.md
+++ b/bpmn-to-code-web/README.md
@@ -1,5 +1,8 @@
 # 🚀 bpmn-to-code-web
 
+> ## ⚠️ Moving to io.miragon
+> bpmn-to-code is **moving to the `io.miragon` namespace**. As of this release the `io.github.emaarco` coordinates and the `emaarco/bpmn-to-code-web` Docker image are **deprecated** and will receive no further updates — migrate to `io.miragon` / `miragon/bpmn-to-code-web` ([github.com/miragon/bpmn-to-code](https://github.com/miragon/bpmn-to-code), [migration note](../docs/changelog/moved-to-miragon.md)).
+
 bpmn-to-code-web is a web application that provides browser-based access to bpmn-to-code's code generation capabilities.
 It offers the same powerful Process API generation without requiring Gradle or Maven installation,
 making it ideal for quick experiments, non-Java projects, or teams who prefer a graphical interface.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -100,6 +100,7 @@ export default defineConfig({
             collapsed: true,
             items: [
               { text: 'Release Notes', link: '/changelog/' },
+              { text: 'Moved to io.miragon', link: '/changelog/moved-to-miragon' },
               { text: 'v2 Migration Guide', link: '/changelog/v2' },
             ],
           },

--- a/docs/changelog/moved-to-miragon.md
+++ b/docs/changelog/moved-to-miragon.md
@@ -1,0 +1,74 @@
+# Moved to io.miragon
+
+::: warning bpmn-to-code has moved
+bpmn-to-code now lives at **[github.com/miragon/bpmn-to-code](https://github.com/miragon/bpmn-to-code)**
+under the `io.miragon` coordinates. The `io.github.emaarco` coordinates and the
+`io.github.emaarco.bpmn-to-code-gradle` plugin id are **deprecated** and will not receive further updates.
+:::
+
+The project has moved to the **io.miragon** namespace, hosted by the
+[Miragon organization](https://github.com/miragon). This is the final release published under
+`io.github.emaarco`; its only purpose is to announce the move. No functionality changed.
+
+## What changed
+
+| | Old (`io.github.emaarco`) | New (`io.miragon`) |
+| --- | --- | --- |
+| Maven / Gradle groupId | `io.github.emaarco` | `io.miragon` |
+| Gradle plugin id | `io.github.emaarco.bpmn-to-code-gradle` | `io.miragon.bpmn-to-code-gradle` |
+| Maven artifacts | `io.github.emaarco:bpmn-to-code-*` | `io.miragon:bpmn-to-code-*` |
+| Docker image | `emaarco/bpmn-to-code-web` | `miragon/bpmn-to-code-web` |
+| Repository | `github.com/emaarco/bpmn-to-code` | `github.com/miragon/bpmn-to-code` |
+
+## How to migrate
+
+### Gradle
+
+Update the plugin id in your `build.gradle.kts`:
+
+```kotlin
+plugins {
+    // Before
+    // id("io.github.emaarco.bpmn-to-code-gradle") version "2.4.0"
+
+    // After
+    id("io.miragon.bpmn-to-code-gradle") version "<new-version>"
+}
+```
+
+Any `import io.github.emaarco.bpmn.*` references in your build configuration (for example
+`GenerateBpmnModelsTask` or `OutputLanguage`) move to `io.miragon.bpmn.*`.
+
+### Maven
+
+Update the `groupId` in your `pom.xml`:
+
+```xml
+<plugin>
+    <!-- Before: <groupId>io.github.emaarco</groupId> -->
+    <groupId>io.miragon</groupId>
+    <artifactId>bpmn-to-code-maven</artifactId>
+    <version><!-- new version --></version>
+</plugin>
+```
+
+### Docker
+
+```bash
+# Before
+# docker pull emaarco/bpmn-to-code-web
+
+# After
+docker pull miragon/bpmn-to-code-web
+```
+
+### Regenerate your Process API
+
+After switching coordinates, **regenerate your Process API** so the generated files line up with the
+new release, and rebuild your project:
+
+- Gradle: `./gradlew generateBpmnModelApi`
+- Maven: `mvn io.miragon:bpmn-to-code-maven:generate-bpmn-api`
+
+For the full picture and any further updates, follow the new repository at
+**[github.com/miragon/bpmn-to-code](https://github.com/miragon/bpmn-to-code)**.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@fontsource-variable/jetbrains-mono": "5.2.8",
         "@fontsource-variable/manrope": "5.2.8",
-        "oxc-minify": "^0.135.0"
+        "oxc-minify": "0.135.0"
       },
       "devDependencies": {
         "vitepress": "2.0.0-alpha.17",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@fontsource-variable/jetbrains-mono": "5.2.8",
     "@fontsource-variable/manrope": "5.2.8",
-    "oxc-minify": "^0.135.0"
+    "oxc-minify": "0.135.0"
   },
   "overrides": {
     "esbuild": "0.28.1"


### PR DESCRIPTION
## Summary

This is the **final release under the `io.github.emaarco` namespace**. Its only purpose is to warn existing users that bpmn-to-code **will move** to the **io.miragon** namespace, hosted at https://github.com/miragon/bpmn-to-code.

Minimal and additive — nothing renamed, publishing untouched, no behavioral changes beyond the deprecation notices. The actual `io.miragon` rename lives in **PR #376** and ships after the repo transfer.

## What changed

**1. Runtime deprecation warning** — `will be moved to the io.miragon namespace`, emitted from every entry point so a user is warned no matter which module they use:

- **Gradle plugin** — `project.logger.warn(...)` at plugin apply.
- **Maven mojos** — `getLog().warn(...)` at the start of `generate-bpmn-api`, `generate-bpmn-json`, `validate-bpmn`.
- **Testing library** — written to **`System.err`** at the start of `BpmnValidator.validate()`, on every run. Deliberately not via a logging facade: `bpmn-to-code-testing` consumers may have no SLF4J backend, in which case a logged warning would be silently dropped — leaving exactly the users we want to warn blind. `System.err` is guaranteed visible with zero classpath assumptions.

**2. Compile-time `@Deprecated` markers** — so IDEs and migration tooling flag usages statically (Kotlin `WARNING` level / Java `@Deprecated` + `@deprecated` javadoc; never `ERROR`, so consumer builds keep compiling). Applied to the primary entry points:

- **Gradle** — `BpmnModelGeneratorPlugin` + the `GenerateBpmnModelsTask` / `GenerateBpmnJsonTask` / `ValidateBpmnModelsTask` task types.
- **Maven** — `BpmnModelMojo`, `BpmnJsonMojo`, `BpmnValidateMojo`.
- **Testing** — `BpmnValidator`.

**3. Migration note** — `docs/changelog/moved-to-miragon.md` (wired into the VitePress sidebar) mapping old → new coordinates (groupId, Gradle plugin id, Maven artifacts, Docker image) plus "switch coordinates and regenerate your Process API" steps.

**4. Test** — a TestKit smoke test asserting the Gradle apply-time warning appears in build output.

Also includes a small `build(docs): pin oxc-minify` fix — a pre-existing unpinned dependency on `main` that the repo's pinned-deps CI check rejects; surfaced because this PR touches docs.

> README/docs banners are **intentionally deferred** — they'll be adapted in a later change. For this release the announcement lives in the warnings + `@Deprecated` markers + migration note.

## Verification

- `./gradlew build` (+ detekt) — green.
- Confirmed the testing-lib warning prints to stderr with no SLF4J backend present.

## Release

`feat:` so release-please cuts **2.4.0**. Version is not hand-edited.